### PR TITLE
Extract parseReviewerVerdict + typed PhaseRef (runner prefactor, #93)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,5 +506,19 @@ docker compose restart agent       # restart after an instance/ overlay edit
 ## Sub-folder docs
 
 - `src/workflows/CLAUDE.md` — runner internals: phase types, linear vs DAG,
-  loop iteration naming (`reviewer_2`, `reviewer_fix_1`), approval gates,
+  loop iteration naming (`reviewer_fix_1`, `reviewer_recheck_1`), approval gates,
   resume semantics, taskId scoping, template rendering.
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked as GitHub issues in `cliftonc/lastlight` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical triage vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,88 @@
+# Last Light — Domain Glossary
+
+The project's **ubiquitous language**. When an issue title, refactor proposal,
+test name, or phase label names a domain concept, use the term as defined here.
+This file is seeded lazily — terms are added as they get pinned down (most
+recently during the `/grilling` of issue #93). It is not exhaustive.
+
+> Orientation lives in `CLAUDE.md`; the rebuild-grade contract in `spec/`.
+> This file is narrower: the words we agree to use, and the ones we avoid.
+
+## Workflow execution
+
+- **Workflow** — a YAML file in `workflows/` listing **phases**. The runner
+  executes it; it knows nothing about "build" vs "triage".
+
+- **Phase** — one entry in a workflow's `phases:` array. Three kinds: a
+  **context phase** (a checkpoint, no agent run), an **agent phase** (one
+  sandboxed agent session), and a **loop phase** (an agent phase that repeats).
+
+- **Loop phase** — a phase with `loop:` set. A **reviewer loop** alternates a
+  review with a **fix** (a different agent run, the executor with `fix_prompt`)
+  up to `max_cycles`, driven by the **reviewer verdict**. A **generic loop**
+  (`generic_loop:`) repeats a phase until an `until` expression passes.
+
+- **Cycle** — one fix-then-re-review pair inside a reviewer loop. Cycle `k`
+  comprises the **fix** `k` and the **recheck** `k`. (The very first review is
+  the loop's initial run, before any cycle.)
+
+- **Scheduler** — the single component that walks a workflow's phases. Every
+  workflow is executed as a DAG; a **linear** workflow (no `depends_on`) is a
+  degenerate **chain** (synthesized `depends_on: [previous]` edges). Phases run
+  **sequentially in topological order**, one at a time. `depends_on` controls
+  *ordering* and *trigger-rule skipping* — _not_ parallelism (concurrent
+  execution is deferred). _Avoid_: "linear runner" vs "DAG runner" — there is
+  one scheduler. (Pre-#94 the two were separate; see [[lastlight-architecture-deepening-issues]].)
+
+- **Workspace** — the single sandbox checkout shared by every phase and loop
+  iteration of one workflow invocation (`ctx.taskId`). One checkout per run;
+  phases hand off through it (architect writes `plan.md`, executor reads it).
+
+- **PhaseExecutor** — the deep module that owns every per-phase body (context /
+  reviewer-loop / generic-loop / standard / approval-gate) behind one
+  `execute(node, outputs) → PhaseOutcome`. The scheduler owns ordering and
+  accumulation; the PhaseExecutor owns what one phase *does*.
+
+- **Trigger rule** — per-edge condition (`all_success`, `one_success`,
+  `none_failed_min_one_success`, `all_done`) deciding whether a node runs given
+  its dependencies' statuses. A node whose rule can't be satisfied is
+  **skipped** (recorded in the executions ledger).
+
+- **Executions ledger** — the `executions` table is the **single source of
+  truth** for "did this phase run and how did it end." It drives resume
+  (`shouldRunPhase`) and the dashboard derives phase status from it. _Avoid_
+  introducing parallel status stores (the dead `node_statuses` map was
+  removed; `phase_history` reconciliation is tracked in #97).
+
+## Phase-iteration naming
+
+The runner generates a phase label for each dynamically-created iteration.
+Convention (post-#93):
+
+| Iteration | Label |
+| --- | --- |
+| initial review | `<phase>` (e.g. `reviewer`) |
+| cycle _n_ fix | `<phase>_fix_<n>` |
+| cycle _n_ re-review | `<phase>_recheck_<n>` |
+| generic-loop iteration _n_ | `<phase>_iter_<n>` |
+
+`n` is the 1-based **cycle** number; `fix_k` and `recheck_k` pair within a
+cycle. _Avoid_ the legacy bare-numeric re-review form (`reviewer_2`) — it was
+untagged, ambiguous with literal phase names, and inconsistent with the
+`_fix_`/`_iter_` tags. These labels are a persisted/observed surface: they land
+in `phase_history`, drive resume via `phaseIndexInDefinition`, and the
+dashboard groups them by `<phase>_` prefix.
+
+- **PhaseRef** — the value object that is the single authority for building and
+  resolving phase-iteration labels: `{ base, kind: 'phase'|'fix'|'recheck'|'iter',
+  index? }`. `format()` is the only place labels are constructed; resolution
+  (`phaseIndexInDefinition`) stays **definition-aware** with exact-match-first
+  ordering. Lives in `src/workflows/phase-ref.ts`.
+
+## Reviewer verdict
+
+- **Reviewer verdict** — a reviewer phase's outcome, `APPROVED` or
+  `REQUEST_CHANGES`, parsed from a `VERDICT:` marker line in the agent output
+  (with a fallback when the marker is absent). `parseReviewerVerdict` is the
+  single pure parser (`src/workflows/verdict.ts`); it reports `viaFallback` so
+  callers can warn when the marker was missing.

--- a/dashboard/src/components/PhaseDetailPanel.tsx
+++ b/dashboard/src/components/PhaseDetailPanel.tsx
@@ -77,7 +77,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 export function PhaseDetailPanel({ phaseName, run, definition, execution, totalExecutions }: Props) {
   // Look up the phase in the workflow definition (may be missing for dynamic
-  // phases like reviewer_2 / fix_loop_1 — we still show what we know).
+  // phases like reviewer_recheck_1 / reviewer_fix_1 — we still show what we know).
   const phaseDef: WorkflowPhaseDefinition | undefined = definition?.phases.find(
     (p) => p.name === phaseName,
   );

--- a/dashboard/src/components/WorkflowList.tsx
+++ b/dashboard/src/components/WorkflowList.tsx
@@ -273,7 +273,7 @@ function DetailPanel({ run, approvals, onCancel, onApprovalResponded, onOpenDefi
   }, [run.id, setSelectedPhase]);
 
   // Build the per-phase grouping. For loop phases that produced multiple
-  // executions (reviewer + reviewer_2 / fix_loop_*) we always pick the most
+  // executions (reviewer + reviewer_recheck_* / reviewer_fix_*) we always pick the most
   // recent — the count is shown in PhaseDetailPanel so the user knows.
   const phaseExecutions = useMemo(() => {
     const map = new Map<string, WorkflowRunExecution[]>();

--- a/dashboard/src/components/WorkflowPipeline.tsx
+++ b/dashboard/src/components/WorkflowPipeline.tsx
@@ -90,11 +90,11 @@ const NODE_ROW_HEIGHT = 78;
 const ROW_GAP = 20;
 
 /**
- * Map a dynamic phase name (e.g. "reviewer_fix_1", "reviewer_2") back to the
- * declared phase it iterates on. The runner names loop iterations like
- * `${parent}_${n}` (re-runs) or `${parent}_fix_${n}` (fix iterations), so the
- * parent is the longest declared name `d` such that the dynamic name is
- * `${d}` or starts with `${d}_`.
+ * Map a dynamic phase name (e.g. "reviewer_fix_1", "reviewer_recheck_1") back
+ * to the declared phase it iterates on. The runner names loop iterations like
+ * `${parent}_recheck_${n}` (re-reviews) or `${parent}_fix_${n}` (fix
+ * iterations), so the parent is the longest declared name `d` such that the
+ * dynamic name is `${d}` or starts with `${d}_`.
  */
 function findParentDeclared(name: string, declared: string[]): string | null {
   let best: string | null = null;
@@ -132,8 +132,8 @@ interface Props {
  *
  * Phase visual states are derived from `run.phaseHistory` (completed) and
  * `run.currentPhase` (active). Phases that show up in history but aren't in
- * the definition (e.g. dynamically-named loop iterations like reviewer_2,
- * fix_loop_1) are appended after the definition's phases so they remain
+ * the definition (e.g. dynamically-named loop iterations like
+ * reviewer_recheck_1, reviewer_fix_1) are appended after the definition's phases so they remain
  * visible.
  */
 export function WorkflowPipeline({
@@ -154,7 +154,7 @@ export function WorkflowPipeline({
       historyMap.set(entry.phase, entry);
     }
 
-    // phase → most-recent-execution. Loop iterations (reviewer_2, etc.) get
+    // phase → most-recent-execution. Loop iterations (reviewer_recheck_1, etc.) get
     // their own keys here so each iteration is independently selectable.
     const execByPhase = new Map<string, WorkflowRunExecution>();
     for (const ex of executions ?? []) {
@@ -168,7 +168,7 @@ export function WorkflowPipeline({
     );
 
     // Dynamic phases that don't appear in the YAML — loop iterations like
-    // `reviewer_2` (re-runs) and `reviewer_fix_1` (fix attempts).
+    // `reviewer_recheck_1` (re-reviews) and `reviewer_fix_1` (fix attempts).
     const dynamicNames = Array.from(
       new Set([
         ...run.phaseHistory.map((e) => e.phase),

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,40 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This repo is **single-context**: one `CONTEXT.md` + `docs/adr/` at the repo root.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+> Note: the repo-root `CLAUDE.md` and `spec/README.md` are the day-to-day
+> orientation and rebuild-grade spec respectively. `CONTEXT.md` is narrower —
+> the project's **domain glossary** (ubiquitous language), seeded lazily as
+> terms get pinned down. It does not yet exist.
+
+## File structure
+
+```
+/
+├── CONTEXT.md          ← domain glossary (created lazily)
+├── docs/adr/           ← architectural decision records (created lazily)
+│   ├── 0001-....md
+│   └── 0002-....md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (...) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `cliftonc/lastlight`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,25 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+## Notes for this repo
+
+- All five labels exist in `cliftonc/lastlight`. `needs-info` and `wontfix`
+  predate this setup; `needs-triage`, `ready-for-agent`, and `ready-for-human`
+  were created during `/setup-matt-pocock-skills`.
+- The repo also carries a separate `needs-review` label (used for
+  design-heavy issues a human should look at before an agent grabs them, e.g.
+  the architecture-deepening backlog #93–#100). It is **not** one of the five
+  canonical triage roles — don't use it as the AFK-ready/human-ready signal.

--- a/spec/00-overview.md
+++ b/spec/00-overview.md
@@ -48,7 +48,7 @@ The terms used across this spec, in dependency order.
 - **Phase** — a single step in a Workflow. Either a `context` checkpoint
   (no agent invocation), an `agent` phase (one agent session), or a
   `loop` phase (an agent phase that iterates on reviewer feedback, e.g.
-  `reviewer_2`, `reviewer_fix_1`).
+  `reviewer_fix_1`, `reviewer_recheck_1`).
 - **Execution** — one agent session: a single phase running, or a single
   chat turn. One row in the `executions` table with tokens, cost, stop
   reason, and a pointer to the JSONL event log for that session.

--- a/spec/06-workflow-engine.md
+++ b/spec/06-workflow-engine.md
@@ -150,19 +150,25 @@ Two flavours.
       fix_variant: "{{variants.fix}}"
 ```
 
-Iteration naming (`runner.ts:282–284, 513`):
+Iteration naming — built by `PhaseRef.format()` and resolved by
+`phaseIndexInDefinition` (both in `src/workflows/phase-ref.ts`):
 
 ```
 reviewer                    ← first review
 reviewer_fix_1              ← fix cycle 1
-reviewer_2                  ← re-review after fix 1
+reviewer_recheck_1          ← re-review after fix 1
 reviewer_fix_2              ← fix cycle 2
-reviewer_3                  ← re-review after fix 2 (max_cycles)
+reviewer_recheck_2          ← re-review after fix 2 (max_cycles)
 ```
 
+`n` is the 1-based cycle; `fix_k` and `recheck_k` pair within a cycle. The
+legacy bare-numeric re-review form (`reviewer_2`) is dropped — neither
+produced nor recognized on resume.
+
 The runner parses the verdict line — `^\s*VERDICT:\s*(APPROVED|REQUEST_CHANGES)`
-— from the reviewer's output and either advances or enters the next
-fix cycle.
+— from the reviewer's output via the single pure parser
+`parseReviewerVerdict` (`src/workflows/verdict.ts`) and either advances or
+enters the next fix cycle.
 
 ### `generic_loop` — until-condition cycle
 

--- a/src/workflows/CLAUDE.md
+++ b/src/workflows/CLAUDE.md
@@ -13,8 +13,10 @@ should require **only a YAML file** in `workflows/`, no runner changes.
 | `loader.ts` | Reads `workflows/*.yaml`, validates against the schema, caches parsed definitions. `getWorkflow(name)` is the only lookup the rest of the code uses. |
 | `templates.ts` | Mustache-ish template engine. Handles `{{branch}}`, `{{issueDir}}`, `{{contextSnapshot}}`, `{{models.architect}}`, `{{phaseOutputs.guardrails.output}}`, list iteration, and `unless_*` clauses. |
 | `simple.ts` | Top-of-stack entry: `runSimpleWorkflow(workflowName, request, …)`. Picks the trigger id, builds the template context, creates or reuses a `workflow_runs` row, then calls `runWorkflow`. |
-| `runner.ts` | The actual executor — linear walk over `definition.phases`, dispatches to DAG runner when dependencies are declared, handles loops and approval gates. Contains `runPhase`, `runWorkflow`, `runDagWorkflow`, `nextPhaseAfter`, `isTerminated`. |
+| `runner.ts` | The actual executor — linear walk over `definition.phases`, dispatches to DAG runner when dependencies are declared, handles loops and approval gates. Contains `runPhase`, `runWorkflow`, `runDagWorkflow`, `isTerminated`. |
 | `dag.ts` | Pure graph logic: `buildDag`, `evaluateTriggerRule`, `getReadyNodes`, `topoSort`. No IO. `runDagWorkflow` in `runner.ts` uses it for dependency-aware scheduling. |
+| `phase-ref.ts` | `PhaseRef` value object — the single authority for building loop-iteration labels (`format()`) and resolving them back (`phaseIndexInDefinition`, exact-match first) — plus `nextPhaseAfter`. No IO. |
+| `verdict.ts` | `parseReviewerVerdict(output) → { verdict, viaFallback }` — the one pure parser for a reviewer phase's `VERDICT:` marker (with the fallback heuristic). Both runner verdict sites call it. |
 | `loop-eval.ts` | Expression evaluator for `generic_loop.until` conditions (`output.contains('PASS')`, `verdict == 'APPROVED'`). |
 | `resume.ts` | Startup orphan recovery + approval-gate resume entry point. Called both on harness boot (recover `running` / `paused` runs) and when a user responds to an approval gate. |
 
@@ -181,16 +183,26 @@ rely on predictable phase names for dynamically-created iterations.
 First reviewer pass       → reviewer
   approves                → workflow continues
   requests changes
-    Fix cycle 1           → reviewer_fix_1   (runs the executor with fix_prompt)
-    Re-review             → reviewer_2       (runs reviewer again)
+    Fix cycle 1           → reviewer_fix_1       (runs the executor with fix_prompt)
+    Re-review (cycle 1)   → reviewer_recheck_1   (runs reviewer again)
     …
     Fix cycle 2           → reviewer_fix_2
-    Re-review             → reviewer_3
+    Re-review (cycle 2)   → reviewer_recheck_2
 ```
 
-General rule: `${parentPhaseName}` for the first run, `${parentPhaseName}_${n+1}`
-for the nth re-run, `${parentPhaseName}_fix_${n}` for the nth fix cycle.
-Generic loops use `${parentPhaseName}_iter_${iteration}`.
+All generated labels are built by `PhaseRef.format()` (`phase-ref.ts`) — the
+single authority — and resolved back via `phaseIndexInDefinition` (exact-match
+first). `n` is the 1-based **cycle**; `fix_k` and `recheck_k` pair within a
+cycle:
+
+- `${parentPhaseName}` — the initial run
+- `${parentPhaseName}_fix_${n}` — the nth fix cycle
+- `${parentPhaseName}_recheck_${n}` — the nth re-review
+- `${parentPhaseName}_iter_${n}` — generic-loop iteration n
+
+The legacy bare-numeric re-review form (`reviewer_2`) is **dropped** — it was
+untagged, ambiguous with literal phase names, and inconsistent with the
+`_fix_`/`_iter_` tags. It is neither produced nor recognized on resume.
 
 The dashboard's `WorkflowPipeline.tsx` uses a longest-prefix match to
 group these under the declared parent (`reviewer_fix_1` → belongs to

--- a/src/workflows/phase-ref.test.ts
+++ b/src/workflows/phase-ref.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { PhaseRef, phaseIndexInDefinition, nextPhaseAfter } from "./phase-ref.js";
+import type { AgentWorkflowDefinition } from "./schema.js";
+
+const def = (...names: string[]): AgentWorkflowDefinition =>
+  ({ phases: names.map((name) => ({ name })) }) as AgentWorkflowDefinition;
+
+describe("PhaseRef.format — the single label authority", () => {
+  it("pins the literal generated label strings", () => {
+    expect(PhaseRef.review("reviewer").format()).toBe("reviewer");
+    expect(PhaseRef.fix("reviewer", 1).format()).toBe("reviewer_fix_1");
+    expect(PhaseRef.recheck("reviewer", 1).format()).toBe("reviewer_recheck_1");
+    expect(PhaseRef.iter("reviewer", 1).format()).toBe("reviewer_iter_1");
+  });
+});
+
+describe("phaseIndexInDefinition — definition-aware resolution", () => {
+  const definition = def("architect", "executor", "reviewer", "pr");
+
+  it("round-trips every generated label back to its base phase", () => {
+    for (const ref of [
+      PhaseRef.review("reviewer"),
+      PhaseRef.fix("reviewer", 2),
+      PhaseRef.recheck("reviewer", 2),
+      PhaseRef.iter("reviewer", 3),
+    ]) {
+      expect(phaseIndexInDefinition(definition, ref.format())).toBe(2);
+    }
+  });
+
+  it("prefers an exact literal phase name over suffix-stripping", () => {
+    const literal = def("reviewer", "reviewer_fix_1");
+    expect(phaseIndexInDefinition(literal, "reviewer_fix_1")).toBe(1);
+  });
+
+  it("resolves the dropped legacy reviewer_2 form to -1", () => {
+    expect(phaseIndexInDefinition(definition, "reviewer_2")).toBe(-1);
+  });
+
+  it("returns -1 for unknown / untracked labels", () => {
+    expect(phaseIndexInDefinition(definition, "waiting_approval")).toBe(-1);
+  });
+});
+
+describe("nextPhaseAfter", () => {
+  const definition = def("architect", "executor", "reviewer", "pr");
+
+  it("steps to the next declared phase, even from a generated label", () => {
+    expect(nextPhaseAfter(definition, "reviewer_recheck_1")).toBe("pr");
+  });
+
+  it("returns null at the end of the workflow", () => {
+    expect(nextPhaseAfter(definition, "pr")).toBeNull();
+  });
+});

--- a/src/workflows/phase-ref.ts
+++ b/src/workflows/phase-ref.ts
@@ -1,0 +1,120 @@
+/**
+ * The single authority for building and resolving the phase labels the runner
+ * generates for loop iterations.
+ *
+ * A workflow phase named in the YAML (e.g. `reviewer`) keeps that bare name for
+ * its initial run. When a reviewer loop fixes-and-rechecks, or a generic loop
+ * iterates, the runner mints a derived label. `PhaseRef.format()` is the ONLY
+ * place those derived strings are constructed, and `phaseIndexInDefinition`
+ * resolves them back to the declared phase.
+ *
+ * Scheme (post-#93):
+ *
+ *   initial review            → reviewer
+ *   cycle n fix               → reviewer_fix_n
+ *   cycle n re-review         → reviewer_recheck_n
+ *   generic-loop iteration n  → reviewer_iter_n
+ *
+ * `n` is the 1-based cycle; `fix_k` and `recheck_k` pair within a cycle. The
+ * legacy bare-numeric re-review form (`reviewer_2`) is dropped entirely — it is
+ * neither produced nor recognized.
+ */
+
+import type { AgentWorkflowDefinition } from "./schema.js";
+
+export type PhaseKind = "phase" | "fix" | "recheck" | "iter";
+
+export class PhaseRef {
+  constructor(
+    readonly base: string,
+    readonly kind: PhaseKind = "phase",
+    readonly index?: number,
+  ) {}
+
+  /** The declared phase, run as-is (no derived suffix). */
+  static review(base: string): PhaseRef {
+    return new PhaseRef(base, "phase");
+  }
+
+  /** The executor fix run for cycle `n`. */
+  static fix(base: string, n: number): PhaseRef {
+    return new PhaseRef(base, "fix", n);
+  }
+
+  /** The reviewer re-review run for cycle `n`. */
+  static recheck(base: string, n: number): PhaseRef {
+    return new PhaseRef(base, "recheck", n);
+  }
+
+  /** The generic-loop iteration `n`. */
+  static iter(base: string, n: number): PhaseRef {
+    return new PhaseRef(base, "iter", n);
+  }
+
+  format(): string {
+    switch (this.kind) {
+      case "phase":
+        return this.base;
+      case "fix":
+        return `${this.base}_fix_${this.index}`;
+      case "recheck":
+        return `${this.base}_recheck_${this.index}`;
+      case "iter":
+        return `${this.base}_iter_${this.index}`;
+    }
+  }
+
+  /**
+   * Parse a label back into a PhaseRef. Recognizes only the generated
+   * `_fix_N` / `_recheck_N` / `_iter_N` suffixes; anything else (including a
+   * bare declared name or the dropped legacy `_N` form) parses as a plain
+   * `phase` whose base is the whole string.
+   */
+  static parse(label: string): PhaseRef {
+    let m = label.match(/^(.*)_fix_(\d+)$/);
+    if (m) return new PhaseRef(m[1], "fix", Number(m[2]));
+    m = label.match(/^(.*)_recheck_(\d+)$/);
+    if (m) return new PhaseRef(m[1], "recheck", Number(m[2]));
+    m = label.match(/^(.*)_iter_(\d+)$/);
+    if (m) return new PhaseRef(m[1], "iter", Number(m[2]));
+    return new PhaseRef(label, "phase");
+  }
+}
+
+/**
+ * Resolve a recorded phase name to its index in `definition.phases`.
+ *
+ * Definition-aware and **exact-match-first**: a phase literally named like a
+ * generated label (e.g. a YAML phase actually called `reviewer_fix_1`) wins
+ * over suffix-stripping. Only when no exact match exists do we strip a
+ * generated suffix and resolve to the base phase.
+ *
+ * Returns -1 when the name doesn't match any phase — unknown/untracked labels
+ * (`waiting_approval`, user `set_phase` values like `complete`) and the dropped
+ * legacy `reviewer_2` form all land here.
+ */
+export function phaseIndexInDefinition(
+  definition: AgentWorkflowDefinition,
+  name: string,
+): number {
+  const exact = definition.phases.findIndex((p) => p.name === name);
+  if (exact >= 0) return exact;
+
+  const ref = PhaseRef.parse(name);
+  if (ref.kind === "phase") return -1;
+  return definition.phases.findIndex((p) => p.name === ref.base);
+}
+
+/**
+ * Given the phase the runner last completed, return the name of the phase the
+ * runner should run next. Returns `null` when there is no next phase (i.e. the
+ * workflow is done).
+ */
+export function nextPhaseAfter(
+  definition: AgentWorkflowDefinition,
+  completedPhase: string,
+): string | null {
+  const idx = phaseIndexInDefinition(definition, completedPhase);
+  if (idx < 0 || idx >= definition.phases.length - 1) return null;
+  return definition.phases[idx + 1].name;
+}

--- a/src/workflows/runner.ts
+++ b/src/workflows/runner.ts
@@ -17,6 +17,8 @@ import { phaseSkillNames } from "./schema.js";
 import { loadPromptTemplate, resolveSkillPaths } from "./loader.js";
 import { renderTemplate, type TemplateContext } from "./templates.js";
 import { evalUntilExpression } from "./loop-eval.js";
+import { parseReviewerVerdict } from "./verdict.js";
+import { PhaseRef, phaseIndexInDefinition, nextPhaseAfter } from "./phase-ref.js";
 import { buildDag, getReadyNodes, getNodesToSkip, isComplete } from "./dag.js";
 import type { ProgressReporter, StepStatus, ProgressStep } from "../notify/types.js";
 import { recordError, recordExecutionMetrics, withSpan } from "../telemetry/index.js";
@@ -370,56 +372,6 @@ async function runPhase(
   });
 }
 
-// ── Resume logic ─────────────────────────────────────────────────────────────
-
-/**
- * Resolve a recorded phase name to its index in `definition.phases`.
- * Handles the generated iteration labels the runner writes for looping phases:
- *
- *   `${phase}_iter_${n}` — generic_loop iteration
- *   `${phase}_fix_${n}`  — reviewer-style loop fix cycle
- *   `${phase}_${n}`      — reviewer-style loop re-review cycle
- *
- * Returns -1 when the name doesn't match any phase (unknown/untracked labels
- * like `waiting_approval` or user set_phase values such as `complete`).
- */
-export function phaseIndexInDefinition(
-  definition: AgentWorkflowDefinition,
-  name: string,
-): number {
-  const exact = definition.phases.findIndex((p) => p.name === name);
-  if (exact >= 0) return exact;
-
-  const tryStrip = (re: RegExp): number => {
-    const m = name.match(re);
-    if (!m) return -1;
-    return definition.phases.findIndex((p) => p.name === m[1]);
-  };
-
-  const iterIdx = tryStrip(/^(.*)_iter_\d+$/);
-  if (iterIdx >= 0) return iterIdx;
-  const fixIdx = tryStrip(/^(.*)_fix_\d+$/);
-  if (fixIdx >= 0) return fixIdx;
-  const cycleIdx = tryStrip(/^(.*)_\d+$/);
-  if (cycleIdx >= 0) return cycleIdx;
-
-  return -1;
-}
-
-/**
- * Given the phase the runner last completed, return the name of the phase the
- * runner should run next. Returns `null` when there is no next phase (i.e. the
- * workflow is done).
- */
-export function nextPhaseAfter(
-  definition: AgentWorkflowDefinition,
-  completedPhase: string,
-): string | null {
-  const idx = phaseIndexInDefinition(definition, completedPhase);
-  if (idx < 0 || idx >= definition.phases.length - 1) return null;
-  return definition.phases[idx + 1].name;
-}
-
 // ── Main workflow runner ─────────────────────────────────────────────────────
 
 /** Returns true if any phase declares explicit dependencies — triggers DAG execution path. */
@@ -658,7 +610,10 @@ export async function runWorkflow(
       }
 
       while (!approved && fixCycles <= MAX_CYCLES) {
-        const reviewLabel = fixCycles === 0 ? phaseName : `${phaseName}_${fixCycles + 1}`;
+        const reviewLabel =
+          fixCycles === 0
+            ? PhaseRef.review(phaseName).format()
+            : PhaseRef.recheck(phaseName, fixCycles).format();
 
         if (!shouldRun(phaseName) && fixCycles === 0) {
           approved = true;
@@ -721,16 +676,9 @@ export async function runWorkflow(
 
         // Parse verdict
         const reviewerOutput = (rr.result.output || "").trim();
-        const verdictMarker = reviewerOutput.match(
-          /^\s*VERDICT:\s*(APPROVED|REQUEST_CHANGES)\s*$/im,
-        );
-        let isApproved: boolean;
-        if (verdictMarker) {
-          isApproved = verdictMarker[1].toUpperCase() === "APPROVED";
-        } else {
-          const upper = reviewerOutput.toUpperCase();
-          const hasRequestChanges = /\bREQUEST_CHANGES\b/.test(upper);
-          isApproved = !hasRequestChanges && /^APPROVED\b/.test(upper);
+        const { verdict, viaFallback } = parseReviewerVerdict(reviewerOutput);
+        const isApproved = verdict === "APPROVED";
+        if (viaFallback) {
           console.warn(
             `[runner] Reviewer output missing VERDICT: marker — using fallback detection (isApproved=${isApproved})`,
           );
@@ -782,7 +730,7 @@ export async function runWorkflow(
           });
 
           // Run fix phase
-          const fixLabel = `${phaseName}_fix_${fixCycles}`;
+          const fixLabel = PhaseRef.fix(phaseName, fixCycles).format();
           await onStart(fixLabel);
           await reportStep(
             fixLabel,
@@ -897,7 +845,7 @@ export async function runWorkflow(
 
       while (!complete && iteration < MAX_ITER) {
         iteration++;
-        const iterLabel = `${phaseName}_iter_${iteration}`;
+        const iterLabel = PhaseRef.iter(phaseName, iteration).format();
 
         await onStart(iterLabel);
 
@@ -1038,7 +986,7 @@ export async function runWorkflow(
           db.createApproval({
             id: approvalId,
             workflowRunId: workflowId,
-            gate: `${phaseName}_iter_${iteration}`,
+            gate: iterLabel,
             summary: gateMsg,
             kind: isReply ? "reply" : "approve",
             requestedBy: ctx.sender,
@@ -1048,7 +996,7 @@ export async function runWorkflow(
             phase: "waiting_approval",
             timestamp: new Date().toISOString(),
             success: true,
-            summary: `Waiting for ${isReply ? "reply" : "approval"}: ${phaseName}_iter_${iteration} (${approvalId})`,
+            summary: `Waiting for ${isReply ? "reply" : "approval"}: ${iterLabel} (${approvalId})`,
           });
           db.pauseWorkflowRun(workflowId);
           await reportStep(phaseName, "awaiting");
@@ -1488,7 +1436,10 @@ async function runDagWorkflow(
         let fixCycles = 0;
 
         while (!approved && fixCycles <= MAX_CYCLES) {
-          const reviewLabel = fixCycles === 0 ? node.name : `${node.name}_${fixCycles + 1}`;
+          const reviewLabel =
+            fixCycles === 0
+              ? PhaseRef.review(node.name).format()
+              : PhaseRef.recheck(node.name, fixCycles).format();
           const reviewPrompt =
             fixCycles === 0
               ? buildPhasePrompt(phase, ctx, { phaseOutputs: { ...outputs }, fixCycle: fixCycles })
@@ -1521,16 +1472,19 @@ async function runDagWorkflow(
           await onEnd(reviewLabel, phases[phases.length - 1]);
 
           const reviewerOutput = (rr.result.output || "").trim();
-          const verdictMarker = reviewerOutput.match(/^\s*VERDICT:\s*(APPROVED|REQUEST_CHANGES)\s*$/im);
-          const isApproved = verdictMarker
-            ? verdictMarker[1].toUpperCase() === "APPROVED"
-            : !(/\bREQUEST_CHANGES\b/.test(reviewerOutput.toUpperCase())) && /^APPROVED\b/.test(reviewerOutput.toUpperCase());
+          const { verdict, viaFallback } = parseReviewerVerdict(reviewerOutput);
+          const isApproved = verdict === "APPROVED";
+          if (viaFallback) {
+            console.warn(
+              `[runner] Reviewer output missing VERDICT: marker — using fallback detection (isApproved=${isApproved})`,
+            );
+          }
 
           if (isApproved) {
             approved = true;
           } else if (fixCycles < MAX_CYCLES) {
             fixCycles++;
-            const fixLabel = `${node.name}_fix_${fixCycles}`;
+            const fixLabel = PhaseRef.fix(node.name, fixCycles).format();
             const fixPromptRendered = renderPrompt(loop.on_request_changes.fix_prompt, { phaseOutputs: { ...outputs }, fixCycle: fixCycles });
             const fixModelRaw = loop.on_request_changes.fix_model ? renderTemplate(loop.on_request_changes.fix_model, ctx) : undefined;
             const fixModel = fixModelRaw || modelFor(`${node.name}_fix`) || modelFor(node.name);
@@ -1576,7 +1530,7 @@ async function runDagWorkflow(
 
         while (!complete && iteration < MAX_ITER) {
           iteration++;
-          const iterLabel = `${node.name}_iter_${iteration}`;
+          const iterLabel = PhaseRef.iter(node.name, iteration).format();
           const iterCtx: Partial<TemplateContext> = {
             iteration,
             maxIterations: MAX_ITER,

--- a/src/workflows/simple.ts
+++ b/src/workflows/simple.ts
@@ -5,11 +5,11 @@ import type { ModelConfig, VariantConfig } from "../config.js";
 import { getWorkflow } from "./loader.js";
 import {
   runWorkflow,
-  nextPhaseAfter,
   type ApprovalGateConfig,
   type RunnerCallbacks,
   type WorkflowResult,
 } from "./runner.js";
+import { nextPhaseAfter } from "./phase-ref.js";
 import type { TemplateContext } from "./templates.js";
 import { slugify } from "./templates.js";
 import { wrapUntrusted } from "../engine/screen.js";

--- a/src/workflows/verdict.test.ts
+++ b/src/workflows/verdict.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { parseReviewerVerdict } from "./verdict.js";
+
+describe("parseReviewerVerdict — explicit VERDICT: marker", () => {
+  it("reads VERDICT: APPROVED with no fallback", () => {
+    expect(parseReviewerVerdict("VERDICT: APPROVED\nLooks great!")).toEqual({
+      verdict: "APPROVED",
+      viaFallback: false,
+    });
+  });
+
+  it("reads VERDICT: REQUEST_CHANGES with no fallback", () => {
+    expect(parseReviewerVerdict("VERDICT: REQUEST_CHANGES\nFix the bug")).toEqual({
+      verdict: "REQUEST_CHANGES",
+      viaFallback: false,
+    });
+  });
+
+  it("matches a case-insensitive marker on a non-first line (/im)", () => {
+    const output = "Here is my review.\n\nverdict: approved\n";
+    expect(parseReviewerVerdict(output)).toEqual({
+      verdict: "APPROVED",
+      viaFallback: false,
+    });
+  });
+});
+
+describe("parseReviewerVerdict — fallback (no VERDICT: marker)", () => {
+  it("approves when output starts with APPROVED and never says REQUEST_CHANGES", () => {
+    expect(parseReviewerVerdict("APPROVED — ship it")).toEqual({
+      verdict: "APPROVED",
+      viaFallback: true,
+    });
+  });
+
+  it("requests changes when output mentions REQUEST_CHANGES", () => {
+    expect(parseReviewerVerdict("I think this needs work: REQUEST_CHANGES")).toEqual({
+      verdict: "REQUEST_CHANGES",
+      viaFallback: true,
+    });
+  });
+
+  it("treats ambiguous output as not approved", () => {
+    expect(parseReviewerVerdict("This looks mostly fine but I'm unsure.")).toEqual({
+      verdict: "REQUEST_CHANGES",
+      viaFallback: true,
+    });
+  });
+});

--- a/src/workflows/verdict.ts
+++ b/src/workflows/verdict.ts
@@ -1,0 +1,38 @@
+/**
+ * The single parser for a reviewer phase's verdict.
+ *
+ * A reviewer agent is asked to end its output with a `VERDICT:` marker line —
+ * either `VERDICT: APPROVED` or `VERDICT: REQUEST_CHANGES`. When that marker is
+ * present we trust it. When it's absent we fall back to a fragile heuristic
+ * (preserved here exactly as both runner sites had it): treat the output as
+ * approved only when it does NOT mention `REQUEST_CHANGES` and DOES start with
+ * `APPROVED`. `viaFallback` lets callers warn when the marker was missing.
+ *
+ * Hardening the fallback is deliberately out of scope — this parser is
+ * behaviour-neutral on verdict semantics.
+ */
+
+export type ReviewerVerdict = "APPROVED" | "REQUEST_CHANGES";
+
+export interface ParsedVerdict {
+  verdict: ReviewerVerdict;
+  viaFallback: boolean;
+}
+
+export function parseReviewerVerdict(output: string): ParsedVerdict {
+  const marker = output.match(/^\s*VERDICT:\s*(APPROVED|REQUEST_CHANGES)\s*$/im);
+  if (marker) {
+    return {
+      verdict: marker[1].toUpperCase() === "APPROVED" ? "APPROVED" : "REQUEST_CHANGES",
+      viaFallback: false,
+    };
+  }
+
+  const upper = output.toUpperCase();
+  const hasRequestChanges = /\bREQUEST_CHANGES\b/.test(upper);
+  const isApproved = !hasRequestChanges && /^APPROVED\b/.test(upper);
+  return {
+    verdict: isApproved ? "APPROVED" : "REQUEST_CHANGES",
+    viaFallback: true,
+  };
+}


### PR DESCRIPTION
Closes #93.

A behavior-neutral prefactor for the workflow runner that removes two pieces of duplicated machinery and makes loop-iteration phase names logically consistent, so the larger linear/DAG unification (#94) becomes a pure control-flow change. Centralized across **both** the linear and DAG paths. Built test-first.

## 1. One reviewer-verdict parser

`src/workflows/verdict.ts` — `parseReviewerVerdict(output) → { verdict, viaFallback }`, the single pure parser used by both verdict sites. Behavior is preserved **exactly**, including the current fragile fallback (`!REQUEST_CHANGES && /^APPROVED\b/` when no `VERDICT:` marker); hardening it is out of scope.

- The **DAG path now emits the fallback `console.warn`** it previously lacked (the two copies had drifted on exactly this).

## 2. Typed `PhaseRef` for consistent iteration naming

`src/workflows/phase-ref.ts` — a `PhaseRef` value object (`{ base, kind: 'phase'|'fix'|'recheck'|'iter', index? }`) whose `format()` is the **single authority** for building generated labels. `phaseIndexInDefinition` (exact-match-first) + `nextPhaseAfter` moved here; the one `simple.ts` import updated.

New, consistent scheme — a deliberate **rename, NOT backward-compatible**:

| Step | Label |
| --- | --- |
| initial review | `reviewer` |
| cycle 1 fix | `reviewer_fix_1` |
| cycle 1 re-review | `reviewer_recheck_1` |
| cycle 2 fix | `reviewer_fix_2` |
| cycle 2 re-review | `reviewer_recheck_2` |
| generic-loop iteration n | `reviewer_iter_n` |

The old bare-`_N` re-review form (`reviewer_2`) is **dropped entirely** — neither produced nor recognized. Resolution stays definition-aware with exact-match-first (a phase literally named like a generated label still wins).

> ⚠️ **Deploy caveat:** a run that *crashed mid-reviewer-loop* (after a re-review) **before** this lands may not auto-resume via `resumeOrphanedWorkflows` — re-trigger it manually (rare). Graceful approval-gate pauses are unaffected. Consider draining in-flight loop runs before deploying.

## Acceptance criteria

- [x] `parseReviewerVerdict` pure, returning `{ verdict, viaFallback }`, with the full unit-test matrix (explicit APPROVED/REQUEST_CHANGES, case-insensitive `/im` non-first-line marker, fallback approved/request-changes/ambiguous, `viaFallback` per case).
- [x] Both runner verdict sites call it and warn on `viaFallback` — no second regex copy; DAG path now warns.
- [x] `PhaseRef.format()` is the only label-construction site; pin-table test asserts the literal new strings.
- [x] `phaseIndexInDefinition` keeps exact-match-first; tests cover round-trip, literal-name-wins, and `reviewer_2 → -1`.
- [x] `phaseIndexInDefinition` + `nextPhaseAfter` live in `phase-ref.ts`; `simple.ts` import updated.
- [x] Existing `runner.test.ts` / `dag.test.ts` pass; `npx vitest run src/workflows/` green (174 passed, 1 todo).
- [x] Loop-naming docs (`src/workflows/CLAUDE.md`, `CLAUDE.md`) + dashboard comments (`WorkflowPipeline.tsx`, `WorkflowList.tsx`, `PhaseDetailPanel.tsx`) updated to the `recheck` scheme.

## Verification

- `npx vitest run src/workflows/` → **174 passed**, 1 todo
- server `tsc --noEmit` → clean
- dashboard `tsc -b` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)