### PR TITLE
fix(webhook): pr.synchronize wasn't reaching the router (two layered filters)

### DIFF
--- a/src/connectors/github-webhook.ts
+++ b/src/connectors/github-webhook.ts
@@ -14,7 +14,16 @@ export interface GitHubWebhookConfig {
   replyFn?: (owner: string, repo: string, issueNumber: number, body: string) => Promise<void>;
 }
 
-/** GitHub webhook actions we skip — these are noisy and never need agent work */
+/**
+ * GitHub webhook actions we skip — these are noisy and never need agent work.
+ *
+ * NOTE: `synchronize` is intentionally NOT in this set. It fires on every new
+ * commit pushed to a PR's branch and is the canonical "needs a fresh review"
+ * trigger — without it, branch protection requiring `last-light/review`
+ * would block merges after a REQUEST_CHANGES + fix-commit cycle (the new
+ * SHA would never get a check posted against it). The handler maps it to
+ * `pr.synchronize` and routes to pr-review.
+ */
 const IGNORED_ACTIONS = new Set([
   "deleted",
   "edited",
@@ -23,7 +32,6 @@ const IGNORED_ACTIONS = new Set([
   "assigned",
   "unassigned",
   "closed",
-  "synchronize",
   "milestoned",
   "demilestoned",
   "locked",
@@ -85,14 +93,31 @@ export class GitHubWebhookConnector extends EventEmitter implements Connector {
         return c.json({ filtered: true, reason: `action=${action}` }, 200);
       }
 
-      // Filter out bot events (self-loop prevention)
+      // Filter out bot events (self-loop prevention).
+      //
+      // Exception: `pull_request` opened/synchronize/reopened from a bot
+      // sender must still flow through. A bot opening its own PR or
+      // pushing a fix commit is the canonical "needs a fresh review"
+      // signal — without this exception, a REQUEST_CHANGES verdict on a
+      // bot-authored PR followed by a fix commit would be invisible to
+      // the harness, leaving branch protection (which requires a check
+      // on the latest SHA) permanently blocked.
+      //
+      // Loop risk on this exception is low: pr-review posts a PR Review
+      // (`pr_review.submitted`, currently unrouted) and a Check Run
+      // (`check_run.completed`, no event type at all here) — nothing the
+      // agent acts on. Comment/issue paths still keep the strict filter
+      // to avoid the bot replying to its own comments.
       const senderLogin = payload.sender?.login || "";
       const senderType = payload.sender?.type || "";
-      if (
+      const isBotSender =
         senderType === "Bot" ||
         senderLogin === this.config.botLogin ||
-        senderLogin.endsWith("[bot]")
-      ) {
+        senderLogin.endsWith("[bot]");
+      const isPrAttention =
+        eventType === "pull_request" &&
+        (action === "opened" || action === "synchronize" || action === "reopened");
+      if (isBotSender && !isPrAttention) {
         return c.json({ filtered: true, reason: "bot sender" }, 200);
       }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ['src/**/*.test.ts'],
+    // Force LASTLIGHT_LOCAL_DEV=1 so any test that touches configureGitAuth
+    // (or imports a code path that does) skips the `git config --global`
+    // writes that would otherwise overwrite the contributor's real git
+    // identity with `last-light[bot]`. Existing tests that explicitly
+    // exercise the global-write path can still `delete process.env.LASTLIGHT_LOCAL_DEV`
+    // in beforeEach (see src/engine/git-auth.test.ts).
+    env: {
+      LASTLIGHT_LOCAL_DEV: "1",
+    },
   },
 });


### PR DESCRIPTION
## Summary

PR #41 mapped `pull_request.synchronize` → `pr.synchronize` and the router routes it to `pr-review`, but **two upstream filters** were eating the event before the mapping could fire. Net effect: a `REQUEST_CHANGES` verdict followed by a fix commit produced no re-review, and branch protection requiring `last-light/review` would sit blocked on a new SHA forever.

### Filter 1 — IGNORED_ACTIONS

`IGNORED_ACTIONS` predated PR #41 and listed `synchronize` as a noisy action. Every re-push was discarded with `{ filtered: true, reason: "action=synchronize" }` before reaching the type-mapping switch. Removed from the set with a docstring noting why.

### Filter 2 — bot self-filter

The filter `senderType === "Bot" || senderLogin === botLogin || senderLogin.endsWith("[bot]")` is correct for issue/comment loops (don't reply to your own comments) but too broad for PR-attention events. When the bot pushes a fix commit to its own bot-authored PR — exactly what happens after a `REQUEST_CHANGES` verdict — the synchronize sender is `last-light[bot]` and the filter drops it.

Scoped exception: `pull_request` events with action `opened`/`synchronize`/`reopened` bypass the bot-self filter. Loop risk is low — `pr-review` posts a PR Review (`pr_review.submitted` is unrouted) and a Check Run (no webhook event at all), neither of which the agent acts on. Comments and issues keep the strict filter.

## Test plan

- [x] `npx vitest run` — 345 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: push a commit to this PR's branch → verify `last-light/review` re-runs and a fresh check appears on the new SHA (this PR self-tests the fix once deployed).

## Followup

- Bot-authored PRs (most of ours, since the bot opens build-cycle PRs) historically waited for the cron pr-review sweep to get reviewed; with the bot exemption on `opened`, they'll now get reviewed at webhook time. That's the desired behaviour but worth flagging — cron sweeps still run as a safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)