### PR TITLE
fix: show readable OAuth errors on login page, not raw JSON

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -320,17 +320,27 @@ export default function App() {
   const [authState, setAuthState] = useState<AuthState>("checking");
   const [slackOAuth, setSlackOAuth] = useState(false);
   const [githubOAuth, setGithubOAuth] = useState(false);
+  const [loginError, setLoginError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     const check = async () => {
       try {
-        // Handle OAuth callback: if ?token= is in URL, store it and strip from history
+        // Handle OAuth callback: if ?token= is in URL, store it and strip from history.
+        // If ?error= is present (set by the server on OAuth failure), capture it for
+        // display on the login card and strip it from the URL.
         const params = new URLSearchParams(window.location.search);
         const urlToken = params.get("token");
+        const urlError = params.get("error");
         if (urlToken) {
           auth.setToken(urlToken);
           params.delete("token");
+        }
+        if (urlError && !cancelled) {
+          setLoginError(urlError);
+          params.delete("error");
+        }
+        if (urlToken || urlError) {
           const newSearch = params.toString();
           const newUrl = window.location.pathname + (newSearch ? `?${newSearch}` : "") + window.location.hash;
           window.history.replaceState(null, "", newUrl);
@@ -373,7 +383,14 @@ export default function App() {
     );
   }
   if (authState === "required") {
-    return <Login onAuthed={() => setAuthState("ok")} slackOAuth={slackOAuth} githubOAuth={githubOAuth} />;
+    return (
+      <Login
+        onAuthed={() => setAuthState("ok")}
+        slackOAuth={slackOAuth}
+        githubOAuth={githubOAuth}
+        initialErrorCode={loginError}
+      />
+    );
   }
   return (
     <Dashboard

--- a/dashboard/src/components/Login.tsx
+++ b/dashboard/src/components/Login.tsx
@@ -5,11 +5,34 @@ interface Props {
   onAuthed: () => void;
   slackOAuth?: boolean;
   githubOAuth?: boolean;
+  initialErrorCode?: string | null;
 }
 
-export function Login({ onAuthed, slackOAuth, githubOAuth }: Props) {
+// Maps short error codes from the /oauth/*/callback redirect into readable
+// messages. Unknown codes fall through to a generic message so we never
+// leak an opaque code to the user.
+function oauthErrorMessage(code: string): string {
+  switch (code) {
+    case "github_org":
+      return "Your GitHub account is not a confirmed member of the allowed organization. Ask an admin to install the GitHub App on the org and grant Members: Read, then try again.";
+    case "github_userinfo":
+      return "Could not read your GitHub profile. Please try again.";
+    case "oauth_state":
+      return "Your sign-in session expired or was tampered with. Please try again.";
+    case "oauth_code":
+      return "Sign-in was cancelled before it completed. Please try again.";
+    case "oauth_exchange":
+      return "GitHub sign-in failed. Please try again.";
+    default:
+      return "Sign-in failed. Please try again.";
+  }
+}
+
+export function Login({ onAuthed, slackOAuth, githubOAuth, initialErrorCode }: Props) {
   const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(
+    initialErrorCode ? oauthErrorMessage(initialErrorCode) : null,
+  );
   const [busy, setBusy] = useState(false);
   const [slackRedirecting, setSlackRedirecting] = useState(false);
   const [githubRedirecting, setGithubRedirecting] = useState(false);
@@ -48,6 +71,12 @@ export function Login({ onAuthed, slackOAuth, githubOAuth }: Props) {
             <div className="text-xs text-base-content/50">Sign in to continue</div>
           </div>
 
+          {error && (
+            <div role="alert" className="alert alert-error alert-soft text-xs py-2 px-3">
+              <span>{error}</span>
+            </div>
+          )}
+
           {slackOAuth && (
             <button
               type="button"
@@ -83,7 +112,6 @@ export function Login({ onAuthed, slackOAuth, githubOAuth }: Props) {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
-            {error && <div className="text-xs text-error">{error}</div>}
             <button
               type="submit"
               className="btn btn-primary btn-sm"

--- a/src/admin/routes.test.ts
+++ b/src/admin/routes.test.ts
@@ -360,10 +360,11 @@ describe("GET /oauth/github/callback", () => {
     }));
     // No cookie set → state mismatch
     const res = await request(app, "/oauth/github/callback?code=abc&state=bad-state");
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/?error=oauth_state");
   });
 
-  it("returns 400 when code is missing", async () => {
+  it("redirects to /admin/?error=oauth_code when code is missing", async () => {
     const app = createAdminRoutes(mockDb, mockSessions, mockSessions, makeConfig({
       githubOAuthClientId: "GH_CLIENT",
       githubOAuthClientSecret: "GH_SECRET",
@@ -374,7 +375,8 @@ describe("GET /oauth/github/callback", () => {
       headers: { Cookie: `github_oauth_state=${state}` },
     });
     const res = await app.fetch(req);
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/?error=oauth_code");
   });
 
   it("redirects with token and skips org fetch when allowlist is \"*\"", async () => {
@@ -428,8 +430,9 @@ describe("GET /oauth/github/callback", () => {
     global.fetch = originalFetch;
   });
 
-  it("returns 403 when org membership returns 404 (not a member)", async () => {
+  it("redirects to /admin/?error=github_org when membership returns 404 (not a member)", async () => {
     const originalFetch = global.fetch;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     global.fetch = mockGithubFetch({ userLogin: "alice", orgStatus: 404 });
 
     const app = createAdminRoutes(mockDb, mockSessions, mockSessions, makeConfig({
@@ -444,15 +447,16 @@ describe("GET /oauth/github/callback", () => {
       headers: { Cookie: `github_oauth_state=${state}` },
     });
     const res = await app.fetch(req);
-    expect(res.status).toBe(403);
-    const body = await res.json() as { error: string };
-    expect(body.error).toBe("org membership required");
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/?error=github_org");
 
     global.fetch = originalFetch;
+    warnSpy.mockRestore();
   });
 
-  it("returns 403 when org membership returns 302 (insufficient visibility)", async () => {
+  it("redirects to /admin/?error=github_org when membership returns 302 (insufficient visibility)", async () => {
     const originalFetch = global.fetch;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     global.fetch = mockGithubFetch({ userLogin: "alice", orgStatus: 302 });
 
     const app = createAdminRoutes(mockDb, mockSessions, mockSessions, makeConfig({
@@ -467,9 +471,11 @@ describe("GET /oauth/github/callback", () => {
       headers: { Cookie: `github_oauth_state=${state}` },
     });
     const res = await app.fetch(req);
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/?error=github_org");
 
     global.fetch = originalFetch;
+    warnSpy.mockRestore();
   });
 });
 

--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -368,15 +368,21 @@ export function createAdminRoutes(
     if (!githubOAuthEnabled) {
       return c.json({ error: "GitHub OAuth not configured" }, 404);
     }
+    // Redirect the user back to the dashboard login screen with a short,
+    // URL-safe error code. The SPA maps this code to a human-readable
+    // message so the user sees the login card with an inline error instead
+    // of a raw JSON body.
+    const fail = (code: string) => c.redirect(`/admin/?error=${encodeURIComponent(code)}`);
+
     const storedState = getCookie(c, "github_oauth_state");
     deleteCookie(c, "github_oauth_state", { path: "/" });
     const { code, state } = c.req.query() as { code?: string; state?: string };
 
     if (!storedState || !state || storedState !== state) {
-      return c.json({ error: "invalid state parameter" }, 400);
+      return fail("oauth_state");
     }
     if (!code) {
-      return c.json({ error: "missing authorization code" }, 400);
+      return fail("oauth_code");
     }
 
     try {
@@ -398,7 +404,7 @@ export function createAdminRoutes(
       const userInfo = (await userRes.json()) as { login?: string };
       if (!userInfo.login) {
         console.error("GitHub /user failed: missing login field");
-        return c.json({ error: "GitHub userInfo failed" }, 502);
+        return fail("github_userinfo");
       }
       const login = userInfo.login;
 
@@ -423,7 +429,7 @@ export function createAdminRoutes(
           console.warn(
             `[oauth] GitHub login rejected: ${login} not a confirmed member of ${org} (status ${memberRes.status})`,
           );
-          return c.json({ error: "org membership required" }, 403);
+          return fail("github_org");
         }
       }
 
@@ -431,7 +437,7 @@ export function createAdminRoutes(
       return c.redirect(`/admin/?token=${encodeURIComponent(token)}`);
     } catch (err: unknown) {
       console.error("GitHub OAuth exchange failed:", err);
-      return c.json({ error: "OAuth exchange failed" }, 502);
+      return fail("oauth_exchange");
     }
   });
 


### PR DESCRIPTION
## Summary

- GitHub OAuth callback failures now redirect to `/admin/?error=<code>` instead of returning JSON.
- Short codes: `oauth_state`, `oauth_code`, `github_userinfo`, `github_org`, `oauth_exchange`.
- `App.tsx` reads the code, strips the query param, passes it to `<Login>`.
- `Login.tsx` maps the code to a readable message and renders a prominent alert at the top of the card.

## Context

Reproduced by logging in with a GitHub account not in `GITHUB_ALLOWED_ORG`: the browser landed on the raw callback URL showing `{"error":"org membership required"}`. Now the user is redirected back to the login card with:

> Your GitHub account is not a confirmed member of the allowed organization. Ask an admin to install the GitHub App on the org and grant Members: Read, then try again.

## Test plan

- [x] `npx vitest run` — 327 tests pass (4 updated, 0 new)
- [x] `npx tsc --noEmit` (server) — clean
- [x] `cd dashboard && npx tsc -b` — clean
- [x] `npm run build:dashboard` — builds
- [ ] Manual: hit `/admin/api/oauth/github/callback?code=x&state=bad` in browser → lands on `/admin/` with error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)