### PR TITLE
fix(sandbox): make Node fetch honor HTTPS_PROXY in docker sandboxes

### DIFF
--- a/deploy/sandbox-proxy-init.mjs
+++ b/deploy/sandbox-proxy-init.mjs
@@ -1,0 +1,32 @@
+// Preloaded into the sandbox `node` process via NODE_OPTIONS='--import ...'.
+//
+// Node 22's built-in fetch (undici) does NOT honor HTTP_PROXY / HTTPS_PROXY
+// env vars by default — every HTTP client built on global fetch (the OpenAI
+// SDK, the Anthropic SDK, agentic-pi) ignores them and dials direct. In a
+// sandbox attached to an `internal: true` docker network, that means
+// every LLM call times out with a generic "Connection error" because the
+// only path off-network is via the tinyproxy sidecar.
+//
+// Register undici's EnvHttpProxyAgent as the global dispatcher so fetch
+// reads HTTP_PROXY / HTTPS_PROXY / NO_PROXY from the environment. This
+// is the documented escape hatch for the "fetch doesn't see env proxies"
+// problem and Node may surface it as a flag in a future release
+// (see `node --use-env-proxy`).
+//
+// Only activates when HTTP_PROXY or HTTPS_PROXY is actually set, so this
+// is a no-op outside the sandbox.
+
+if (process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy) {
+  try {
+    const { setGlobalDispatcher, EnvHttpProxyAgent } = await import("undici");
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+    if (process.env.LASTLIGHT_PROXY_INIT_DEBUG) {
+      console.error(`[proxy-init] EnvHttpProxyAgent installed (HTTPS_PROXY=${process.env.HTTPS_PROXY || process.env.https_proxy || "unset"})`);
+    }
+  } catch (err) {
+    // Don't crash the process if undici isn't reachable — agentic-pi vendors
+    // it as a dependency so this should always resolve, but a stricter
+    // resolver setting or a stripped image would surface here.
+    console.error(`[proxy-init] failed to install EnvHttpProxyAgent: ${err?.message ?? err}`);
+  }
+}

--- a/sandbox.Dockerfile
+++ b/sandbox.Dockerfile
@@ -84,8 +84,22 @@ RUN curl -fsSL "https://registry.npmjs.org/agentic-pi/-/agentic-pi-${AGENTIC_PI_
  && npm install -g --no-audit --no-fund /tmp/agentic-pi.tgz \
  && rm /tmp/agentic-pi.tgz
 
+# undici as a top-level global so deploy/sandbox-proxy-init.mjs can
+# `import("undici")` without depending on agentic-pi's nested node_modules
+# layout. Node's built-in fetch ignores HTTP_PROXY/HTTPS_PROXY env vars by
+# default; the preload below registers EnvHttpProxyAgent as the global
+# dispatcher so OpenAI/Anthropic/etc SDK calls actually route through the
+# sandbox-side tinyproxy.
+RUN npm install -g --no-audit --no-fund undici@^7
+
 # Agent context (baked at /app/ — entrypoint cats into workspace/AGENTS.md)
 COPY agent-context/ /app/agent-context/
+
+# Node preload script that wires fetch up to the HTTPS_PROXY env var.
+# Activated by NODE_OPTIONS='--import file:///app/sandbox-proxy-init.mjs',
+# which the harness sets when spawning a sandbox container with a proxy
+# configured (see src/sandbox/docker.ts).
+COPY deploy/sandbox-proxy-init.mjs /app/sandbox-proxy-init.mjs
 
 # Entrypoint
 COPY deploy/sandbox-entrypoint.sh /app/sandbox-entrypoint.sh

--- a/src/sandbox/docker.ts
+++ b/src/sandbox/docker.ts
@@ -118,6 +118,12 @@ export class DockerSandbox {
       proxyEnv.http_proxy = proxyUrl;
       proxyEnv.NO_PROXY = "localhost,127.0.0.1,::1";
       proxyEnv.no_proxy = proxyEnv.NO_PROXY;
+      // Node 22's built-in fetch (undici) doesn't read HTTP_PROXY/HTTPS_PROXY
+      // by default — the OpenAI / Anthropic / pi-ai SDKs all use fetch and
+      // would otherwise dial direct, which on `sandbox-egress` (internal:true)
+      // hits a connection error. Preload sandbox-proxy-init.mjs to register
+      // EnvHttpProxyAgent as the global dispatcher.
+      proxyEnv.NODE_OPTIONS = "--import file:///app/sandbox-proxy-init.mjs";
     }
     const combinedEnv = { ...this.config.env, ...proxyEnv };
     const envFlags = Object.entries(combinedEnv).flatMap(([k, v]) => ["-e", `${k}=${v}`]);


### PR DESCRIPTION
## Summary
Docker-mode workflows were erroring with \"Connection error\" because Node 22's built-in fetch (undici) doesn't honor \`HTTP_PROXY\` / \`HTTPS_PROXY\` env vars by default. The OpenAI/Anthropic/pi-ai SDKs all use fetch, so they dialed direct — and on \`sandbox-egress\` (\`internal: true\`) there's no host route, so every LLM call hung. Tinyproxy logs showed zero connections, confirming the SDK bypassed the proxy entirely.

\`HTTPS_PROXY\` does work for everything else in the sandbox (\`curl\`, \`gh\`, \`git\`, \`npm\`, \`python\`/\`pip\`) since those honor it natively. Node fetch is the lone exception.

## Fix
- \`deploy/sandbox-proxy-init.mjs\` — tiny preload that calls \`setGlobalDispatcher(new EnvHttpProxyAgent())\` when \`HTTP(S)_PROXY\` is set. No-op otherwise.
- \`sandbox.Dockerfile\` — \`npm install -g undici@^7\` and \`COPY\` the preload into the image.
- \`src/sandbox/docker.ts\` — when \`proxyHost\` is configured, also set \`NODE_OPTIONS=--import file:///app/sandbox-proxy-init.mjs\` in the sandbox env so every node process in the container preloads the dispatcher.

## Why not transparent?
A real transparent SNI proxy (HAProxy/sniproxy + DNAT) was considered and discarded for now — same security properties as the env-var path for the LLM-traffic case but materially more architecture. Tracked as a follow-up.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 436 + 1 todo, all green
- [ ] Manual on prod: run an issue-comment workflow, verify tinyproxy-strict logs show CONNECT to api.openai.com and the workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)