### PR TITLE
feat(pr-review): post a Check Run for branch-protection gating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,16 @@ WEBHOOK_SECRET=your-webhook-secret
 # externally-reachable host (reverse proxy, custom port, etc.). No trailing /.
 # PUBLIC_URL=https://lastlight.example.com
 
+# ── PR review as a blocking check ──────────────────────────────────────────
+# When 1, the pr-review workflow posts a `last-light/review` Check Run on the
+# PR's head SHA — yellow on workflow start, then success/failure/neutral when
+# the agent's review lands. Add `last-light/review` to the repo's required
+# status checks in branch protection to gate merges on the review.
+#
+# Requires the GitHub App to have Checks: Read and write permission. Without
+# it, check-run posts will fail with 403 (the workflow itself still runs).
+# REVIEW_POSTS_CHECK=1
+
 # ── Claude API (optional) ───────────────────────────────
 # If set, uses API credits. If not set, uses your Claude Code login (subscription).
 # For Docker: either set this, or run `docker exec -it lastlight-agent-1 claude login`

--- a/src/config.ts
+++ b/src/config.ts
@@ -104,6 +104,16 @@ export interface LastLightConfig {
    * omitted when neither is configured.
    */
   publicUrl?: string;
+  /**
+   * When true, the pr-review workflow posts a `last-light/review` Check Run
+   * on the PR's head SHA — `in_progress` at workflow start, then completed
+   * with `success` (APPROVE), `failure` (REQUEST_CHANGES) or `neutral`
+   * (COMMENT) when the agent submits its review. Repos that add this check
+   * to "Required status checks" in branch protection will block merges on
+   * the conclusion. Requires the GitHub App to have Checks: Read and write.
+   * Defaults off so a permission-less rollout is unchanged behaviour.
+   */
+  reviewPostsCheck: boolean;
 }
 
 /**
@@ -153,7 +163,14 @@ export function loadConfig(): LastLightConfig {
     bootstrapLabel: process.env.BOOTSTRAP_LABEL || "lastlight:bootstrap",
     exploreDefaultRepo: process.env.EXPLORE_DEFAULT_REPO || undefined,
     publicUrl: resolvePublicUrl(),
+    reviewPostsCheck: parseBool(process.env.REVIEW_POSTS_CHECK),
   };
+}
+
+function parseBool(raw: string | undefined): boolean {
+  if (!raw) return false;
+  const v = raw.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
 }
 
 /**

--- a/src/engine/github.ts
+++ b/src/engine/github.ts
@@ -109,6 +109,113 @@ export class GitHubClient {
     return data;
   }
 
+  /** Convenience: fetch only the PR's head commit SHA. Used by check-run code. */
+  async getPullRequestHeadSha(owner: string, repo: string, pullNumber: number): Promise<string> {
+    const { data } = await this.octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: pullNumber,
+    });
+    return data.head.sha;
+  }
+
+  /**
+   * Create a Check Run on a PR's head commit. Returns the new check_run id so
+   * the caller can later transition it from `in_progress` → `completed` with
+   * a conclusion. Repos that enable "Require status checks to pass" with
+   * `name` in their list will gate merges on the eventual conclusion.
+   *
+   * Requires the GitHub App to have `Checks: Read and write` permission.
+   */
+  async createCheckRun(
+    owner: string,
+    repo: string,
+    headSha: string,
+    name: string,
+    options: { detailsUrl?: string; output?: { title: string; summary: string } } = {},
+  ): Promise<number> {
+    const { data } = await this.octokit.rest.checks.create({
+      owner,
+      repo,
+      name,
+      head_sha: headSha,
+      status: "in_progress",
+      started_at: new Date().toISOString(),
+      ...(options.detailsUrl ? { details_url: options.detailsUrl } : {}),
+      ...(options.output ? { output: options.output } : {}),
+    });
+    return data.id;
+  }
+
+  /**
+   * Update an existing Check Run — typically to transition `in_progress` →
+   * `completed` with a conclusion. Conclusion values that branch protection
+   * treats as passing: `success`, `neutral`, `skipped`. Failing: `failure`,
+   * `cancelled`, `timed_out`, `action_required`.
+   */
+  async updateCheckRun(
+    owner: string,
+    repo: string,
+    checkRunId: number,
+    update: {
+      status?: "queued" | "in_progress" | "completed";
+      conclusion?:
+        | "success"
+        | "failure"
+        | "neutral"
+        | "cancelled"
+        | "timed_out"
+        | "action_required"
+        | "skipped";
+      output?: { title: string; summary: string };
+    },
+  ): Promise<void> {
+    await this.octokit.rest.checks.update({
+      owner,
+      repo,
+      check_run_id: checkRunId,
+      ...(update.status ? { status: update.status } : {}),
+      ...(update.conclusion ? { conclusion: update.conclusion } : {}),
+      ...(update.status === "completed" ? { completed_at: new Date().toISOString() } : {}),
+      ...(update.output ? { output: update.output } : {}),
+    });
+  }
+
+  /**
+   * Find the bot's most recent review on this PR's current head commit. Used
+   * after a pr-review workflow finishes to derive the check-run conclusion
+   * from the review the agent actually posted (APPROVE / REQUEST_CHANGES /
+   * COMMENT). Returns null when the bot hasn't reviewed this SHA yet.
+   *
+   * `botLogin` defaults to `last-light[bot]` so the lookup matches App-auth'd
+   * reviews regardless of how the agent identified itself.
+   */
+  async getLatestBotReview(
+    owner: string,
+    repo: string,
+    pullNumber: number,
+    headSha: string,
+    botLogin = "last-light[bot]",
+  ): Promise<{ state: string; body: string | null; submittedAt: string | null } | null> {
+    const reviews = await this.octokit.paginate(this.octokit.rest.pulls.listReviews, {
+      owner,
+      repo,
+      pull_number: pullNumber,
+      per_page: 100,
+    });
+    // Reviews are returned oldest-first; iterate newest-first to pick the most
+    // recent one tied to this SHA. `commit_id` on a review is the head sha at
+    // the time the review was submitted, which is exactly the discriminator
+    // we want — re-pushes invalidate stale reviews here naturally.
+    for (let i = reviews.length - 1; i >= 0; i--) {
+      const r = reviews[i]!;
+      if (r.user?.login === botLogin && r.commit_id === headSha) {
+        return { state: r.state, body: r.body ?? null, submittedAt: r.submitted_at ?? null };
+      }
+    }
+    return null;
+  }
+
   /**
    * Get failed check runs for a PR's head SHA.
    * Fetches the actual job logs (not just annotations) to show real errors.

--- a/src/index.ts
+++ b/src/index.ts
@@ -930,8 +930,103 @@ async function main() {
       return;
     }
 
-    // Run workflow asynchronously (webhook triggers)
-    dispatchWorkflow(skill, { ...context, _triggerType: "webhook" }).catch((err: unknown) => {
+    // Run workflow asynchronously (webhook triggers).
+    //
+    // Special case: when REVIEW_POSTS_CHECK=1, the pr-review workflow on a
+    // pr.opened event posts a `last-light/review` Check Run on the PR's
+    // head SHA so branch protection can gate the merge on its conclusion.
+    // The check goes `in_progress` here and is completed below from the
+    // workflow's terminal result.
+    const wantReviewCheck =
+      config.reviewPostsCheck &&
+      envelope.type === "pr.opened" &&
+      skill === "pr-review" &&
+      !!github &&
+      !!envelope.repo &&
+      typeof envelope.prNumber === "number";
+
+    let prCheckRunId: number | undefined;
+    let prHeadSha: string | undefined;
+    let prOwner = "";
+    let prRepoName = "";
+    let prNumberForCheck = 0;
+    if (wantReviewCheck) {
+      [prOwner, prRepoName] = envelope.repo!.split("/");
+      prNumberForCheck = envelope.prNumber as number;
+      try {
+        prHeadSha = await github!.getPullRequestHeadSha(prOwner, prRepoName, prNumberForCheck);
+        prCheckRunId = await github!.createCheckRun(
+          prOwner,
+          prRepoName,
+          prHeadSha,
+          "last-light/review",
+          {
+            output: {
+              title: "Review in progress",
+              summary: "Last Light is reviewing this PR. The conclusion will land here when the review completes.",
+            },
+          },
+        );
+        console.log(
+          `[check] Posted in-progress check ${prCheckRunId} for ${prOwner}/${prRepoName}#${prNumberForCheck} on ${prHeadSha.slice(0, 7)}`,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[check] failed to create in-progress check: ${msg}`);
+      }
+    }
+
+    const workflowPromise = dispatchWorkflow(skill, { ...context, _triggerType: "webhook" });
+
+    if (prCheckRunId !== undefined) {
+      // Capture local copies so the closure doesn't depend on the loop
+      // variables changing between invocations.
+      const checkId = prCheckRunId;
+      const owner = prOwner;
+      const repo = prRepoName;
+      const prNumber = prNumberForCheck;
+      workflowPromise
+        .then(async (result) => {
+          try {
+            // Re-fetch head SHA in case the PR was rebased mid-review — the
+            // bot's review is keyed off the SHA at submit time, so matching
+            // on the latest SHA correctly skips stale reviews.
+            const headSha = await github!.getPullRequestHeadSha(owner, repo, prNumber);
+            const review = await github!.getLatestBotReview(owner, repo, prNumber, headSha);
+            const conclusion: "success" | "failure" | "neutral" = !result.success
+              ? "neutral"
+              : review?.state === "APPROVED"
+              ? "success"
+              : review?.state === "CHANGES_REQUESTED"
+              ? "failure"
+              : "neutral";
+            await github!.updateCheckRun(owner, repo, checkId, {
+              status: "completed",
+              conclusion,
+              output: {
+                title: `Review ${conclusion === "success" ? "approved" : conclusion === "failure" ? "requested changes" : "completed"}`,
+                summary: review?.body?.slice(0, 65000) || "Review complete.",
+              },
+            });
+            console.log(`[check] Completed check ${checkId} → ${conclusion}`);
+          } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.warn(`[check] failed to complete check ${checkId}: ${msg}`);
+          }
+        })
+        .catch(async (err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          try {
+            await github!.updateCheckRun(owner, repo, checkId, {
+              status: "completed",
+              conclusion: "neutral",
+              output: { title: "Review errored", summary: `Workflow threw: ${msg.slice(0, 1000)}` },
+            });
+          } catch { /* ignore — best effort */ }
+        });
+    }
+
+    workflowPromise.catch((err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[event] Unhandled error in workflow ${skill}: ${msg}`);
     });


### PR DESCRIPTION
## Summary

PR reviews aren't required-status-checks — branch protection can't gate merges on them. To act as a real merge blocker (CodeRabbit-style) the bot needs to publish a **Check Run** on the PR's head SHA. This change adds that, gated behind `REVIEW_POSTS_CHECK=1` so the rollout is fully opt-in.

## Behaviour

When `REVIEW_POSTS_CHECK=1`:

| Stage | What happens on the PR |
|---|---|
| `pr.opened` webhook routes to `pr-review` | Harness posts `last-light/review` check with `status=in_progress`. Yellow circle appears immediately. |
| Workflow finishes — agent posted APPROVE | Check → `success` (green). |
| Workflow finishes — agent posted REQUEST_CHANGES | Check → `failure` (red, blocks merge). |
| Workflow finishes — agent posted COMMENT or no review found | Check → `neutral` (visible, doesn't block). |
| Workflow itself failed/threw/cancelled | Check → `neutral`. |

Mid-review rebase: harness re-fetches the head SHA at completion time and matches the bot's review against the latest SHA, so a stale review on an obsolete SHA correctly resolves to `neutral`.

All check-run posts are best-effort — failures log a warn and never break the underlying review.

## Plumbing

- **`src/engine/github.ts`** — `createCheckRun` / `updateCheckRun` / `getPullRequestHeadSha` / `getLatestBotReview` helpers (Octokit Checks + Reviews API).
- **`src/config.ts`** — `reviewPostsCheck` flag from `REVIEW_POSTS_CHECK` env.
- **`src/index.ts`** — webhook dispatch path only (`pr.opened` + `pr-review`). Chat / cron / CLI dispatch paths untouched.
- **`.env.example`** — documents the env var + the branch-protection step.

## Operator action to make it a real blocker

1. **GitHub App settings** → Permissions → **Checks: Read and write**. Org admin will get an email asking to approve the new permission.
2. Set `REVIEW_POSTS_CHECK=1` in production `.env` and redeploy.
3. Repo settings → **Branches** → branch protection rule for `main` → **Require status checks to pass before merging** → add `last-light/review`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 338 pass (no behavior change without env var)
- [ ] Manual on prod with REVIEW_POSTS_CHECK=1: open a PR → yellow check appears → review lands → check goes green/red.
- [ ] Manual: enable branch protection → confirm a `failure` conclusion blocks merge.

## Followups not in this PR

- Cron pr-review scans currently don't publish checks (only `pr.opened` webhook does). Easy to extend if useful.
- `pr.synchronize` (re-push) doesn't currently re-trigger a review or post a fresh check. Worth adding if you want the check to refresh on each push.
- No automated tests for the check-run posting itself (would need a deeper Octokit mock); covered by the manual plan above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)