### PR TITLE
fix: route URL/question security requests correctly + chat deep-work guardrail

### DIFF
--- a/src/engine/chat.ts
+++ b/src/engine/chat.ts
@@ -26,6 +26,30 @@ WHAT YOU CANNOT DO:
   issue capturing the request, then tell them to run \`/build owner/repo#N\`
   to start the full build cycle (Architect → Executor → Reviewer → PR).
 
+DO NOT ATTEMPT DEEP WORK IN-PROCESS.
+Each of the following is a dedicated workflow — NOT something you can do
+by chaining tool calls. If the user asks for one, reply with ONE message
+naming the right command and stop. Do not start fetching files, reading
+code, listing issues, or running any investigative tool calls in service
+of these requests — you will hit the turn limit before producing useful
+output, exactly as happened in prior incidents.
+
+- "security review" / "scan for vulnerabilities" / "check security of <repo>"
+  → reply: "run \`/security owner/repo\` (or tell me 'security review owner/repo')"
+- "triage" / "scan issues" / "go through open issues on <repo>"
+  → reply: "run \`/triage owner/repo\`"
+- "review PRs on <repo>" / "check open PRs"
+  → reply: "run \`/review owner/repo\`"
+- "weekly health report" / "repo health"
+  → reply: "run \`/health owner/repo\`"
+- "build this" / "implement this" / "fix this bug" on a specific issue
+  → create the GitHub issue if needed, then reply: "run \`/build owner/repo#N\`"
+
+Only exception: if the user is asking a narrow *question* that you can
+answer with one or two reads (e.g. "what does this file do?", "what labels
+does this issue have?"), just do it. The rule is about full-repo scans and
+multi-phase workflows, not about one-off lookups.
+
 STYLE:
 - Reach for tools immediately. Don't pre-explain what you're about to do.
 - Keep replies concise — this is chat, not a document.
@@ -33,7 +57,8 @@ STYLE:
   re-summarize it; just respond to the latest message.
 
 Useful commands you can suggest:
-\`/build owner/repo#N\`, \`/triage owner/repo\`, \`/review owner/repo\`, \`/status\`
+\`/build owner/repo#N\`, \`/triage owner/repo\`, \`/review owner/repo\`,
+\`/security owner/repo\`, \`/health owner/repo\`, \`/status\`
 `;
 
 /**

--- a/src/engine/classifier.test.ts
+++ b/src/engine/classifier.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { extractGithubRefFromText } from "./classifier.js";
+
+describe("extractGithubRefFromText", () => {
+  it("returns undefined when no github.com URL is present", () => {
+    expect(extractGithubRefFromText("hi there")).toBeUndefined();
+    expect(extractGithubRefFromText("check cliftonc/lastlight")).toBeUndefined();
+  });
+
+  it("extracts owner/repo from a bare github.com URL", () => {
+    expect(extractGithubRefFromText("https://github.com/cliftonc/lastlight")).toEqual({
+      repo: "cliftonc/lastlight",
+    });
+  });
+
+  it("extracts from a URL embedded in surrounding text", () => {
+    const input = "can you do a security review of https://github.com/cliftonc/lastlight";
+    expect(extractGithubRefFromText(input)).toEqual({ repo: "cliftonc/lastlight" });
+  });
+
+  it("strips a trailing slash", () => {
+    expect(extractGithubRefFromText("https://github.com/cliftonc/lastlight/")).toEqual({
+      repo: "cliftonc/lastlight",
+    });
+  });
+
+  it("strips a trailing punctuation (question mark, comma, period)", () => {
+    expect(extractGithubRefFromText("triage https://github.com/foo/bar?")).toEqual({
+      repo: "foo/bar",
+    });
+    expect(extractGithubRefFromText("review https://github.com/foo/bar, please")).toEqual({
+      repo: "foo/bar",
+    });
+    expect(extractGithubRefFromText("scan https://github.com/foo/bar.")).toEqual({
+      repo: "foo/bar",
+    });
+  });
+
+  it("strips a .git suffix", () => {
+    expect(extractGithubRefFromText("https://github.com/foo/bar.git")).toEqual({
+      repo: "foo/bar",
+    });
+  });
+
+  it("extracts an issue number from /issues/N URLs", () => {
+    expect(
+      extractGithubRefFromText("please look at https://github.com/cliftonc/lastlight/issues/42"),
+    ).toEqual({ repo: "cliftonc/lastlight", issueNumber: 42 });
+  });
+
+  it("extracts a PR number from /pull/N URLs", () => {
+    expect(
+      extractGithubRefFromText("review https://github.com/foo/bar/pull/7 when you can"),
+    ).toEqual({ repo: "foo/bar", issueNumber: 7 });
+  });
+
+  it("ignores trailing URL path segments beyond owner/repo when no issue/PR", () => {
+    expect(extractGithubRefFromText("https://github.com/foo/bar/tree/main/src")).toEqual({
+      repo: "foo/bar",
+    });
+  });
+
+  it("handles http:// in addition to https://", () => {
+    expect(extractGithubRefFromText("http://github.com/foo/bar")).toEqual({
+      repo: "foo/bar",
+    });
+  });
+
+  it("handles repo names with dots and hyphens", () => {
+    expect(extractGithubRefFromText("https://github.com/cliftonc/drizzle-cube")).toEqual({
+      repo: "cliftonc/drizzle-cube",
+    });
+    expect(extractGithubRefFromText("https://github.com/user/foo.bar")).toEqual({
+      repo: "user/foo.bar",
+    });
+  });
+});

--- a/src/engine/classifier.ts
+++ b/src/engine/classifier.ts
@@ -42,18 +42,28 @@ Classify the user's message into exactly one category, and extract any repositor
 Categories:
 BUILD — The user wants code changes NOW: implement a feature, fix a bug, write code, create/send a PR, resolve an issue with code. They already know what to build.
 EXPLORE — The user has a half-formed idea and wants help thinking it through BEFORE code: "help me think through X", "brainstorm Y", "spec this out", "explore an idea for Z".
-TRIAGE — The user wants to scan/triage issues on a repo: "triage cliftonc/repo", "scan for new issues".
-REVIEW — The user wants to review PRs on a repo: "review cliftonc/repo", "check PRs".
-SECURITY — The user wants a security scan/review of a repo: "security review cliftonc/repo", "scan for vulnerabilities", "check security".
+TRIAGE — The user wants to scan/triage issues on a repo: "triage cliftonc/repo", "scan for new issues", "can you triage <repo>?".
+REVIEW — The user wants to review PRs on a repo: "review cliftonc/repo", "check PRs", "can you review PRs on <repo>?".
+SECURITY — The user wants a security scan/review of a repo: "security review cliftonc/repo", "scan for vulnerabilities", "check security", "can you do a security review of <repo>?".
 APPROVE — The user is approving a pending gate: "approve", "go ahead", "looks good, continue", "yes proceed".
 REJECT — The user is rejecting a pending gate: "reject", "abort", "cancel this", "no don't proceed". Extract any reason given.
 STATUS — The user wants to know what's running: "status", "what's running", "any tasks active?".
 RESET — The user wants to start a fresh session: "new", "reset", "start over", "fresh session".
 CHAT — Anything else: questions, conversation, thanks, general discussion.
 
+Polite or question phrasings are still clear intent. "Can you do a security review of X?",
+"could you triage <repo>?", "please review PRs on <repo>" are SECURITY, TRIAGE, REVIEW
+respectively — not CHAT. The "prefer CHAT when ambiguous" rule only applies when the
+message has no clear action verb. Presence of "security review", "triage", "review PRs",
+"scan for vulnerabilities", etc. makes the intent unambiguous regardless of politeness.
+
 When ambiguous between EXPLORE and CHAT, prefer CHAT. Only pick EXPLORE when the user is explicitly asking for brainstorming / spec-shaping / design exploration.
 When ambiguous between BUILD and CHAT, prefer CHAT.
 When ambiguous between APPROVE/REJECT and CHAT, prefer CHAT — only classify as APPROVE/REJECT when the intent is clearly about a pending workflow gate.
+
+Repo extraction: always emit REPO as "owner/name" (never a URL). If the message contains
+a github.com URL, convert it: https://github.com/cliftonc/lastlight → cliftonc/lastlight.
+URL paths like /issues/42 or /pull/5 should populate ISSUE as well.
 
 When the message is a reply on an existing issue/PR, the issue title is provided
 as ISSUE TITLE. Short imperative replies like "lets build this", "build it",
@@ -76,7 +86,45 @@ Examples:
 "approve" → INTENT: APPROVE, REPO: NONE, ISSUE: NONE, REASON: NONE
 "reject, the plan is too complex" → INTENT: REJECT, REPO: NONE, ISSUE: NONE, REASON: the plan is too complex
 "what's running?" → INTENT: STATUS, REPO: NONE, ISSUE: NONE, REASON: NONE
-"run a security review on cliftonc/lastlight" → INTENT: SECURITY, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE`;
+"run a security review on cliftonc/lastlight" → INTENT: SECURITY, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE
+"can you do a security review of https://github.com/cliftonc/lastlight" → INTENT: SECURITY, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE
+"could you triage https://github.com/foo/bar?" → INTENT: TRIAGE, REPO: foo/bar, ISSUE: NONE, REASON: NONE
+"please review https://github.com/foo/bar/pull/42" → INTENT: REVIEW, REPO: foo/bar, ISSUE: 42, REASON: NONE
+"scan https://github.com/cliftonc/lastlight for vulnerabilities" → INTENT: SECURITY, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE`;
+
+/**
+ * Extract owner/repo and optional issue/PR number from any github.com URL
+ * in the text. Belt-and-suspenders for the LLM — if the classifier forgets
+ * to normalize a URL to owner/name, this fallback still recovers the repo.
+ * Returns undefined when no github.com URL is present.
+ */
+export function extractGithubRefFromText(
+  text: string,
+): { repo: string; issueNumber?: number } | undefined {
+  // URL with /issues/N or /pull/N — capture the number too
+  const withNumber = text.match(
+    /github\.com\/([\w-]+)\/([\w.-]+?)\/(?:issues|pull)\/(\d+)\b/i,
+  );
+  if (withNumber) {
+    return {
+      repo: `${withNumber[1]}/${cleanRepoName(withNumber[2])}`,
+      issueNumber: parseInt(withNumber[3], 10),
+    };
+  }
+  // Bare repo URL — stop at next slash / whitespace / query / fragment, then
+  // strip trailing sentence punctuation and any .git suffix.
+  const bare = text.match(/github\.com\/([\w-]+)\/([\w.-]+?)(?=[\s/?#,]|$)/i);
+  if (bare) {
+    return { repo: `${bare[1]}/${cleanRepoName(bare[2])}` };
+  }
+  return undefined;
+}
+
+function cleanRepoName(name: string): string {
+  // Repo names don't end in punctuation; a trailing `.` or `,` is sentence
+  // punctuation that leaked into the match.
+  return name.replace(/[.,]+$/, "").replace(/\.git$/i, "");
+}
 
 /**
  * Classify a GitHub/Slack comment's intent and extract a repo reference.
@@ -133,13 +181,22 @@ export async function classifyComment(
       ? (intentMap[intentMatch[1]] ?? "chat")
       : "chat";
 
-    // Extract repo from "REPO: owner/name" line
+    // Extract repo from "REPO: owner/name" line. If the classifier didn't
+    // emit one (e.g. the user pasted a full github.com URL and the model
+    // left REPO as NONE), recover it from the raw message.
     const repoMatch = output.match(/REPO:\s*([\w-]+\/[\w.-]+)/i);
-    const repo = repoMatch?.[1];
-
-    // Extract issue number
     const issueMatch = output.match(/ISSUE:\s*(\d+)/i);
-    const issueNumber = issueMatch ? parseInt(issueMatch[1], 10) : undefined;
+    let repo = repoMatch?.[1];
+    let issueNumber = issueMatch ? parseInt(issueMatch[1], 10) : undefined;
+    if (!repo) {
+      const fallback = extractGithubRefFromText(commentBody);
+      if (fallback) {
+        repo = fallback.repo;
+        if (issueNumber === undefined && fallback.issueNumber !== undefined) {
+          issueNumber = fallback.issueNumber;
+        }
+      }
+    }
 
     // Extract reject reason
     const reasonMatch = output.match(/REASON:\s*(.+)/i);


### PR DESCRIPTION
## Summary

Reproduces the Slack message `@lastlight can you do a security review of https://github.com/cliftonc/lastlight` that was misrouted to `chat`, which then burned 10 turns fetching files and hit `error_max_turns` with no reply.

**Two fixes, defense in depth:**

1. **Classifier** (primary fix) — stop misrouting
   - Prompt tightens: polite/question phrasings with a clear action verb ("can you do a security review of X?", "could you triage <repo>?") no longer fall through to CHAT.
   - Prompt instructs the model to normalize github.com URLs to `owner/name` (and extract `/issues/N` or `/pull/N` into ISSUE).
   - New `extractGithubRefFromText` post-processor recovers `owner/repo` from any github.com URL in the raw message when the model still emits `REPO: NONE`. Handles trailing punctuation, `.git` suffixes, and dotted repo names.

2. **Chat system prompt** (defense in depth) — if a deep-work request ever does reach chat, don't attempt it
   - New "DO NOT ATTEMPT DEEP WORK IN-PROCESS" section enumerating security-review / triage / review / health / build as dedicated workflows.
   - Explicit instruction: reply with the matching slash command and stop — don't start investigative tool calls.
   - `/security` and `/health` added to the suggested-commands footer.

## Test plan

- [x] `npx vitest run` — 338 tests pass (+11 new URL-extractor tests)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: Slack `@lastlight can you do a security review of https://github.com/cliftonc/lastlight` → routes to `security-review`, not `chat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)