### PR TITLE
feat: link dashboard run from Slack 'Starting <skill>' ack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ WEBHOOK_SECRET=your-webhook-secret
 
 # ── Domain (used by Caddy for TLS) ─────────────────────────────────────────
 # DOMAIN=lastlight.example.com
+#
+# Public URL embedded in outbound messages (Slack "Live progress" link, etc.).
+# If unset, derived as https://<DOMAIN>. Set explicitly when DOMAIN is not the
+# externally-reachable host (reverse proxy, custom port, etc.). No trailing /.
+# PUBLIC_URL=https://lastlight.example.com
 
 # ── Claude API (optional) ───────────────────────────────
 # If set, uses API credits. If not set, uses your Claude Code login (subscription).

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,6 +96,14 @@ export interface LastLightConfig {
    * phase without a target repo identified earlier in the flow.
    */
   exploreDefaultRepo?: string;
+  /**
+   * Publicly-reachable base URL of the harness (no trailing slash), used
+   * when embedding links back to the admin dashboard in outbound messages
+   * (e.g. the Slack "starting workflow" reply). Read from `PUBLIC_URL`,
+   * falling back to `https://<DOMAIN>` when `DOMAIN` is set. Links are
+   * omitted when neither is configured.
+   */
+  publicUrl?: string;
 }
 
 /**
@@ -144,7 +152,22 @@ export function loadConfig(): LastLightConfig {
     approval: parseApprovalGates(),
     bootstrapLabel: process.env.BOOTSTRAP_LABEL || "lastlight:bootstrap",
     exploreDefaultRepo: process.env.EXPLORE_DEFAULT_REPO || undefined,
+    publicUrl: resolvePublicUrl(),
   };
+}
+
+/**
+ * Prefer an explicit PUBLIC_URL (e.g. behind a reverse proxy where DOMAIN
+ * isn't the externally-visible host). Fall back to https://<DOMAIN> — the
+ * same DOMAIN Caddy uses for TLS. Trailing slashes are stripped so callers
+ * can append paths unconditionally.
+ */
+function resolvePublicUrl(): string | undefined {
+  const explicit = process.env.PUBLIC_URL?.trim();
+  if (explicit) return explicit.replace(/\/+$/, "");
+  const domain = process.env.DOMAIN?.trim();
+  if (domain) return `https://${domain.replace(/\/+$/, "")}`;
+  return undefined;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,7 @@ async function main() {
   const dispatchWorkflow = async (
     workflowName: string,
     context: Record<string, unknown>,
+    onRunStart?: (runId: string) => Promise<void>,
   ): Promise<{ success: boolean; error?: string; paused?: boolean }> => {
     // Slack-initiated workflows (explore, /explore) carry a
     // `slack:{team}:{channel}:{thread}` triggerId and don't require a
@@ -279,6 +280,7 @@ async function main() {
       },
       onPhaseEnd: async (phase, result) =>
         console.log(`[dispatch] ◀ ${workflowName}/${phase}: ${result.success ? "OK" : "FAILED"}`),
+      onRunStart,
     };
 
     try {
@@ -894,8 +896,24 @@ async function main() {
     // The router still uses skill names — they map 1:1 to workflow YAML names
     // for the four agent skills (issue-triage, pr-review, repo-health, issue-comment).
     if (envelope.type === "message") {
-      await envelope.reply(`Starting *${skill}*... I'll report back when it's done.`);
-      dispatchWorkflow(skill, { ...context, _triggerType: "chat" }).then(async (result) => {
+      // Post the "Starting *<skill>*" ack once the workflow_runs row exists,
+      // so the reply can include a deep link to the dashboard. Falls back to
+      // a plain ack when no PUBLIC_URL/DOMAIN is configured.
+      const onRunStart = async (runId: string) => {
+        const link = config.publicUrl
+          ? `${config.publicUrl}/admin/?run=${encodeURIComponent(runId)}&tab=workflows`
+          : undefined;
+        const body = link
+          ? `Starting *${skill}*... I'll report back when it's done.\n<${link}|Live progress>`
+          : `Starting *${skill}*... I'll report back when it's done.`;
+        try {
+          await envelope.reply(body);
+        } catch (err: unknown) {
+          const m = err instanceof Error ? err.message : String(err);
+          console.warn(`[event] failed to post run-start ack: ${m}`);
+        }
+      };
+      dispatchWorkflow(skill, { ...context, _triggerType: "chat" }, onRunStart).then(async (result) => {
         if (result.paused) {
           // Workflow paused at a gate (approval or reply) — don't say
           // "completed", the workflow itself already posted instructions.

--- a/src/workflows/runner.ts
+++ b/src/workflows/runner.ts
@@ -90,6 +90,13 @@ export interface RunnerCallbacks {
   onPhaseStart?: (phase: string) => Promise<void>;
   onPhaseEnd?: (phase: string, result: PhaseResult) => Promise<void>;
   postComment?: (body: string) => Promise<void>;
+  /**
+   * Fires once the workflow_runs row is known — either freshly created or
+   * reused from a running/paused trigger. Used by the Slack dispatch path
+   * to post the "Starting <skill>" reply with a deep link to the run.
+   * Fire-and-forget: the workflow does not await this, so failures only log.
+   */
+  onRunStart?: (runId: string) => Promise<void>;
 }
 
 export interface WorkflowResult {

--- a/src/workflows/simple.ts
+++ b/src/workflows/simple.ts
@@ -159,6 +159,16 @@ export async function runSimpleWorkflow(
     console.log(`[simple] Created workflow run ${workflowId} (${workflowName})`);
   }
 
+  // Surface the run id to the dispatch layer as soon as it's known (either
+  // fresh or reused). Fire-and-forget so a slow/broken downstream hook can't
+  // stall the workflow.
+  if (callbacks.onRunStart) {
+    callbacks.onRunStart(workflowId).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[simple] onRunStart callback threw: ${msg}`);
+    });
+  }
+
   // ── Build template context ─────────────────────────────────────────────────
   //
   // The context snapshot is the agent's primary view of the task. All


### PR DESCRIPTION
## Summary

When a chat message triggers a workflow (security-review / triage / review / health), the Slack ack posted today is:

> Starting *security-review*... I'll report back when it's done.

This change embeds a deep link to the admin dashboard so you can watch progress live instead of waiting for the terminal "completed" reply:

> Starting *security-review*... I'll report back when it's done.
> <https://lastlight.drizby.com/admin/?run=024073f1-…&tab=workflows|Live progress>

Link format mirrors the dashboard's existing URL state: `?run=<id>&tab=workflows`.

## Config

- New env var **`PUBLIC_URL`** (optional). Falls back to `https://<DOMAIN>` when `DOMAIN` is already set (which it is on prod for Caddy TLS). When neither is configured, the ack falls back to the plain version — no behavior change.

## Plumbing

- `RunnerCallbacks` gains `onRunStart(runId)` — fire-and-forget, called once the `workflow_runs` row exists (fresh create **or** existing-run reuse) so the link always points at the row the user sees.
- `dispatchWorkflow` accepts an `onRunStart` argument; the messaging branch in `src/index.ts` uses it to post the ack with the link.
- The existing-run reuse path fires `onRunStart` too, so a Slack re-trigger against a still-running/paused thread links back to the real run.

## Test plan

- [x] `npx vitest run` — 338 pass, 1 todo (no new tests; pure plumbing)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: ask the bot for a `/triage` over Slack → ack contains a working dashboard link
- [ ] Manual: with `PUBLIC_URL` / `DOMAIN` unset → ack has no link (falls back cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)