### PR TITLE
sandbox: install agentic-pi in the docker-mode sandbox image

### DIFF
--- a/sandbox.Dockerfile
+++ b/sandbox.Dockerfile
@@ -65,6 +65,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Create non-root agent user
 RUN useradd -m -s /bin/bash agent
 
+# Install agentic-pi globally so the harness can `docker exec ...
+# agentic-pi run ...` against this container. Pinned + integrity-checked
+# against the lastlight package-lock.json — `npm install -g <name>@<v>`
+# doesn't consult any lockfile, so without this a republished/compromised
+# tarball would land silently. To bump: copy the new `sha512-…` from
+# lastlight's package-lock.json (node_modules/agentic-pi → integrity).
+ARG AGENTIC_PI_VERSION=0.2.2
+ARG AGENTIC_PI_INTEGRITY=sha512-3aSFw9mrK4qvee599tVS8LT0UkDJl519N2mzxac2pe5sMMyDFMEvFSOuJ7HAaMvSoWeMWet/koYr8c69hyaXMg==
+RUN curl -fsSL "https://registry.npmjs.org/agentic-pi/-/agentic-pi-${AGENTIC_PI_VERSION}.tgz" -o /tmp/agentic-pi.tgz \
+ && actual="sha512-$(node -e "const c=require('crypto'),f=require('fs');process.stdout.write(c.createHash('sha512').update(f.readFileSync('/tmp/agentic-pi.tgz')).digest('base64'))")" \
+ && if [ "$actual" != "$AGENTIC_PI_INTEGRITY" ]; then \
+      echo "agentic-pi tarball integrity mismatch:" >&2; \
+      echo "  expected: $AGENTIC_PI_INTEGRITY" >&2; \
+      echo "  actual:   $actual" >&2; \
+      exit 1; \
+    fi \
+ && npm install -g --no-audit --no-fund /tmp/agentic-pi.tgz \
+ && rm /tmp/agentic-pi.tgz
+
 # Agent context (baked at /app/ — entrypoint cats into workspace/AGENTS.md)
 COPY agent-context/ /app/agent-context/
 


### PR DESCRIPTION
## Summary
- Phase 1 cleanup removed the global \`opencode-ai\` install from \`sandbox.Dockerfile\` but didn't add the \`agentic-pi\` replacement. Result: when \`LASTLIGHT_SANDBOX=docker\` the harness gets \`exit 127: sh: 1: agentic-pi: not found\` from inside the spawned sandbox container.
- Pinned to \`0.2.2\` with sha512 integrity verification (matches \`package-lock.json\`).
- Tested locally: \`agentic-pi --help\` resolves cleanly via fnm's default alias bin for both \`root\` and the \`agent\` user.

## Test plan
- [x] \`docker build -f sandbox.Dockerfile -t lastlight-sandbox-test .\` — clean
- [x] \`docker exec --user agent <container> agentic-pi --help\` — prints CLI usage
- [ ] After merge: rebuild on prod, trigger an explore workflow, confirm the sandbox spawn succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)