### PR TITLE
fix: scan-summary routing + make Cancel actually stop the run

### DIFF
--- a/src/admin/routes.test.ts
+++ b/src/admin/routes.test.ts
@@ -506,3 +506,105 @@ describe("POST /login (password)", () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe("POST /workflow-runs/:id/cancel", () => {
+  // Helper to make a cancel-test db that returns a single run and
+  // records calls to the mutating methods we care about.
+  function makeCancelDb(opts: {
+    run: {
+      id: string;
+      status: "running" | "paused" | "succeeded" | "failed" | "cancelled";
+      triggerId: string;
+      taskId?: string;
+    };
+    runningExecutions?: Array<{ id: string; workflowRunId?: string; triggerId: string }>;
+  }) {
+    const finishes: Array<{ id: string; error?: string }> = [];
+    const cancels: string[] = [];
+    const db = {
+      ...((mockDb as unknown) as Record<string, unknown>),
+      getWorkflowRun: vi.fn(() => opts.run.status === "cancelled" ? null : {
+        id: opts.run.id,
+        workflowName: "pr-review",
+        triggerId: opts.run.triggerId,
+        currentPhase: "review",
+        phaseHistory: [],
+        status: opts.run.status,
+        context: opts.run.taskId ? { taskId: opts.run.taskId } : {},
+        startedAt: "",
+        updatedAt: "",
+      }),
+      cancelWorkflowRun: vi.fn((id: string) => { cancels.push(id); }),
+      runningExecutions: vi.fn(() => opts.runningExecutions ?? []),
+      recordFinish: vi.fn((id: string, res: { error?: string }) => { finishes.push({ id, error: res.error }); }),
+    } as unknown as StateDb;
+    return { db, finishes, cancels };
+  }
+
+  it("returns 404 when run not found", async () => {
+    const db = {
+      ...((mockDb as unknown) as Record<string, unknown>),
+      getWorkflowRun: vi.fn(() => null),
+    } as unknown as StateDb;
+    const app = createAdminRoutes(db, mockSessions, mockSessions, makeConfig({ adminPassword: "" }));
+    const res = await request(app, "/workflow-runs/run-abc/cancel", { method: "POST" });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when run already in a terminal state", async () => {
+    const { db } = makeCancelDb({ run: { id: "r1", status: "succeeded", triggerId: "t1" } });
+    const app = createAdminRoutes(db, mockSessions, mockSessions, makeConfig({ adminPassword: "" }));
+    const res = await request(app, "/workflow-runs/r1/cancel", { method: "POST" });
+    expect(res.status).toBe(400);
+  });
+
+  it("cancels and kills containers matching the run's taskId prefix", async () => {
+    const dockerMod = await import("./docker.js");
+    const listMock = vi.mocked(dockerMod.listRunningContainers);
+    const killMock = vi.mocked(dockerMod.killContainer);
+    listMock.mockResolvedValueOnce([
+      { id: "c1", name: "lastlight-sandbox-task-xyz-aaaaaaaa", taskId: "task-xyz", status: "running", created: "", image: "" },
+      { id: "c2", name: "lastlight-sandbox-task-xyz-review-bbbbbbbb", taskId: "task-xyz-review", status: "running", created: "", image: "" },
+      { id: "c3", name: "lastlight-sandbox-other-cccccccc", taskId: "other", status: "running", created: "", image: "" },
+    ]);
+
+    const { db, finishes, cancels } = makeCancelDb({
+      run: { id: "r1", status: "running", triggerId: "t1", taskId: "task-xyz" },
+      runningExecutions: [
+        { id: "e1", workflowRunId: "r1", triggerId: "t1" },
+        { id: "e2", workflowRunId: "r1", triggerId: "t1" },
+      ],
+    });
+    const app = createAdminRoutes(db, mockSessions, mockSessions, makeConfig({ adminPassword: "" }));
+    const res = await request(app, "/workflow-runs/r1/cancel", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(cancels).toEqual(["r1"]);
+    expect(killMock).toHaveBeenCalledTimes(2);
+    expect(killMock).toHaveBeenCalledWith("lastlight-sandbox-task-xyz-aaaaaaaa");
+    expect(killMock).toHaveBeenCalledWith("lastlight-sandbox-task-xyz-review-bbbbbbbb");
+    expect(killMock).not.toHaveBeenCalledWith("lastlight-sandbox-other-cccccccc");
+    expect(finishes.map((f) => f.id).sort()).toEqual(["e1", "e2"]);
+    expect(finishes.every((f) => f.error === "cancelled via admin dashboard")).toBe(true);
+  });
+
+  it("does NOT mark sibling-run executions as failed when cancelling a run with a shared triggerId", async () => {
+    // Regression for the PR #38 review: matching by triggerId clobbered
+    // execution rows belonging to a concurrent run on the same trigger.
+    // Matching by workflowRunId must only finish rows for THIS run.
+    const dockerMod = await import("./docker.js");
+    vi.mocked(dockerMod.listRunningContainers).mockResolvedValueOnce([]);
+
+    const { db, finishes } = makeCancelDb({
+      run: { id: "r1", status: "running", triggerId: "shared-trigger", taskId: "task-r1" },
+      runningExecutions: [
+        { id: "e1", workflowRunId: "r1", triggerId: "shared-trigger" },
+        { id: "e2", workflowRunId: "r2", triggerId: "shared-trigger" },
+        { id: "e3", workflowRunId: undefined, triggerId: "shared-trigger" },
+      ],
+    });
+    const app = createAdminRoutes(db, mockSessions, mockSessions, makeConfig({ adminPassword: "" }));
+    const res = await request(app, "/workflow-runs/r1/cancel", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(finishes.map((f) => f.id)).toEqual(["e1"]);
+  });
+});

--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -622,7 +622,7 @@ export function createAdminRoutes(
     return c.json({ executions });
   });
 
-  app.post("/workflow-runs/:id/cancel", (c) => {
+  app.post("/workflow-runs/:id/cancel", async (c) => {
     const id = c.req.param("id");
     const run = db.getWorkflowRun(id);
     if (!run) return c.json({ error: "workflow run not found" }, 404);
@@ -630,7 +630,42 @@ export function createAdminRoutes(
       return c.json({ error: `cannot cancel a run with status '${run.status}'` }, 400);
     }
     db.cancelWorkflowRun(id);
-    return c.json({ cancelled: id });
+    // Flipping the DB row alone only stops the runner before the NEXT phase.
+    // Kill any sandbox container currently executing a phase of this run so
+    // the in-flight phase stops too. Container names are
+    //   lastlight-sandbox-<taskId>-<uuid>
+    // where taskId is the linear run's taskId or the DAG's phase-scoped
+    // `<taskId>-<phaseName>`, both of which start with the stored taskId.
+    const storedTaskId = (run.context as Record<string, unknown> | undefined)?.taskId;
+    let killed: string[] = [];
+    if (typeof storedTaskId === "string" && storedTaskId) {
+      try {
+        const containers = await listRunningContainers();
+        const matches = containers.filter(
+          (ctr) => ctr.taskId && ctr.taskId.startsWith(storedTaskId),
+        );
+        await Promise.all(
+          matches.map(async (ctr) => {
+            try {
+              await killContainer(ctr.name);
+              killed.push(ctr.name);
+              // Mark any live execution row for this container as failed so
+              // the dashboard stops showing it as running.
+              for (const e of db.runningExecutions()) {
+                if (ctr.taskId && e.triggerId && (e.triggerId === run.triggerId)) {
+                  db.recordFinish(e.id, { success: false, error: "cancelled via admin dashboard" });
+                }
+              }
+            } catch (err) {
+              console.warn(`[cancel] failed to kill ${ctr.name}:`, err);
+            }
+          }),
+        );
+      } catch (err) {
+        console.warn(`[cancel] container enumeration failed:`, err);
+      }
+    }
+    return c.json({ cancelled: id, killedContainers: killed });
   });
 
   // ── Workflow definitions ─────────────────────────────────────────

--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -649,18 +649,21 @@ export function createAdminRoutes(
             try {
               await killContainer(ctr.name);
               killed.push(ctr.name);
-              // Mark any live execution row for this container as failed so
-              // the dashboard stops showing it as running.
-              for (const e of db.runningExecutions()) {
-                if (ctr.taskId && e.triggerId && (e.triggerId === run.triggerId)) {
-                  db.recordFinish(e.id, { success: false, error: "cancelled via admin dashboard" });
-                }
-              }
             } catch (err) {
               console.warn(`[cancel] failed to kill ${ctr.name}:`, err);
             }
           }),
         );
+        // Mark execution rows belonging to THIS cancelled run as failed.
+        // Matching by workflowRunId (the run's id) instead of triggerId
+        // avoids clobbering a sibling run that happens to share the same
+        // trigger — e.g. two webhook deliveries for the same PR that
+        // raced before dedup closed.
+        for (const e of db.runningExecutions()) {
+          if (e.workflowRunId === id) {
+            db.recordFinish(e.id, { success: false, error: "cancelled via admin dashboard" });
+          }
+        }
       } catch (err) {
         console.warn(`[cancel] container enumeration failed:`, err);
       }

--- a/src/engine/router.test.ts
+++ b/src/engine/router.test.ts
@@ -508,12 +508,12 @@ describe('routeEvent — security-review structured match', () => {
   });
 });
 
-describe('routeEvent — security-labeled issue routing', () => {
+describe('routeEvent — security summary issue routing', () => {
   beforeEach(() => {
     mockScreen.mockResolvedValue({ flagged: false });
   });
 
-  it('routes chat comment on security-labeled issue to security-feedback', async () => {
+  it('routes chat comment on scan summary (security + security-scan labels) to security-feedback', async () => {
     mockClassifyComment.mockResolvedValue({ intent: 'chat' });
     const result = await routeEvent(makeEnvelope({
       type: 'comment.created',
@@ -521,7 +521,7 @@ describe('routeEvent — security-labeled issue routing', () => {
       authorAssociation: 'OWNER',
       issueNumber: 42,
       repo: 'cliftonc/lastlight',
-      labels: ['security', 'p1-high'],
+      labels: ['security', 'security-scan'],
     }));
     expect(result.action).toBe('skill');
     if (result.action === 'skill') {
@@ -530,7 +530,46 @@ describe('routeEvent — security-labeled issue routing', () => {
     }
   });
 
-  it('does not route to security-feedback when issue has no security label', async () => {
+  it('routes BUILD intent on scan summary to security-feedback (regression: "create issues for the highs")', async () => {
+    // "create issues for the highs" classifies as BUILD but on a scan
+    // summary that phrase means "break out findings", which is security-
+    // feedback territory. The earlier routing carved out build from this
+    // case and it triggered a real build cycle.
+    mockClassifyComment.mockResolvedValue({ intent: 'build' });
+    const result = await routeEvent(makeEnvelope({
+      type: 'comment.created',
+      body: '@last-light create issues for the highs',
+      authorAssociation: 'OWNER',
+      issueNumber: 42,
+      repo: 'cliftonc/lastlight',
+      labels: ['security', 'security-scan'],
+    }));
+    expect(result.action).toBe('skill');
+    if (result.action === 'skill') {
+      expect(result.skill).toBe('security-feedback');
+    }
+  });
+
+  it('does NOT route to security-feedback on broken-out sub-issue (security label only, no security-scan)', async () => {
+    // Sub-issues broken out from the summary carry ["security", severity]
+    // but not "security-scan". On a sub-issue, "build this fix" SHOULD
+    // kick off the real build cycle.
+    mockClassifyComment.mockResolvedValue({ intent: 'build' });
+    const result = await routeEvent(makeEnvelope({
+      type: 'comment.created',
+      body: '@last-light build this fix',
+      authorAssociation: 'OWNER',
+      issueNumber: 43,
+      repo: 'cliftonc/lastlight',
+      labels: ['security', 'p1-high'],
+    }));
+    expect(result.action).toBe('skill');
+    if (result.action === 'skill') {
+      expect(result.skill).toBe('github-orchestrator');
+    }
+  });
+
+  it('does not route to security-feedback when issue has no security-scan label', async () => {
     mockClassifyComment.mockResolvedValue({ intent: 'chat' });
     const result = await routeEvent(makeEnvelope({
       type: 'comment.created',
@@ -543,22 +582,6 @@ describe('routeEvent — security-labeled issue routing', () => {
     expect(result.action).toBe('skill');
     if (result.action === 'skill') {
       expect(result.skill).toBe('issue-comment');
-    }
-  });
-
-  it('routes build intent on security-labeled issue to github-orchestrator, not security-feedback', async () => {
-    mockClassifyComment.mockResolvedValue({ intent: 'build' });
-    const result = await routeEvent(makeEnvelope({
-      type: 'comment.created',
-      body: '@last-light build this fix',
-      authorAssociation: 'OWNER',
-      issueNumber: 42,
-      repo: 'cliftonc/lastlight',
-      labels: ['security'],
-    }));
-    expect(result.action).toBe('skill');
-    if (result.action === 'skill') {
-      expect(result.skill).toBe('github-orchestrator');
     }
   });
 });

--- a/src/engine/router.ts
+++ b/src/engine/router.ts
@@ -193,10 +193,21 @@ export async function routeEvent(
       }
 
       // Issue comments: build → full build cycle, explore → socratic
-      // explore workflow, security-labeled issues → security-feedback,
+      // explore workflow, security scan summary issues → security-feedback,
       // otherwise → issue-comment.
-      const hasSecurityLabel = (envelope.labels || []).includes("security");
-      if (hasSecurityLabel && !["build", "approve", "reject"].includes(intent)) {
+      //
+      // Key on `security-scan` (not just `security`) so we only divert to
+      // security-feedback on the per-run SUMMARY issue. Broken-out sub-issues
+      // carry `["security", severity]` (no `security-scan`) and must stay on
+      // the normal build/issue-comment path — "@last-light build this fix"
+      // on a sub-issue needs the real build cycle, not security-feedback.
+      //
+      // ALL comment intents on a summary issue funnel to security-feedback
+      // — including BUILD ("create issues for the highs" looks like build to
+      // the classifier but is really a break-out request). Approve/reject
+      // regex matches already returned above, so they don't reach here.
+      const hasScanSummaryLabel = (envelope.labels || []).includes("security-scan");
+      if (hasScanSummaryLabel) {
         return {
           action: "skill",
           skill: "security-feedback",

--- a/src/workflows/runner.ts
+++ b/src/workflows/runner.ts
@@ -445,6 +445,11 @@ export async function runWorkflow(
         console.log(`[runner] ${definition.name} cancelled — stopping before phase ${phase.name}`);
         return { success: false, phases };
       }
+    } else {
+      // Shouldn't happen for real runs (simple.ts always passes both),
+      // but if a caller wires the runner without db/workflowId the run
+      // becomes uncancellable — log so the misconfiguration is obvious.
+      console.warn(`[runner] cancel check skipped — no db/workflowId context`);
     }
 
     const { name: phaseName, type: phaseType = "agent" } = phase;
@@ -1146,6 +1151,8 @@ async function runDagWorkflow(
         console.log(`[runner:dag] ${definition.name} cancelled — stopping DAG`);
         return { success: false, phases };
       }
+    } else {
+      console.warn(`[runner:dag] cancel check skipped — no db/workflowId context`);
     }
 
     // First, mark nodes that should be skipped (trigger rule fails but deps are terminal)

--- a/src/workflows/runner.ts
+++ b/src/workflows/runner.ts
@@ -435,6 +435,18 @@ export async function runWorkflow(
   }
 
   for (const phase of definition.phases) {
+    // Honour a cancel that landed during the previous phase's execution.
+    // The admin /cancel endpoint both flips status to 'cancelled' and
+    // kills the in-flight sandbox container; this check keeps the runner
+    // from picking up the next phase after the DB flag flips.
+    if (db && workflowId) {
+      const latest = db.getWorkflowRun(workflowId);
+      if (latest?.status === "cancelled") {
+        console.log(`[runner] ${definition.name} cancelled — stopping before phase ${phase.name}`);
+        return { success: false, phases };
+      }
+    }
+
     const { name: phaseName, type: phaseType = "agent" } = phase;
     // Linear workflows share one sandbox workspace across phases via `taskId`.
     // (DAG path uses phase-scoped taskIds to avoid concurrent write races.)
@@ -1126,6 +1138,16 @@ async function runDagWorkflow(
   // ── Main DAG execution loop ────────────────────────────────────────────────
 
   while (!isComplete(dag)) {
+    // Cancel check (DAG path) — mirror the linear runner's between-phase
+    // guard so a /cancel dispatch halts the next scheduling round.
+    if (db && workflowId) {
+      const latest = db.getWorkflowRun(workflowId);
+      if (latest?.status === "cancelled") {
+        console.log(`[runner:dag] ${definition.name} cancelled — stopping DAG`);
+        return { success: false, phases };
+      }
+    }
+
     // First, mark nodes that should be skipped (trigger rule fails but deps are terminal)
     const toSkip = getNodesToSkip(dag);
     for (const node of toSkip) {


### PR DESCRIPTION
## Summary

Two fixes surfaced while trying to use the new security-review pipeline end-to-end.

### 1. "@last-light create issues for the highs" triggered a full build cycle

On a scan summary issue (labels `["security", "security-scan"]`) a comment like *"create issues for the highs"* classifies as **BUILD** to the LLM — which is reasonable for "create issues" in isolation but completely wrong on a scan summary where it's unambiguously security-feedback territory ("break out findings into individual issues").

The previous guard was:

```ts
const hasSecurityLabel = labels.includes("security");
if (hasSecurityLabel && !["build", "approve", "reject"].includes(intent)) {
  return security-feedback;
}
```

Two problems:
- `security` alone also applies to broken-out sub-issues (`["security", severity]`), so we can't just drop the `build` exclusion without breaking the "build this fix" flow on sub-issues.
- On a summary, BUILD intent is definitionally a routing miss.

**Fix:** key on `security-scan` (unique to summary issues per `skills/security-review/SKILL.md`) and route *every* non-regex-matched comment to security-feedback on summaries. Sub-issues continue through the normal build/issue-comment path.

### 2. Dashboard Cancel didn't actually cancel

`POST /workflow-runs/:id/cancel` only flipped `status='cancelled'` in the DB. Nothing killed the in-flight sandbox container, and the runner didn't re-check status between phases — the workflow kept running every remaining phase to completion.

**Fix:**
- Cancel route enumerates running sandbox containers whose taskId matches the run's taskId prefix (covers DAG phase-scoped `<taskId>-<phaseName>` suffixes too) and `docker rm -f`s each.
- Matching live execution rows are marked failed with `"cancelled via admin dashboard"`.
- Linear runner re-reads `workflow_runs.status` between phases, bails on `cancelled`.
- DAG runner does the same at the top of each scheduling round.

## Test plan

- [x] `npx vitest run` — 339 pass (+3 router tests covering summary vs sub-issue vs no-security-scan)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: comment `@last-light create issues for the highs` on a scan summary → security-feedback (not build)
- [ ] Manual: hit Cancel on a running run → sandbox container dies, next phase never starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)