### PR TITLE
refactor(runner): unify linear + DAG runner behind one phase scheduler (#94)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -944,28 +944,10 @@ async function main() {
         socratic: { ...prevSocratic, qa: qaList },
       });
 
-      // Set currentPhase to the phase BEFORE the loop owner so the
-      // runner's nextPhaseAfter lands back on the loop phase for the
-      // next iteration. Walk the workflow definition to find it.
-      try {
-        const { getWorkflow } = await import("./workflows/loader.js");
-        const def = getWorkflow(run.workflowName);
-        // Find the phase that owns this gate (pattern: socratic_iter_N)
-        const gateParts = pending.gate.match(/^(.+)_iter_\d+$/);
-        const owningPhaseName = gateParts ? gateParts[1] : null;
-        if (owningPhaseName) {
-          const ownIdx = def.phases.findIndex((p) => p.name === owningPhaseName);
-          const priorPhase = ownIdx > 0 ? def.phases[ownIdx - 1].name : owningPhaseName;
-          db.updateWorkflowPhase(workflowRunId, priorPhase, {
-            phase: priorPhase,
-            timestamp: new Date().toISOString(),
-            success: true,
-            summary: `Resumed after reply on gate: ${pending.gate}`,
-          });
-        }
-      } catch (err) {
-        console.warn(`[event] explore-reply: could not resolve owning phase:`, err);
-      }
+      // Resume is ledger-driven: the runner re-runs from the top, completed
+      // phases skip via shouldRunPhase, and the generic-loop node picks up
+      // from `scratch.iteration` (persisted when it paused). No currentPhase
+      // manipulation is needed.
       db.resumeWorkflowRun(workflowRunId);
 
       // Re-dispatch. Use channelId/threadId from the current event context

--- a/src/state/db.test.ts
+++ b/src/state/db.test.ts
@@ -126,6 +126,36 @@ describe("workflow_runs CRUD", () => {
   });
 });
 
+describe("node_statuses store removed (issue #94)", () => {
+  it("no longer exposes updateNodeStatus and getWorkflowRun has no nodeStatuses", () => {
+    const id = randomUUID();
+    db.createWorkflowRun({
+      id,
+      workflowName: "build",
+      triggerId: "owner/repo#77",
+      currentPhase: "phase_0",
+      status: "running",
+      startedAt: new Date().toISOString(),
+    });
+    expect((db as unknown as Record<string, unknown>).updateNodeStatus).toBeUndefined();
+    const run = db.getWorkflowRun(id);
+    expect(run).not.toBeNull();
+    expect((run as unknown as Record<string, unknown>).nodeStatuses).toBeUndefined();
+  });
+});
+
+describe("recordSkippedPhase — skips land in the executions ledger", () => {
+  it("writes a finished, non-successful skip row that shouldRunPhase re-evaluates", () => {
+    const skill = "build:merge";
+    const triggerId = "owner/repo#88";
+    db.recordSkippedPhase(skill, triggerId, "wf-skip-1", "repo");
+
+    // Not "done" (success != 1) and not "running" (finished_at set) — so a
+    // resume re-evaluates the node (it'll simply be re-skipped if still gated).
+    expect(db.shouldRunPhase(skill, triggerId, "wf-skip-1")).toBe("run");
+  });
+});
+
 describe("getWorkflowRunByTrigger", () => {
   it("returns the active run for a trigger", () => {
     const id = randomUUID();

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -333,6 +333,25 @@ export class StateDb {
     return row?.output_text ?? null;
   }
 
+  /**
+   * Most recent finished execution's `output_text` for a phase (`skill`), or
+   * null. Used by the reviewer loop on resume to re-derive a completed review's
+   * verdict from its persisted output (a dedup-`done` review must not be
+   * assumed APPROVED — it may have requested changes).
+   */
+  getPhaseOutput(skill: string, triggerId: string, workflowRunId?: string): string | null {
+    const [scopeClause, scopeParam] = workflowRunId
+      ? ["workflow_run_id = ?", workflowRunId]
+      : ["trigger_id = ?", triggerId];
+    const row = this.db.prepare(`
+      SELECT output_text FROM executions
+      WHERE skill = ? AND ${scopeClause} AND output_text IS NOT NULL
+      ORDER BY finished_at DESC
+      LIMIT 1
+    `).get(skill, scopeParam) as { output_text: string | null } | undefined;
+    return row?.output_text ?? null;
+  }
+
   recordFinish(
     id: string,
     result: {

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 import { resolve } from "path";
+import { randomUUID } from "crypto";
 
 const DEFAULT_DB_PATH = "lastlight.db";
 
@@ -46,7 +47,6 @@ export interface WorkflowRun {
    * loop to accumulate Q&A across reply-gate pauses.
    */
   scratch?: Record<string, unknown>;
-  nodeStatuses?: Record<string, "pending" | "running" | "succeeded" | "failed" | "skipped">;
   /**
    * Number of times `resumeOrphanedWorkflows` has re-dispatched this run
    * after a harness restart. Bounded by a small limit so a run that
@@ -212,13 +212,6 @@ export class StateDb {
       CREATE INDEX IF NOT EXISTS idx_approvals_workflow ON workflow_approvals(workflow_run_id);
       CREATE INDEX IF NOT EXISTS idx_approvals_status ON workflow_approvals(status);
     `);
-
-    // Add node_statuses column for DAG parallelism (safe for existing DBs)
-    try {
-      this.db.exec(`ALTER TABLE workflow_runs ADD COLUMN node_statuses TEXT`);
-    } catch {
-      // Column already exists — ignore
-    }
 
     // Mutable phase-to-phase state for features like the socratic explore
     // loop that accumulate data across reply-gate pauses.
@@ -392,6 +385,40 @@ export class StateDb {
       result.stopReason ?? null,
       result.extensionStatus ?? null,
       id,
+    );
+  }
+
+  /**
+   * Record a phase that the scheduler skipped because its trigger rule was
+   * not satisfied (a failed/skipped upstream cascaded down a chain). The
+   * executions ledger is the single source of truth the dashboard derives
+   * phase status from, so skips are written here too — as a finished,
+   * non-successful row (`success = 0`, `stop_reason = 'skipped'`). Because it
+   * is not `success = 1`, `shouldRunPhase` re-evaluates it on resume (the node
+   * will simply be re-skipped if the upstream is still failed).
+   */
+  recordSkippedPhase(
+    skill: string,
+    triggerId: string,
+    workflowRunId?: string,
+    repo?: string,
+  ): void {
+    const now = new Date().toISOString();
+    const m = triggerId.match(/#(\d+)$/);
+    const issueNumber = m ? Number(m[1]) : null;
+    this.db.prepare(`
+      INSERT INTO executions
+        (id, trigger_type, trigger_id, skill, repo, issue_number, started_at, finished_at, success, error, stop_reason, workflow_run_id)
+      VALUES (?, 'webhook', ?, ?, ?, ?, ?, ?, 0, 'skipped: trigger rule not satisfied', 'skipped', ?)
+    `).run(
+      randomUUID(),
+      triggerId,
+      skill,
+      repo ?? null,
+      issueNumber,
+      now,
+      now,
+      workflowRunId ?? null,
     );
   }
 
@@ -1036,8 +1063,8 @@ export class StateDb {
         .get(...params) as { c: number }
     ).c;
 
-    // Explicit column list — the heavy JSON blobs (`context`, `scratch`,
-    // `node_statuses`) can each be many MB on long-running build runs and
+    // Explicit column list — the heavy JSON blobs (`context`, `scratch`)
+    // can each be many MB on long-running build runs and
     // the dashboard list view doesn't read them. Returning them turned a
     // 20-row page into a 14MB payload. The single-row endpoint
     // (`getWorkflowRun`) still uses `SELECT *` so the detail panel keeps
@@ -1216,20 +1243,6 @@ export class StateDb {
     `).run(status, respondedBy, response ?? null, now, id);
   }
 
-  /** Update a single node's status in the workflow run's nodeStatuses map. */
-  updateNodeStatus(
-    workflowId: string,
-    nodeName: string,
-    status: "pending" | "running" | "succeeded" | "failed" | "skipped",
-  ): void {
-    const now = new Date().toISOString();
-    const row = this.db.prepare(`SELECT node_statuses FROM workflow_runs WHERE id = ?`).get(workflowId) as { node_statuses: string | null } | undefined;
-    if (!row) return;
-    const statuses = row.node_statuses ? JSON.parse(row.node_statuses) as Record<string, string> : {};
-    statuses[nodeName] = status;
-    this.db.prepare(`UPDATE workflow_runs SET node_statuses = ?, updated_at = ? WHERE id = ?`).run(JSON.stringify(statuses), now, workflowId);
-  }
-
   // ── Cron overrides ─────────────────────────────────────────────
 
   /** Get the override row for a single cron, or null if none. */
@@ -1378,7 +1391,6 @@ export class StateDb {
       status: row.status as WorkflowRun["status"],
       context: row.context ? JSON.parse(row.context as string) as Record<string, unknown> : undefined,
       scratch: row.scratch ? JSON.parse(row.scratch as string) as Record<string, unknown> : undefined,
-      nodeStatuses: row.node_statuses ? JSON.parse(row.node_statuses as string) as Record<string, "pending" | "running" | "succeeded" | "failed" | "skipped"> : undefined,
       restartCount: typeof row.restart_count === "number" ? row.restart_count : 0,
       startedAt: row.started_at as string,
       updatedAt: row.updated_at as string,

--- a/src/workflows/CLAUDE.md
+++ b/src/workflows/CLAUDE.md
@@ -13,9 +13,10 @@ should require **only a YAML file** in `workflows/`, no runner changes.
 | `loader.ts` | Reads `workflows/*.yaml`, validates against the schema, caches parsed definitions. `getWorkflow(name)` is the only lookup the rest of the code uses. |
 | `templates.ts` | Mustache-ish template engine. Handles `{{branch}}`, `{{issueDir}}`, `{{contextSnapshot}}`, `{{models.architect}}`, `{{phaseOutputs.guardrails.output}}`, list iteration, and `unless_*` clauses. |
 | `simple.ts` | Top-of-stack entry: `runSimpleWorkflow(workflowName, request, …)`. Picks the trigger id, builds the template context, creates or reuses a `workflow_runs` row, then calls `runWorkflow`. |
-| `runner.ts` | The actual executor — linear walk over `definition.phases`, dispatches to DAG runner when dependencies are declared, handles loops and approval gates. Contains `runPhase`, `runWorkflow`, `runDagWorkflow`, `isTerminated`. |
-| `dag.ts` | Pure graph logic: `buildDag`, `evaluateTriggerRule`, `getReadyNodes`, `topoSort`. No IO. `runDagWorkflow` in `runner.ts` uses it for dependency-aware scheduling. |
-| `phase-ref.ts` | `PhaseRef` value object — the single authority for building loop-iteration labels (`format()`) and resolving them back (`phaseIndexInDefinition`, exact-match first) — plus `nextPhaseAfter`. No IO. |
+| `runner.ts` | The **scheduler**. One sequential walk over a chain-synthesized DAG — no separate linear/DAG paths. Owns the `phases[]`/`outputs{}` accumulation, node status, cancel/skip handling, and the terminal `set_phase`/PR wrap-up. Delegates each node's body to `PhaseExecutor`. Also: `gitAccessProfileForWorkflow`, `gitSandboxAccessForWorkflow`. Re-exports `isTerminated`. |
+| `phase-executor.ts` | `PhaseExecutor` — owns every per-phase body (context / standard agent / reviewer-loop / generic-loop, plus approval & reply gates) behind `execute(node, outputs) → PhaseOutcome`. Constructed once per run from three collaborators: run-scoped data, a `PhaseReporter`, a `PhaseResolver`. Also home to `runPhase`, `buildPhasePrompt`, `phaseConfigFor`, `isTerminated`. Unit-tested with fakes (`phase-executor.test.ts`). |
+| `dag.ts` | Pure graph logic: `buildDag(phases, { chainIfNoDeps })`, `evaluateTriggerRule`, `getReadyNodes`, `getNodesToSkip`, `isComplete`, `topoSort`. No IO. `chainIfNoDeps` synthesizes a previous-phase chain when no phase declares `depends_on`. |
+| `phase-ref.ts` | `PhaseRef` value object — the single authority for building loop-iteration labels (`format()`) and parsing them back (`parse()` → base + kind). No IO. |
 | `verdict.ts` | `parseReviewerVerdict(output) → { verdict, viaFallback }` — the one pure parser for a reviewer phase's `VERDICT:` marker (with the fallback heuristic). Both runner verdict sites call it. |
 | `loop-eval.ts` | Expression evaluator for `generic_loop.until` conditions (`output.contains('PASS')`, `verdict == 'APPROVED'`). |
 | `resume.ts` | Startup orphan recovery + approval-gate resume entry point. Called both on harness boot (recover `running` / `paused` runs) and when a user responds to an approval gate. |
@@ -29,18 +30,20 @@ EventEnvelope
       → runSimpleWorkflow()
         → loader.getWorkflow(name)   loads + validates YAML
         → db.createWorkflowRun()     or reuses an existing paused/running row
-        → runWorkflow()              [src/workflows/runner.ts]
-          ├─ runPhase()              per phase: context / agent / loop
-          │    └─ executeAgent()     [src/engine/opencode-executor.ts]
-          │         └─ spawns a docker sandbox, runs `opencode run --format json`,
-          │           parses the event stream + writes the dashboard shim jsonl
-          └─ runDagWorkflow()        invoked when any phase has depends_on
+        → runWorkflow()              [src/workflows/runner.ts] — the scheduler
+          └─ PhaseExecutor.execute()  [src/workflows/phase-executor.ts]
+               └─ runPhase()          per node: context / agent / loop
+                    └─ executeAgent()  [src/engine/agent-executor.ts]
+                         └─ spawns a docker sandbox, runs the agent,
+                           parses the event stream + writes the dashboard shim jsonl
 ```
 
 Approval-gate resumption bypasses the router and re-enters via
-`src/workflows/resume.ts → resumeOrphanedWorkflows / resumeWorkflowRun →
-runSimpleWorkflow`. The runner's `nextPhaseAfter(definition, currentPhase)`
-derives the resume point from the YAML alone — no per-workflow branching.
+`src/workflows/resume.ts → resumeOrphanedWorkflows → runWorkflow` (boot
+recovery) or `runSimpleWorkflow` (a fresh trigger on a paused/running run).
+Resume is **ledger-driven**: the runner always re-runs from the top and the
+`executions` table (via `shouldRunPhase`) skips already-completed phases — no
+per-workflow branching, no `currentPhase`-derived resume index.
 
 ## Phase types
 
@@ -157,22 +160,34 @@ third-party docs goes through the same firewall path. See the
 "Environment" section of the top-level `CLAUDE.md` for the required
 provider env vars.
 
-## Linear vs DAG runner
+## One scheduler (every workflow is a DAG)
 
-`runWorkflow` checks `hasDependencies(definition)`. If any phase has
-`depends_on`, it hands off to `runDagWorkflow`; otherwise it walks
-`definition.phases` in declaration order.
+There is a single scheduler — no separate linear/DAG paths. `runWorkflow`
+builds a DAG with `buildDag(phases, { chainIfNoDeps: true })`:
 
-- **Linear runner** shares one `taskId` across all phases of the run. The
-  sandbox workspace persists between phases (architect writes `plan.md`,
-  executor reads it). This is the default for build / triage / review.
-- **DAG runner** gives each phase its own phase-scoped taskId
-  (`${taskId}-${phaseName}`) so concurrent phases can't race on the
-  workspace. Uses `buildDag` + `getReadyNodes` from `dag.ts` to dispatch
-  ready nodes in parallel.
+- **No `depends_on`** (every production workflow) → chain synthesis adds
+  `depends_on: [previousPhase]` (`all_success`) to each phase, reproducing the
+  old linear semantics including the failure cascade.
+- **Any `depends_on` declared** (only `examples/parallel-review.yaml`) → the
+  declared edges are used as-is.
 
-Loop iterations always run serially (even in the DAG path) because each
-fix cycle reads the previous reviewer verdict.
+The scheduler then loops `while (!isComplete(dag))`: it skips nodes whose
+trigger rule fails (a failure cascades down the chain as **skips**, recorded
+in the `executions` ledger), and runs the earliest-declared ready node — **one
+at a time, sequentially, in declaration order**. Real concurrency via git
+worktrees is deferred to a later issue.
+
+- **One workspace.** Every phase and every loop iteration uses the single
+  `ctx.taskId`. The sandbox workspace persists between phases (architect writes
+  `plan.md`, executor reads it). The old DAG path's per-phase
+  `${taskId}-${phaseName}` clones are gone.
+- **Uniform skip semantics.** A node runs iff its trigger rule is satisfied by
+  its deps' statuses; otherwise it is skipped (no downstream agent calls; the
+  run ends `success: false`). `isTerminated` errors (OOM/cancel) are not
+  reported as phase failures, and the failing node's error propagates to the
+  run.
+- Loop iterations run serially within their node because each fix cycle reads
+  the previous reviewer verdict.
 
 ## Loop iteration naming
 
@@ -191,8 +206,8 @@ First reviewer pass       → reviewer
 ```
 
 All generated labels are built by `PhaseRef.format()` (`phase-ref.ts`) — the
-single authority — and resolved back via `phaseIndexInDefinition` (exact-match
-first). `n` is the 1-based **cycle**; `fix_k` and `recheck_k` pair within a
+single authority — and parsed back via `PhaseRef.parse()` (base + kind).
+`n` is the 1-based **cycle**; `fix_k` and `recheck_k` pair within a
 cycle:
 
 - `${parentPhaseName}` — the initial run
@@ -230,8 +245,11 @@ The user then resolves the gate via one of:
 All three paths funnel into the same `resumeWorkflowRun(run, sender)`
 callback wired in `src/index.ts`. It updates `workflow_approvals`,
 flips the run back to `running`, and re-enters `runSimpleWorkflow`. The
-runner's `nextPhaseAfter(definition, run.currentPhase)` skips already-
-completed phases, so the re-entry picks up exactly where it paused.
+runner re-runs from the top and the `executions` ledger (`shouldRunPhase`)
+skips already-completed phases, so the re-entry picks up exactly where it
+paused. For an **approve** gate the gated phase is already `done` so the
+runner proceeds past it; for a **reply** gate the generic-loop node resumes
+from `scratch.iteration`. No `currentPhase`-reset scaffolding is involved.
 
 ## taskId scoping
 
@@ -244,12 +262,10 @@ ${repo}-${issueNumber}-${workflowName}-${runId.slice(0, 8)}
 
 - Includes the run id suffix so two parallel runs against the same
   issue can't collide on the sandbox workspace.
-- Linear runner passes this exact taskId to every `runPhase` call →
-  all phases share one workspace.
-- DAG runner uses `${taskId}-${phaseName}` for parallel phases →
-  concurrent writes are isolated.
-- Loop iterations use the linear taskId (fixes read the reviewer's
-  output from the same workspace).
+- The scheduler passes this exact taskId to every `runPhase` call →
+  all phases **and all loop iterations** share one workspace (fixes read
+  the reviewer's output from the same checkout). The old DAG path's
+  per-phase `${taskId}-${phaseName}` clones are gone.
 
 `resume.ts` reconstructs the taskId from the stored `context.taskId` so
 a resumed run lands in the same sandbox dir the original started in.
@@ -275,10 +291,15 @@ and similar.
 
 Unit tests for every non-trivial piece live alongside the source:
 
-- `runner.test.ts` — 1000+ lines, covers linear and DAG paths, context
-  phases, loop cycles, approval gates, resume, guardrails bypass, and
-  the nextPhaseAfter / isTerminated helpers.
-- `dag.test.ts` — pure graph scheduling.
+- `runner.test.ts` — covers the unified scheduler: chain + declared-DAG
+  workflows, context phases, loop cycles, approval gates, ledger-driven
+  resume, guardrails bypass, sequential ordering, one-workspace, and
+  skip-in-ledger.
+- `phase-executor.test.ts` — direct unit tests for `PhaseExecutor.execute`
+  with fake collaborators (each per-phase body, gates, dedup).
+- `golden-build.test.ts` — pins `build.yaml`'s phase sequence under the
+  unified scheduler (regression guard against reorders).
+- `dag.test.ts` — pure graph scheduling + chain synthesis.
 - `loader.test.ts` — YAML validation.
 - `templates.test.ts` — variable substitution and `unless_*`.
 - `loop-eval.test.ts` — expression evaluator.

--- a/src/workflows/CLAUDE.md
+++ b/src/workflows/CLAUDE.md
@@ -247,9 +247,14 @@ callback wired in `src/index.ts`. It updates `workflow_approvals`,
 flips the run back to `running`, and re-enters `runSimpleWorkflow`. The
 runner re-runs from the top and the `executions` ledger (`shouldRunPhase`)
 skips already-completed phases, so the re-entry picks up exactly where it
-paused. For an **approve** gate the gated phase is already `done` so the
-runner proceeds past it; for a **reply** gate the generic-loop node resumes
-from `scratch.iteration`. No `currentPhase`-reset scaffolding is involved.
+paused. For a standalone **approve** gate the gated phase is already `done` so
+the runner proceeds past it; for a **reply** gate the generic-loop node resumes
+from `scratch.iteration`. A **reviewer-loop** gate (`loop.approval_gate`) is
+mid-loop, so it persists `scratch["rloop:<phase>"].pausedAtCycle` before
+pausing and persists each review's output: on resume the loop re-derives the
+prior review's verdict from that output (a dedup-`done` review is **not**
+assumed APPROVED) and runs the fix cycle for the approved gate rather than
+re-pausing. No `currentPhase`-reset scaffolding is involved.
 
 ## taskId scoping
 

--- a/src/workflows/dag.test.ts
+++ b/src/workflows/dag.test.ts
@@ -59,6 +59,31 @@ describe("buildDag", () => {
   });
 });
 
+describe("buildDag — chain synthesis", () => {
+  it("synthesizes a previous-phase chain when no phase declares depends_on", () => {
+    const phases = [makePhase("A"), makePhase("B"), makePhase("C")];
+    const dag = buildDag(phases, { chainIfNoDeps: true });
+    expect(dag[0].depends_on).toEqual([]);
+    expect(dag[1].depends_on).toEqual(["A"]);
+    expect(dag[2].depends_on).toEqual(["B"]);
+    expect(dag.every((n) => n.trigger_rule === "all_success")).toBe(true);
+  });
+
+  it("leaves declared edges untouched when any phase declares depends_on", () => {
+    const phases = [makePhase("A"), makePhase("B"), makePhase("C", ["A"])];
+    const dag = buildDag(phases, { chainIfNoDeps: true });
+    expect(dag[0].depends_on).toEqual([]);
+    expect(dag[1].depends_on).toEqual([]); // B keeps its (absent) edge — no synthesis
+    expect(dag[2].depends_on).toEqual(["A"]);
+  });
+
+  it("does not synthesize a chain by default (chainIfNoDeps off)", () => {
+    const phases = [makePhase("A"), makePhase("B"), makePhase("C")];
+    const dag = buildDag(phases);
+    expect(dag.every((n) => n.depends_on.length === 0)).toBe(true);
+  });
+});
+
 describe("evaluateTriggerRule", () => {
   it("all_success: true when all deps succeeded", () => {
     expect(evaluateTriggerRule("all_success", ["succeeded", "succeeded"])).toBe(true);

--- a/src/workflows/dag.ts
+++ b/src/workflows/dag.ts
@@ -13,8 +13,21 @@ export interface DagNode {
 
 const TERMINAL: NodeStatus[] = ["succeeded", "failed", "skipped"];
 
+export interface BuildDagOptions {
+  /**
+   * When set and **no** phase declares `depends_on`, synthesize a chain:
+   * each phase depends on the one declared before it (trigger rule
+   * `all_success`). This reproduces the old linear runner's semantics —
+   * sequential execution with a failure cascade — as a degenerate DAG, so
+   * the unified scheduler can treat every workflow uniformly. When any phase
+   * declares an explicit edge, the declared graph is used verbatim (no
+   * synthesis).
+   */
+  chainIfNoDeps?: boolean;
+}
+
 /** Build a DAG from phase definitions. Validates edges and detects cycles. */
-export function buildDag(phases: PhaseDefinition[]): DagNode[] {
+export function buildDag(phases: PhaseDefinition[], opts: BuildDagOptions = {}): DagNode[] {
   const names = new Set(phases.map((p) => p.name));
 
   for (const phase of phases) {
@@ -25,9 +38,14 @@ export function buildDag(phases: PhaseDefinition[]): DagNode[] {
     }
   }
 
-  const nodes: DagNode[] = phases.map((p) => ({
+  const anyDeclared = phases.some((p) => p.depends_on && p.depends_on.length > 0);
+  const synthesizeChain = opts.chainIfNoDeps === true && !anyDeclared;
+
+  const nodes: DagNode[] = phases.map((p, i) => ({
     name: p.name,
-    depends_on: p.depends_on ?? [],
+    depends_on: synthesizeChain
+      ? (i > 0 ? [phases[i - 1].name] : [])
+      : (p.depends_on ?? []),
     trigger_rule: p.trigger_rule ?? "all_success",
     status: "pending" as NodeStatus,
   }));

--- a/src/workflows/golden-build.test.ts
+++ b/src/workflows/golden-build.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { getWorkflow } from "./loader.js";
+import { buildDag, getReadyNodes, getNodesToSkip, isComplete } from "./dag.js";
+
+/**
+ * Golden test: the unified scheduler must execute `build.yaml` in exactly the
+ * same phase order as the old linear runner. build.yaml declares no
+ * `depends_on`, so chain synthesis must reproduce its declaration order as a
+ * sequential chain. If this order ever changes, the build cycle's contract
+ * (architect → executor → reviewer → pr) has shifted — fail loudly.
+ */
+describe("golden — build.yaml phase sequence is unchanged under the unified scheduler", () => {
+  it("schedules build phases in declaration order", () => {
+    const def = getWorkflow("build");
+    const declared = def.phases.map((p) => p.name);
+
+    // build.yaml is a linear workflow — no explicit edges.
+    expect(def.phases.every((p) => !p.depends_on?.length)).toBe(true);
+
+    // Simulate the scheduler: chain-synthesize, then repeatedly run the
+    // earliest-declared ready node (sequential), collecting the visit order.
+    const dag = buildDag(def.phases, { chainIfNoDeps: true });
+    const order: string[] = [];
+    let guard = 0;
+    while (!isComplete(dag) && guard++ < 100) {
+      for (const n of getNodesToSkip(dag)) n.status = "skipped";
+      const ready = getReadyNodes(dag);
+      if (ready.length === 0) break;
+      const node = ready[0];
+      order.push(node.name);
+      node.status = "succeeded";
+    }
+
+    expect(order).toEqual(declared);
+    // Pin the actual phase names so an accidental rename/reorder is caught.
+    expect(declared).toEqual(["phase_0", "guardrails", "architect", "executor", "reviewer", "pr"]);
+  });
+
+  it("synthesizes a previous-phase chain for build.yaml", () => {
+    const def = getWorkflow("build");
+    const dag = buildDag(def.phases, { chainIfNoDeps: true });
+    expect(dag[0].depends_on).toEqual([]);
+    for (let i = 1; i < dag.length; i++) {
+      expect(dag[i].depends_on).toEqual([def.phases[i - 1].name]);
+    }
+  });
+});

--- a/src/workflows/phase-executor.test.ts
+++ b/src/workflows/phase-executor.test.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AgentWorkflowDefinition, PhaseDefinition } from "./schema.js";
+import type { TemplateContext } from "./templates.js";
+import type { StateDb } from "../state/db.js";
+import type { DagNode } from "./dag.js";
+import type { PhaseResult } from "./runner.js";
+
+// Mock the executor so we don't make real agent calls.
+vi.mock("../engine/agent-executor.js", () => ({
+  executeAgent: vi.fn(),
+}));
+vi.mock("../admin/docker.js", () => ({
+  listRunningContainers: vi.fn(async () => []),
+}));
+vi.mock("./loader.js", () => ({
+  loadPromptTemplate: vi.fn((path: string) => `TEMPLATE:${path}`),
+  resolveSkillPaths: vi.fn(() => undefined),
+}));
+vi.mock("child_process", () => ({ execSync: vi.fn() }));
+
+import { executeAgent } from "../engine/agent-executor.js";
+import { listRunningContainers } from "../admin/docker.js";
+import {
+  PhaseExecutor,
+  type PhaseReporter,
+  type PhaseResolver,
+  type PhaseRunContext,
+} from "./phase-executor.js";
+
+const mockExecuteAgent = vi.mocked(executeAgent);
+
+const BASE_CTX: TemplateContext = {
+  owner: "acme",
+  repo: "widget",
+  issueNumber: 42,
+  issueTitle: "Add Rate Limiter",
+  issueBody: "We need a rate limiter",
+  issueLabels: [],
+  commentBody: "",
+  sender: "alice",
+  branch: "lastlight/42-add-rate-limiter",
+  taskId: "widget-42",
+  issueDir: ".lastlight/issue-42",
+  bootstrapLabel: "lastlight:bootstrap",
+};
+
+function makeSuccessResult(output = "success output") {
+  return { success: true, output, error: undefined, turns: 5, durationMs: 1000 };
+}
+function makeFailResult(error = "boom") {
+  return { success: false, output: "", error, turns: 2, durationMs: 500 };
+}
+
+interface RecordedStep {
+  key: string;
+  status: string;
+  template?: string;
+}
+
+function makeReporter(): PhaseReporter & { steps: RecordedStep[]; notes: string[]; persisted: string[]; failed: string[] } {
+  const steps: RecordedStep[] = [];
+  const notes: string[] = [];
+  const persisted: string[] = [];
+  const failed: string[] = [];
+  return {
+    steps,
+    notes,
+    persisted,
+    failed,
+    onStart: vi.fn(async () => {}),
+    onEnd: vi.fn(async () => {}),
+    step: vi.fn(async (key, status, template) => {
+      steps.push({ key, status, template });
+    }),
+    message: vi.fn(async (template) => {
+      if (template) notes.push(template);
+    }),
+    postNote: vi.fn(async (text) => {
+      notes.push(text);
+    }),
+    persistPhase: vi.fn((phase) => {
+      persisted.push(phase);
+    }),
+    failWorkflow: vi.fn((err) => {
+      failed.push(err ?? "");
+    }),
+  };
+}
+
+function makeResolver(overrides: Partial<PhaseResolver> = {}): PhaseResolver {
+  return {
+    modelFor: () => undefined,
+    variantFor: () => undefined,
+    renderPrompt: (path: string) => `RENDERED:${path}`,
+    gateEnabled: () => false,
+    ...overrides,
+  };
+}
+
+function makeRun(definition: AgentWorkflowDefinition, db?: StateDb): PhaseRunContext {
+  return {
+    definition,
+    ctx: { ...BASE_CTX },
+    config: {} as never,
+    taskId: "widget-42",
+    triggerId: "acme/widget#42",
+    githubAccess: { owner: "acme", repo: "widget", profile: "read", allowMcpAppAuth: false } as never,
+    scratch: {},
+    db,
+    workflowId: db ? "wf-1" : undefined,
+  };
+}
+
+function node(name: string, depends_on: string[] = []): DagNode {
+  return { name, depends_on, status: "pending", trigger_rule: "all_success" };
+}
+
+function makeMockDb(): StateDb {
+  return {
+    shouldRunPhase: vi.fn(() => "run"),
+    recordStart: vi.fn(),
+    recordFinish: vi.fn(),
+    recordOutputText: vi.fn(),
+    recordSessionId: vi.fn(),
+    getExecutionOutput: vi.fn(() => null),
+    markStaleAsFailed: vi.fn(),
+    markLatestAsFailed: vi.fn(),
+    updateWorkflowPhase: vi.fn(),
+    pauseWorkflowRun: vi.fn(),
+    createApproval: vi.fn(),
+    updateWorkflowRunScratch: vi.fn(),
+    getWorkflowRun: vi.fn(() => ({ currentPhase: "phase_0", phaseHistory: [], status: "running", scratch: {} })),
+  } as unknown as StateDb;
+}
+
+function makePhase(p: Partial<PhaseDefinition> & { name: string }): PhaseDefinition {
+  return { type: "agent", ...p } as PhaseDefinition;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PhaseExecutor — context phase", () => {
+  it("returns succeeded without invoking the agent and persists phase history", async () => {
+    const def: AgentWorkflowDefinition = {
+      kind: "agent",
+      name: "ctx-only",
+      phases: [makePhase({ name: "phase_0", type: "context" })],
+    };
+    const reporter = makeReporter();
+    const exec = new PhaseExecutor(makeRun(def), reporter, makeResolver());
+
+    const outcome = await exec.execute(node("phase_0"), {});
+
+    expect(mockExecuteAgent).not.toHaveBeenCalled();
+    expect(outcome.status).toBe("succeeded");
+    expect(outcome.results).toEqual([
+      { phase: "phase_0", success: true, output: "Context assembled" },
+    ]);
+    expect(reporter.persisted).toContain("phase_0");
+  });
+});
+
+describe("PhaseExecutor — standard agent phase", () => {
+  const def: AgentWorkflowDefinition = {
+    kind: "agent",
+    name: "wf",
+    phases: [makePhase({ name: "architect", prompt: "prompts/architect.md", output_var: "plan" })],
+  };
+
+  it("runs the agent and exposes output under phase name + output_var", async () => {
+    mockExecuteAgent.mockResolvedValue(makeSuccessResult("the plan"));
+    const exec = new PhaseExecutor(makeRun(def), makeReporter(), makeResolver());
+
+    const outcome = await exec.execute(node("architect"), {});
+
+    expect(mockExecuteAgent).toHaveBeenCalledTimes(1);
+    expect(outcome.status).toBe("succeeded");
+    expect(outcome.results).toEqual([{ phase: "architect", success: true, output: "the plan", error: undefined }]);
+    expect(outcome.outputVars).toEqual({ architect: "the plan", plan: "the plan" });
+  });
+
+  it("returns status=failed and fails the workflow when the agent fails", async () => {
+    mockExecuteAgent.mockResolvedValue(makeFailResult("kaboom"));
+    const reporter = makeReporter();
+    const exec = new PhaseExecutor(makeRun(def), reporter, makeResolver());
+
+    const outcome = await exec.execute(node("architect"), {});
+
+    expect(outcome.status).toBe("failed");
+    expect(reporter.failed).toContain("kaboom");
+    expect(reporter.steps.some((s: RecordedStep) => s.key === "architect" && s.status === "failed")).toBe(true);
+  });
+
+  it("does NOT report a failed step for terminated (OOM/cancel) errors", async () => {
+    mockExecuteAgent.mockResolvedValue(makeFailResult("container is not running"));
+    const reporter = makeReporter();
+    const exec = new PhaseExecutor(makeRun(def), reporter, makeResolver());
+
+    const outcome = await exec.execute(node("architect"), {});
+
+    expect(outcome.status).toBe("failed");
+    expect(reporter.steps.some((s: RecordedStep) => s.key === "architect" && s.status === "failed")).toBe(false);
+  });
+
+  it("aborts (running-skip) when the dedup ledger reports the phase running and the container is alive", async () => {
+    const db = makeMockDb();
+    vi.mocked(db.shouldRunPhase).mockReturnValue("running");
+    vi.mocked(listRunningContainers).mockResolvedValueOnce([{ taskId: "widget-42" }] as never);
+    const exec = new PhaseExecutor(makeRun(def, db), makeReporter(), makeResolver());
+
+    const outcome = await exec.execute(node("architect"), {});
+
+    expect(outcome.aborted).toBe(true);
+    expect(outcome.status).toBe("failed");
+    expect(mockExecuteAgent).not.toHaveBeenCalled();
+  });
+
+  it("treats a done dedup row as already-completed (skips the agent)", async () => {
+    const db = makeMockDb();
+    vi.mocked(db.shouldRunPhase).mockReturnValue("done");
+    const reporter = makeReporter();
+    const exec = new PhaseExecutor(makeRun(def, db), reporter, makeResolver());
+
+    const outcome = await exec.execute(node("architect"), {});
+
+    expect(mockExecuteAgent).not.toHaveBeenCalled();
+    expect(outcome.status).toBe("succeeded");
+    expect(outcome.results[0].output).toBe("Already completed");
+    expect(reporter.persisted).toContain("architect");
+  });
+});
+
+describe("PhaseExecutor — on_output BLOCKED", () => {
+  const def: AgentWorkflowDefinition = {
+    kind: "agent",
+    name: "guarded",
+    phases: [
+      makePhase({
+        name: "guardrails",
+        prompt: "prompts/guardrails.md",
+        on_output: {
+          contains_BLOCKED: { action: "fail", message: "Guardrails: BLOCKED", unless_label: "lastlight:bootstrap" },
+        },
+      }),
+    ],
+  };
+
+  it("fails the node when output contains BLOCKED", async () => {
+    mockExecuteAgent.mockResolvedValue(makeSuccessResult("BLOCKED — no tests"));
+    const reporter = makeReporter();
+    const db = makeMockDb();
+    const exec = new PhaseExecutor(makeRun(def, db), reporter, makeResolver());
+
+    const outcome = await exec.execute(node("guardrails"), {});
+
+    expect(outcome.status).toBe("failed");
+    expect(outcome.results[0]).toMatchObject({ phase: "guardrails", success: false, error: "BLOCKED" });
+    expect(db.markLatestAsFailed).toHaveBeenCalled();
+    expect(reporter.failed.length).toBeGreaterThan(0);
+  });
+
+  it("bypasses BLOCKED when the unless_label is present", async () => {
+    mockExecuteAgent.mockResolvedValue(makeSuccessResult("BLOCKED — no tests"));
+    const run = makeRun(def, makeMockDb());
+    run.ctx.issueLabels = ["lastlight:bootstrap"];
+    const exec = new PhaseExecutor(run, makeReporter(), makeResolver());
+
+    const outcome = await exec.execute(node("guardrails"), {});
+
+    expect(outcome.status).toBe("succeeded");
+  });
+});
+
+describe("PhaseExecutor — approval gate", () => {
+  const def: AgentWorkflowDefinition = {
+    kind: "agent",
+    name: "gated",
+    phases: [makePhase({ name: "architect", prompt: "prompts/architect.md", approval_gate: "post_architect" })],
+  };
+
+  it("pauses when the gate is enabled", async () => {
+    mockExecuteAgent.mockResolvedValue(makeSuccessResult("plan"));
+    const db = makeMockDb();
+    const exec = new PhaseExecutor(
+      makeRun(def, db),
+      makeReporter(),
+      makeResolver({ gateEnabled: (g?: string) => g === "post_architect" }),
+    );
+
+    const outcome = await exec.execute(node("architect"), {});
+
+    expect(outcome.paused).toBe(true);
+    expect(outcome.status).toBe("succeeded");
+    expect(db.createApproval).toHaveBeenCalled();
+    expect(db.pauseWorkflowRun).toHaveBeenCalled();
+  });
+
+  it("does not pause when the gate is disabled", async () => {
+    mockExecuteAgent.mockResolvedValue(makeSuccessResult("plan"));
+    const db = makeMockDb();
+    const exec = new PhaseExecutor(makeRun(def, db), makeReporter(), makeResolver());
+
+    const outcome = await exec.execute(node("architect"), {});
+
+    expect(outcome.paused).toBeFalsy();
+    expect(db.createApproval).not.toHaveBeenCalled();
+  });
+});
+
+describe("PhaseExecutor — reviewer loop", () => {
+  const def: AgentWorkflowDefinition = {
+    kind: "agent",
+    name: "full",
+    phases: [
+      makePhase({
+        name: "reviewer",
+        prompt: "prompts/reviewer.md",
+        output_var: "review",
+        loop: {
+          max_cycles: 2,
+          on_request_changes: { fix_prompt: "prompts/fix.md", re_review_prompt: "prompts/re.md" },
+        },
+      }),
+    ],
+  };
+
+  it("approves on first review — no fix cycle", async () => {
+    mockExecuteAgent.mockResolvedValue(makeSuccessResult("VERDICT: APPROVED"));
+    const exec = new PhaseExecutor(makeRun(def), makeReporter(), makeResolver());
+
+    const outcome = await exec.execute(node("reviewer"), {});
+
+    expect(mockExecuteAgent).toHaveBeenCalledTimes(1);
+    expect(outcome.status).toBe("succeeded");
+    expect(outcome.outputVars).toEqual({ review: { approved: true, cycles: 0 } });
+  });
+
+  it("runs one fix cycle on REQUEST_CHANGES then APPROVED", async () => {
+    mockExecuteAgent
+      .mockResolvedValueOnce(makeSuccessResult("VERDICT: REQUEST_CHANGES"))
+      .mockResolvedValueOnce(makeSuccessResult("fixed"))
+      .mockResolvedValueOnce(makeSuccessResult("VERDICT: APPROVED"));
+    const exec = new PhaseExecutor(makeRun(def), makeReporter(), makeResolver());
+
+    const outcome = await exec.execute(node("reviewer"), {});
+
+    expect(outcome.status).toBe("succeeded");
+    expect(outcome.outputVars).toEqual({ review: { approved: true, cycles: 1 } });
+    expect(outcome.results.map((r: PhaseResult) => r.phase)).toEqual(["reviewer", "reviewer_fix_1", "reviewer_recheck_1"]);
+  });
+
+  it("pauses at an enabled loop approval gate before the fix cycle", async () => {
+    mockExecuteAgent.mockResolvedValue(makeSuccessResult("VERDICT: REQUEST_CHANGES"));
+    const loopDef: AgentWorkflowDefinition = {
+      kind: "agent",
+      name: "full",
+      phases: [
+        makePhase({
+          name: "reviewer",
+          prompt: "prompts/reviewer.md",
+          loop: {
+            max_cycles: 2,
+            approval_gate: "post_reviewer",
+            on_request_changes: { fix_prompt: "prompts/fix.md", re_review_prompt: "prompts/re.md" },
+          },
+        }),
+      ],
+    };
+    const db = makeMockDb();
+    const exec = new PhaseExecutor(
+      makeRun(loopDef, db),
+      makeReporter(),
+      makeResolver({ gateEnabled: (g?: string) => g === "post_reviewer" }),
+    );
+
+    const outcome = await exec.execute(node("reviewer"), {});
+
+    expect(outcome.paused).toBe(true);
+    expect(db.createApproval).toHaveBeenCalled();
+    // Only the first review ran — no fix agent call yet.
+    expect(mockExecuteAgent).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PhaseExecutor — generic loop", () => {
+  const def: AgentWorkflowDefinition = {
+    kind: "agent",
+    name: "gl",
+    phases: [
+      makePhase({
+        name: "worker",
+        prompt: "prompts/worker.md",
+        output_var: "work",
+        generic_loop: { max_iterations: 3, until: "output.contains('DONE')", interactive: false, fresh_context: false },
+      }),
+    ],
+  };
+
+  it("completes when the until expression matches", async () => {
+    mockExecuteAgent
+      .mockResolvedValueOnce(makeSuccessResult("still going"))
+      .mockResolvedValueOnce(makeSuccessResult("all DONE"));
+    const exec = new PhaseExecutor(makeRun(def, makeMockDb()), makeReporter(), makeResolver());
+
+    const outcome = await exec.execute(node("worker"), {});
+
+    expect(mockExecuteAgent).toHaveBeenCalledTimes(2);
+    expect(outcome.status).toBe("succeeded");
+    expect(outcome.outputVars).toEqual({ work: { completed: true, iterations: 2 } });
+  });
+
+  it("fails the workflow when an iteration agent fails", async () => {
+    mockExecuteAgent.mockResolvedValue(makeFailResult("iter boom"));
+    const reporter = makeReporter();
+    const exec = new PhaseExecutor(makeRun(def, makeMockDb()), reporter, makeResolver());
+
+    const outcome = await exec.execute(node("worker"), {});
+
+    expect(outcome.status).toBe("failed");
+    expect(reporter.failed).toContain("iter boom");
+  });
+});

--- a/src/workflows/phase-executor.test.ts
+++ b/src/workflows/phase-executor.test.ts
@@ -97,7 +97,7 @@ function makeResolver(overrides: Partial<PhaseResolver> = {}): PhaseResolver {
   };
 }
 
-function makeRun(definition: AgentWorkflowDefinition, db?: StateDb): PhaseRunContext {
+function makeRun(definition: AgentWorkflowDefinition, db?: StateDb, scratch: Record<string, unknown> = {}): PhaseRunContext {
   return {
     definition,
     ctx: { ...BASE_CTX },
@@ -105,7 +105,7 @@ function makeRun(definition: AgentWorkflowDefinition, db?: StateDb): PhaseRunCon
     taskId: "widget-42",
     triggerId: "acme/widget#42",
     githubAccess: { owner: "acme", repo: "widget", profile: "read", allowMcpAppAuth: false } as never,
-    scratch: {},
+    scratch,
     db,
     workflowId: db ? "wf-1" : undefined,
   };
@@ -123,6 +123,7 @@ function makeMockDb(): StateDb {
     recordOutputText: vi.fn(),
     recordSessionId: vi.fn(),
     getExecutionOutput: vi.fn(() => null),
+    getPhaseOutput: vi.fn(() => null),
     markStaleAsFailed: vi.fn(),
     markLatestAsFailed: vi.fn(),
     updateWorkflowPhase: vi.fn(),
@@ -381,6 +382,58 @@ describe("PhaseExecutor — reviewer loop", () => {
     expect(db.createApproval).toHaveBeenCalled();
     // Only the first review ran — no fix agent call yet.
     expect(mockExecuteAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("on resume past an approved loop gate, runs the fix cycle instead of treating the deduped review as approved", async () => {
+    const loopDef: AgentWorkflowDefinition = {
+      kind: "agent",
+      name: "full",
+      phases: [
+        makePhase({
+          name: "reviewer",
+          prompt: "prompts/reviewer.md",
+          output_var: "review",
+          loop: {
+            max_cycles: 2,
+            approval_gate: "post_reviewer",
+            on_request_changes: { fix_prompt: "prompts/fix.md", re_review_prompt: "prompts/re.md" },
+          },
+        }),
+      ],
+    };
+    const db = makeMockDb();
+    // Resume state: the initial review already ran and requested changes; the
+    // fix for cycle 1 has NOT run yet; we paused at cycle 1's gate.
+    vi.mocked(db.shouldRunPhase).mockImplementation((skill: string) =>
+      skill === "full:reviewer" ? "done" : "run",
+    );
+    vi.mocked(db.getPhaseOutput).mockImplementation((skill: string) =>
+      skill === "full:reviewer" ? "VERDICT: REQUEST_CHANGES\nfix the bug" : null,
+    );
+    // fix succeeds, then the re-review approves.
+    mockExecuteAgent
+      .mockResolvedValueOnce(makeSuccessResult("fixed"))
+      .mockResolvedValueOnce(makeSuccessResult("VERDICT: APPROVED"));
+
+    const exec = new PhaseExecutor(
+      makeRun(loopDef, db, { "rloop:reviewer": { pausedAtCycle: 1 } }),
+      makeReporter(),
+      makeResolver({ gateEnabled: (g?: string) => g === "post_reviewer" }),
+    );
+
+    const outcome = await exec.execute(node("reviewer"), {});
+
+    // Must NOT pause again, and must NOT report approved=true with 0 cycles.
+    expect(outcome.paused).toBeFalsy();
+    expect(db.createApproval).not.toHaveBeenCalled();
+    expect(outcome.outputVars).toEqual({ review: { approved: true, cycles: 1 } });
+    // The fix + re-review ran (2 agent calls); the initial review was deduped.
+    expect(mockExecuteAgent).toHaveBeenCalledTimes(2);
+    expect(outcome.results.map((r: PhaseResult) => r.phase)).toEqual([
+      "reviewer",
+      "reviewer_fix_1",
+      "reviewer_recheck_1",
+    ]);
   });
 });
 

--- a/src/workflows/phase-executor.ts
+++ b/src/workflows/phase-executor.ts
@@ -1,0 +1,910 @@
+import { randomUUID } from "crypto";
+import { execSync } from "child_process";
+import type {
+  ExecutorConfig,
+  ExecutionResult,
+  GitSandboxAccess,
+} from "../engine/profiles.js";
+import { executeAgent } from "../engine/agent-executor.js";
+import type { StateDb } from "../state/db.js";
+import type { AgentWorkflowDefinition, PhaseDefinition } from "./schema.js";
+import { phaseSkillNames } from "./schema.js";
+import { loadPromptTemplate, resolveSkillPaths } from "./loader.js";
+import { renderTemplate, type TemplateContext } from "./templates.js";
+import { evalUntilExpression } from "./loop-eval.js";
+import { parseReviewerVerdict } from "./verdict.js";
+import { PhaseRef } from "./phase-ref.js";
+import type { DagNode } from "./dag.js";
+import type { PhaseResult } from "./runner.js";
+import type { StepStatus, ProgressStep } from "../notify/types.js";
+import { recordError, recordExecutionMetrics, withSpan } from "../telemetry/index.js";
+import { listRunningContainers } from "../admin/docker.js";
+
+/**
+ * The single per-phase executor. Constructed once per workflow run, it owns
+ * every per-phase body — context / standard agent / reviewer-loop /
+ * generic-loop — behind one `execute(node, outputs)` entry point. The
+ * scheduler (`runner.ts`) owns the DAG, the `phases[]`/`outputs{}`
+ * accumulation, and the in-memory node status; `execute` reads the current
+ * outputs and returns its delta.
+ *
+ * Dependencies are grouped into three cohesive collaborators:
+ *   - {@link PhaseRunContext}  run-scoped immutable data
+ *   - {@link PhaseReporter}    progress / notification surface
+ *   - {@link PhaseResolver}    model / variant / prompt / gate resolution
+ *
+ * This makes the executor unit-testable with fakes (see
+ * `phase-executor.test.ts`), and — because both chain and explicit-DAG nodes
+ * now route through the same code — loop nodes finally support the approval /
+ * reply gates that the old DAG fork dropped.
+ */
+
+// ── Collaborators ────────────────────────────────────────────────────────────
+
+/** Run-scoped immutable data shared by every phase execution. */
+export interface PhaseRunContext {
+  definition: AgentWorkflowDefinition;
+  ctx: TemplateContext;
+  config: ExecutorConfig;
+  /** Single workspace shared by every phase + loop iteration of the run. */
+  taskId: string;
+  triggerId: string;
+  githubAccess: GitSandboxAccess;
+  /** Mutable scratch bag (generic-loop resume state). */
+  scratch: Record<string, unknown>;
+  db?: StateDb;
+  workflowId?: string;
+}
+
+export interface ReportStepOpts {
+  label?: string;
+  insertBefore?: string;
+  insert?: boolean;
+  alsoNote?: boolean;
+}
+
+/** Progress / notification surface — the reporting collaborator. */
+export interface PhaseReporter {
+  onStart(phase: string): Promise<void>;
+  onEnd(phase: string, result: PhaseResult): Promise<void>;
+  /** Transition a checklist step (and optionally render a YAML message detail). */
+  step(
+    key: string,
+    status: StepStatus,
+    template?: string,
+    extraCtx?: Partial<TemplateContext>,
+    opts?: ReportStepOpts,
+  ): Promise<void>;
+  /** Render a YAML message template and post it as a standalone note. */
+  message(template: string | undefined, extraCtx?: Partial<TemplateContext>): Promise<void>;
+  /** Post a pre-rendered standalone message. */
+  postNote(text: string): Promise<void>;
+  /** Persist a phase-history entry on the workflow run. */
+  persistPhase(phase: string, summary?: string): void;
+  /** Mark the workflow run failed. */
+  failWorkflow(errorMsg?: string): void;
+}
+
+/** Model / variant / prompt / gate resolution — the resolution collaborator. */
+export interface PhaseResolver {
+  modelFor(taskType: string): string | undefined;
+  variantFor(taskType: string): string | undefined;
+  renderPrompt(promptPath: string, extraCtx?: Partial<TemplateContext>): string;
+  gateEnabled(gateName: string | undefined): boolean;
+}
+
+/** The delta a single `execute(node, outputs)` returns to the scheduler. */
+export interface PhaseOutcome {
+  results: PhaseResult[];
+  status: "succeeded" | "failed" | "skipped";
+  /** Approval / reply gate hit — scheduler returns `{ success: true, paused: true }`. */
+  paused?: boolean;
+  /**
+   * Dedup running-skip — another instance is mid-flight on this exact phase.
+   * Scheduler stops the whole run immediately with `success: false` and does
+   * NOT cascade skips (it isn't a phase failure).
+   */
+  aborted?: boolean;
+  /** Output map additions to merge into the scheduler's accumulated outputs. */
+  outputVars?: Record<string, unknown>;
+}
+
+// ── Module-level helpers (moved here from runner.ts) ─────────────────────────
+
+/**
+ * Reject shell commands containing mustache template markers to prevent
+ * accidental template injection into until_bash values.
+ */
+function validateShellCommand(cmd: string): void {
+  if (cmd.includes("{{")) {
+    throw new Error(`until_bash command rejected: contains template marker '{{'. Render templates before passing to shell.`);
+  }
+}
+
+/**
+ * Build the agent prompt for a phase, handling both `prompt:` (template file)
+ * and `skill:`/`skills:` (skill references) phase definitions.
+ */
+export function buildPhasePrompt(
+  phase: PhaseDefinition,
+  ctx: TemplateContext,
+  extraCtx?: Partial<TemplateContext>,
+): string {
+  const fullCtx = extraCtx ? { ...ctx, ...extraCtx } : ctx;
+
+  if (phase.prompt) {
+    const template = loadPromptTemplate(phase.prompt);
+    return renderTemplate(template, fullCtx);
+  }
+
+  const skills = phaseSkillNames(phase);
+  if (skills.length) {
+    const [primary, ...rest] = skills;
+    const contextLines = Object.entries(fullCtx)
+      .filter(([, v]) => v !== undefined && v !== null)
+      .map(([k, v]) => `${k}: ${typeof v === "object" ? JSON.stringify(v) : v}`)
+      .join("\n");
+    const others = rest.length
+      ? `Other skills available if you need them: ${rest.join(", ")}.`
+      : "";
+    return [
+      `Use the **${primary}** skill to handle this request.`,
+      others,
+      "",
+      "Context:",
+      contextLines,
+    ]
+      .filter((line) => line !== "")
+      .join("\n");
+  }
+
+  throw new Error(`Phase "${phase.name}" has neither prompt: nor skills: — cannot build prompt`);
+}
+
+/**
+ * Overlay per-phase executor config fields (`unrestricted_egress`,
+ * `web_search`, resolved skill paths) onto the run-level config.
+ */
+export function phaseConfigFor(config: ExecutorConfig, phase: PhaseDefinition): ExecutorConfig {
+  const skills = phaseSkillNames(phase);
+  const skillPaths = skills.length ? resolveSkillPaths(skills) : undefined;
+
+  if (
+    phase.unrestricted_egress === undefined &&
+    phase.web_search === undefined &&
+    !skillPaths
+  ) {
+    return config;
+  }
+  const next: ExecutorConfig = { ...config };
+  if (phase.unrestricted_egress !== undefined) {
+    next.unrestrictedEgress = phase.unrestricted_egress;
+  }
+  if (phase.web_search !== undefined) {
+    next.webSearch = phase.web_search;
+  }
+  if (skillPaths) {
+    next.skillPaths = skillPaths;
+  }
+  return next;
+}
+
+/** Check if an error was caused by manual termination (OOM/cancel/kill). */
+export function isTerminated(error?: string): boolean {
+  if (!error) return false;
+  const lower = error.toLowerCase();
+  return (
+    lower.includes("terminated") ||
+    lower.includes("killed") ||
+    lower.includes("exit undefined") ||
+    (lower.includes("container") && lower.includes("not running"))
+  );
+}
+
+function pickResult(r: ExecutionResult): Pick<ExecutionResult, "success" | "output" | "error"> {
+  return { success: r.success, output: r.output, error: r.error };
+}
+
+function issueNumberFromTrigger(triggerId: string): number | undefined {
+  const m = triggerId.match(/#(\d+)$/);
+  return m ? Number(m[1]) : undefined;
+}
+
+/** Check if a sandbox container is actually running for a given taskId prefix. */
+async function isContainerAlive(taskId: string): Promise<boolean> {
+  try {
+    const containers = await listRunningContainers();
+    return containers.some((c) => c.taskId === taskId);
+  } catch {
+    return false;
+  }
+}
+
+type RunPhaseResult =
+  | { result: ExecutionResult; executionId: string; skipped: false }
+  | { result: ExecutionResult; skipped: false }
+  | { skipped: true; reason: "running" | "done" };
+
+/**
+ * Run a single agent phase with DB-tracked deduplication. Moved verbatim from
+ * runner.ts — the dedup ledger (`shouldRunPhase`) is the single source of
+ * truth for resume, so re-running from the top skips completed phases here.
+ */
+export async function runPhase(
+  workflowName: string,
+  phaseName: string,
+  taskId: string,
+  triggerId: string,
+  prompt: string,
+  config: ExecutorConfig,
+  db?: StateDb,
+  modelOverride?: string,
+  workflowRunId?: string,
+  githubAccess?: GitSandboxAccess,
+  variantOverride?: string,
+): Promise<RunPhaseResult> {
+  const dedupKey = `${workflowName}:${phaseName}`;
+  const attrs = {
+    "workflow.name": workflowName,
+    "phase.name": phaseName,
+    "workflow.run_id": workflowRunId,
+    "trigger.id": triggerId,
+    "task.id": taskId,
+    repo: githubAccess?.repo,
+    "issue.number": issueNumberFromTrigger(triggerId),
+    "sandbox.backend": config.sandbox,
+    model: modelOverride || config.model,
+  };
+  return withSpan("lastlight.workflow.phase", attrs, async (span) => {
+    if (db) {
+      const status = db.shouldRunPhase(dedupKey, triggerId, workflowRunId);
+
+      if (status === "running") {
+        const alive = await isContainerAlive(taskId);
+        if (alive) {
+          console.log(`[runner] Phase ${phaseName} is already running (container alive) — skipping`);
+          span?.addEvent("lastlight.workflow.phase.skipped", { reason: "running" });
+          return { skipped: true, reason: "running" };
+        }
+        console.log(`[runner] Phase ${phaseName} was running but container is dead — cleaning up`);
+        db.markStaleAsFailed(dedupKey, triggerId, workflowRunId);
+      } else if (status === "done") {
+        console.log(`[runner] Phase ${phaseName} already completed successfully — skipping`);
+        span?.addEvent("lastlight.workflow.phase.skipped", { reason: "done" });
+        return { skipped: true, reason: "done" };
+      }
+
+      const executionId = randomUUID();
+      db.recordStart({
+        id: executionId,
+        triggerType: "webhook",
+        triggerId,
+        skill: dedupKey,
+        repo: githubAccess?.repo,
+        issueNumber: issueNumberFromTrigger(triggerId),
+        startedAt: new Date().toISOString(),
+        workflowRunId,
+      });
+
+      const baseConfig = modelOverride ? { ...config, model: modelOverride } : config;
+      const phaseConfigBase = variantOverride ? { ...baseConfig, variant: variantOverride } : baseConfig;
+      const phaseConfig: ExecutorConfig = {
+        ...phaseConfigBase,
+        telemetry: { workflowName, phaseName, triggerId, workflowRunId },
+      };
+      try {
+        const result = await executeAgent(prompt, phaseConfig, {
+          taskId,
+          githubAccess,
+          onSessionId: (sessionId) => {
+            try {
+              db.recordSessionId(executionId, sessionId);
+            } catch (err) {
+              console.warn(`[runner] Failed to persist session id mid-run for ${phaseName}:`, err);
+            }
+          },
+        });
+
+        db.recordFinish(executionId, {
+          success: result.success,
+          error: result.error,
+          turns: result.turns,
+          durationMs: result.durationMs,
+          sessionId: result.sessionId,
+          costUsd: result.costUsd,
+          inputTokens: result.inputTokens,
+          cacheCreationInputTokens: result.cacheCreationInputTokens,
+          cacheReadInputTokens: result.cacheReadInputTokens,
+          outputTokens: result.outputTokens,
+          apiDurationMs: result.apiDurationMs,
+          stopReason: result.stopReason,
+          extensionStatus: result.extensions ? JSON.stringify(result.extensions) : undefined,
+        });
+        span?.setAttributes({ success: result.success, stop_reason: result.stopReason ?? "unknown" });
+        recordExecutionMetrics("phase", { ...attrs, success: result.success, stop_reason: result.stopReason, durationMs: result.durationMs, costUsd: result.costUsd, inputTokens: result.inputTokens, outputTokens: result.outputTokens });
+        return { result, executionId, skipped: false };
+      } catch (err) {
+        recordError("phase", err, attrs);
+        throw err;
+      }
+    }
+
+    const baseConfig = modelOverride ? { ...config, model: modelOverride } : config;
+    const phaseConfigBase = variantOverride ? { ...baseConfig, variant: variantOverride } : baseConfig;
+    const phaseConfig: ExecutorConfig = { ...phaseConfigBase, telemetry: { workflowName, phaseName, triggerId, workflowRunId } };
+    const result = await executeAgent(prompt, phaseConfig, { taskId, githubAccess });
+    recordExecutionMetrics("phase", { ...attrs, success: result.success, stop_reason: result.stopReason, durationMs: result.durationMs, costUsd: result.costUsd, inputTokens: result.inputTokens, outputTokens: result.outputTokens });
+    return { result, skipped: false };
+  });
+}
+
+// ── PhaseExecutor ────────────────────────────────────────────────────────────
+
+const MAX_PREV_OUTPUT_BYTES = 10 * 1024; // cap accumulated generic-loop output at 10KB
+
+export class PhaseExecutor {
+  constructor(
+    private readonly run: PhaseRunContext,
+    private readonly reporter: PhaseReporter,
+    private readonly resolver: PhaseResolver,
+  ) {}
+
+  /**
+   * Execute one DAG node and return its delta. The scheduler accumulates
+   * `results` into `phases[]`, merges `outputVars` into the shared outputs
+   * map, and maps `status`/`paused`/`aborted` onto node state + run control.
+   */
+  async execute(
+    node: DagNode,
+    outputs: Readonly<Record<string, unknown>>,
+  ): Promise<PhaseOutcome> {
+    const phase = this.run.definition.phases.find((p) => p.name === node.name);
+    if (!phase) {
+      // Unknown node — shouldn't happen; treat as a no-op success.
+      return { results: [{ phase: node.name, success: true, output: "" }], status: "succeeded" };
+    }
+
+    const phaseType = phase.type ?? "agent";
+    if (phaseType === "context") return this.runContext(phase);
+
+    if (!phase.prompt && !phase.skill) {
+      console.warn(`[runner] Phase "${phase.name}" has type=agent but neither prompt: nor skill: — skipping`);
+      return { results: [], status: "succeeded" };
+    }
+
+    if (phase.loop) return this.runReviewerLoop(phase, outputs);
+    if (phase.generic_loop) return this.runGenericLoop(phase, outputs);
+    return this.runStandard(phase, outputs);
+  }
+
+  // ── Per-phase bodies ───────────────────────────────────────────────────────
+
+  private async runContext(phase: PhaseDefinition): Promise<PhaseOutcome> {
+    await this.reporter.onStart(phase.name);
+    const result: PhaseResult = { phase: phase.name, success: true, output: "Context assembled" };
+    // Persist a phase_history entry so the dashboard marks context phases done.
+    this.reporter.persistPhase(phase.name, "Context assembled");
+    await this.reporter.onEnd(phase.name, result);
+    return { results: [result], status: "succeeded" };
+  }
+
+  /** Resolve model + variant for a phase/task, honouring YAML templates first. */
+  private resolveModelVariant(
+    template: string | undefined,
+    variantTemplate: string | undefined,
+    taskName: string,
+    fallbackTask?: string,
+  ): { model?: string; variant?: string } {
+    const ctx = this.run.ctx;
+    const modelRaw = template ? renderTemplate(template, ctx) : undefined;
+    const model = modelRaw || this.resolver.modelFor(taskName)
+      || (fallbackTask ? this.resolver.modelFor(fallbackTask) : undefined);
+    const variantRaw = variantTemplate ? renderTemplate(variantTemplate, ctx) : undefined;
+    const variant = variantRaw || this.resolver.variantFor(taskName)
+      || (fallbackTask ? this.resolver.variantFor(fallbackTask) : undefined);
+    return { model, variant };
+  }
+
+  private async runPhaseCall(
+    label: string,
+    prompt: string,
+    phase: PhaseDefinition,
+    model?: string,
+    variant?: string,
+  ): Promise<RunPhaseResult> {
+    const { definition, config, db, workflowId, githubAccess, taskId, triggerId } = this.run;
+    return runPhase(
+      definition.name,
+      label,
+      taskId,
+      triggerId,
+      prompt,
+      phaseConfigFor(config, phase),
+      db,
+      model,
+      workflowId,
+      githubAccess,
+      variant,
+    );
+  }
+
+  private async runStandard(
+    phase: PhaseDefinition,
+    outputs: Readonly<Record<string, unknown>>,
+  ): Promise<PhaseOutcome> {
+    const phaseName = phase.name;
+    await this.reporter.onStart(phaseName);
+    await this.reporter.step(phaseName, "running", phase.messages?.on_start);
+
+    const { model, variant } = this.resolveModelVariant(phase.model, phase.variant, phaseName);
+    const prompt = buildPhasePrompt(phase, this.run.ctx, { phaseOutputs: outputs });
+
+    const pr = await this.runPhaseCall(phaseName, prompt, phase, model, variant);
+
+    if (pr.skipped) {
+      if (pr.reason === "running") {
+        await this.reporter.message(phase.messages?.on_skipped_done);
+        return { results: [], status: "failed", aborted: true };
+      }
+      const result: PhaseResult = { phase: phaseName, success: true, output: "Already completed" };
+      this.reporter.persistPhase(phaseName, "Already completed (deduplicated)");
+      await this.reporter.onEnd(phaseName, result);
+      await this.reporter.step(phaseName, "done", phase.messages?.on_skipped_done);
+      return { results: [result], status: "succeeded" };
+    }
+
+    const result: PhaseResult = { phase: phaseName, ...pickResult(pr.result) };
+    await this.reporter.onEnd(phaseName, result);
+
+    const rawOutput = pr.result.output ?? "";
+    const outputVars: Record<string, unknown> = { [phaseName]: rawOutput };
+    if (phase.output_var) outputVars[phase.output_var] = rawOutput;
+
+    if (!pr.result.success) {
+      if (!isTerminated(pr.result.error)) {
+        await this.reporter.step(phaseName, "failed", phase.messages?.on_failure);
+      }
+      this.reporter.failWorkflow(pr.result.error);
+      return { results: [result], status: "failed", outputVars };
+    }
+
+    // on_output rules (BLOCKED).
+    if (phase.on_output) {
+      const blocked = await this.evaluateBlocked(phase, pr.result.output ?? "");
+      if (blocked === "fail") {
+        const failResult: PhaseResult = {
+          phase: phaseName,
+          success: false,
+          output: pr.result.output ?? "",
+          error: "BLOCKED",
+        };
+        return { results: [failResult], status: "failed", outputVars };
+      }
+    }
+
+    // Approval gate.
+    if (phase.approval_gate && this.resolver.gateEnabled(phase.approval_gate) && this.run.db && this.run.workflowId) {
+      await this.pauseForApproval(
+        phaseName,
+        phase.approval_gate,
+        `${phaseName} complete — awaiting ${phase.approval_gate} approval.`,
+        "approve",
+        phase.approval_gate_message,
+        { gateKey: phase.approval_gate },
+      );
+      return { results: [result], status: "succeeded", paused: true, outputVars };
+    }
+
+    this.reporter.persistPhase(phaseName);
+    await this.reporter.step(phaseName, "done", phase.messages?.on_success);
+    return { results: [result], status: "succeeded", outputVars };
+  }
+
+  /**
+   * Evaluate the `contains_BLOCKED` rule. Returns "fail" when the workflow
+   * should fail, or "continue" when the marker is absent or bypassed.
+   */
+  private async evaluateBlocked(
+    phase: PhaseDefinition,
+    output: string,
+  ): Promise<"fail" | "continue"> {
+    const rule = phase.on_output?.contains_BLOCKED;
+    if (!rule) return "continue";
+    if (!output.toUpperCase().includes("BLOCKED")) return "continue";
+
+    const ctx = this.run.ctx;
+    const hasUnlessLabel = rule.unless_label && ctx.issueLabels.includes(rule.unless_label);
+    const titleMatches = (() => {
+      if (!rule.unless_title_matches) return false;
+      if (rule.unless_title_matches.length > 200) return false;
+      if (/[+*]\{0,\}.*[+*]/.test(rule.unless_title_matches) || /(\([^)]*[+*][^)]*\))[+*?]/.test(rule.unless_title_matches)) return false;
+      try {
+        return new RegExp(rule.unless_title_matches, "i").test(ctx.issueTitle || "");
+      } catch {
+        return false;
+      }
+    })();
+
+    if (hasUnlessLabel || titleMatches) {
+      await this.reporter.message(rule.bypass_message || phase.messages?.on_blocked_bypassed);
+      return "continue";
+    }
+    if (rule.action === "fail") {
+      this.run.db?.markLatestAsFailed(
+        `${this.run.definition.name}:${phase.name}`,
+        this.run.triggerId,
+        rule.message || "BLOCKED",
+        this.run.workflowId,
+      );
+      this.reporter.failWorkflow(rule.message || "BLOCKED");
+      const blockedTemplate = rule.message || phase.messages?.on_blocked;
+      if (blockedTemplate) await this.reporter.step(phase.name, "blocked", blockedTemplate);
+      return "fail";
+    }
+    return "continue";
+  }
+
+  /** Persist + pause for an approval/reply gate. */
+  private async pauseForApproval(
+    stepKey: string,
+    gate: string,
+    summary: string,
+    kind: "approve" | "reply",
+    message: string | undefined,
+    extraCtx: Partial<TemplateContext>,
+  ): Promise<void> {
+    const { db, workflowId, ctx } = this.run;
+    if (!db || !workflowId) return;
+    const approvalId = randomUUID();
+    db.createApproval({
+      id: approvalId,
+      workflowRunId: workflowId,
+      gate,
+      summary,
+      kind,
+      requestedBy: ctx.sender,
+      createdAt: new Date().toISOString(),
+    });
+    db.updateWorkflowPhase(workflowId, "waiting_approval", {
+      phase: "waiting_approval",
+      timestamp: new Date().toISOString(),
+      success: true,
+      summary: `Waiting for ${kind === "reply" ? "reply" : "approval"}: ${gate} (${approvalId})`,
+    });
+    db.pauseWorkflowRun(workflowId);
+    await this.reporter.step(stepKey, "awaiting", message, extraCtx, { alsoNote: true });
+  }
+
+  private async runReviewerLoop(
+    phase: PhaseDefinition,
+    outputs: Readonly<Record<string, unknown>>,
+  ): Promise<PhaseOutcome> {
+    const loop = phase.loop!;
+    const phaseName = phase.name;
+    const MAX_CYCLES = loop.max_cycles;
+    const results: PhaseResult[] = [];
+    let approved = false;
+    let fixCycles = 0;
+
+    while (!approved && fixCycles <= MAX_CYCLES) {
+      const reviewLabel =
+        fixCycles === 0
+          ? PhaseRef.review(phaseName).format()
+          : PhaseRef.recheck(phaseName, fixCycles).format();
+
+      await this.reporter.onStart(reviewLabel);
+      await this.reporter.step(
+        reviewLabel,
+        "running",
+        loop.messages?.on_cycle_start,
+        { cycle: fixCycles + 1, maxCycles: MAX_CYCLES },
+        fixCycles === 0
+          ? undefined
+          : { insert: true, label: `${phase.label ?? phaseName} (cycle ${fixCycles + 1})` },
+      );
+
+      const reviewPrompt =
+        fixCycles === 0
+          ? buildPhasePrompt(phase, this.run.ctx, { phaseOutputs: outputs, fixCycle: fixCycles })
+          : this.resolver.renderPrompt(loop.on_request_changes.re_review_prompt, { phaseOutputs: outputs, fixCycle: fixCycles });
+
+      const { model, variant } = this.resolveModelVariant(phase.model, phase.variant, phaseName);
+      const rr = await this.runPhaseCall(reviewLabel, reviewPrompt, phase, model, variant);
+
+      if (rr.skipped) {
+        if (rr.reason === "running") {
+          await this.reporter.message(phase.messages?.on_skipped_done);
+          return { results, status: "failed", aborted: true };
+        }
+        approved = true;
+        results.push({ phase: reviewLabel, success: true, output: "Already completed" });
+        break;
+      }
+
+      results.push({ phase: reviewLabel, ...pickResult(rr.result) });
+      await this.reporter.onEnd(reviewLabel, results[results.length - 1]);
+
+      const reviewerOutput = (rr.result.output || "").trim();
+      const { verdict, viaFallback } = parseReviewerVerdict(reviewerOutput);
+      const isApproved = verdict === "APPROVED";
+      if (viaFallback) {
+        console.warn(
+          `[runner] Reviewer output missing VERDICT: marker — using fallback detection (isApproved=${isApproved})`,
+        );
+      }
+
+      if (isApproved) {
+        approved = true;
+        this.reporter.persistPhase(reviewLabel, "APPROVED");
+        await this.reporter.step(reviewLabel, "done", loop.messages?.on_approved, { cycle: fixCycles + 1 });
+      } else if (fixCycles < MAX_CYCLES) {
+        fixCycles++;
+        this.reporter.persistPhase(reviewLabel, "REQUEST_CHANGES");
+
+        // Approval gate before the fix loop.
+        if (this.resolver.gateEnabled(loop.approval_gate) && this.run.db && this.run.workflowId) {
+          await this.pauseForApproval(
+            reviewLabel,
+            loop.approval_gate!,
+            `Reviewer requested changes (cycle ${fixCycles}/${MAX_CYCLES}) on phase ${phaseName}.`,
+            "approve",
+            loop.messages?.on_pause_for_approval,
+            { cycle: fixCycles, maxCycles: MAX_CYCLES, gateKey: loop.approval_gate },
+          );
+          return { results, status: "succeeded", paused: true };
+        }
+
+        await this.reporter.step(reviewLabel, "done", loop.messages?.on_request_changes, {
+          cycle: fixCycles,
+          maxCycles: MAX_CYCLES,
+        });
+
+        // Fix phase.
+        const fixLabel = PhaseRef.fix(phaseName, fixCycles).format();
+        await this.reporter.onStart(fixLabel);
+        await this.reporter.step(
+          fixLabel,
+          "running",
+          loop.messages?.on_fix_start,
+          { cycle: fixCycles, maxCycles: MAX_CYCLES },
+          { insert: true, label: `Fix (cycle ${fixCycles})` },
+        );
+
+        const { model: fixModel, variant: fixVariant } = this.resolveModelVariant(
+          loop.on_request_changes.fix_model,
+          loop.on_request_changes.fix_variant,
+          `${phaseName}_fix`,
+          phaseName,
+        );
+        const fixPromptRendered = this.resolver.renderPrompt(loop.on_request_changes.fix_prompt, {
+          phaseOutputs: outputs,
+          fixCycle: fixCycles,
+        });
+
+        const fr = await this.runPhaseCall(fixLabel, fixPromptRendered, phase, fixModel, fixVariant);
+
+        if (fr.skipped) {
+          if (fr.reason === "running") {
+            await this.reporter.message(phase.messages?.on_skipped_done);
+            return { results, status: "failed", aborted: true };
+          }
+          results.push({ phase: fixLabel, success: true, output: "Already completed" });
+        } else {
+          results.push({ phase: fixLabel, ...pickResult(fr.result) });
+          await this.reporter.onEnd(fixLabel, results[results.length - 1]);
+
+          if (!fr.result.success) {
+            if (!isTerminated(fr.result.error)) {
+              await this.reporter.step(fixLabel, "failed", loop.messages?.on_fix_failed, {
+                cycle: fixCycles,
+                maxCycles: MAX_CYCLES,
+              });
+            }
+            break;
+          }
+          this.reporter.persistPhase(fixLabel);
+          await this.reporter.step(fixLabel, "done");
+        }
+      } else {
+        this.reporter.persistPhase(reviewLabel, "REQUEST_CHANGES — max cycles reached");
+        await this.reporter.step(reviewLabel, "blocked", loop.messages?.on_max_cycles, {
+          cycle: fixCycles,
+          maxCycles: MAX_CYCLES,
+        }, { alsoNote: true });
+        break;
+      }
+    }
+
+    const outputVars: Record<string, unknown> = {};
+    if (phase.output_var) outputVars[phase.output_var] = { approved, cycles: fixCycles };
+    // The loop node itself succeeds as a scheduling unit — even at max cycles
+    // the linear runner continued to the next phase. Individual review/fix
+    // results carry their own success flags for the run-level rollup.
+    return { results, status: "succeeded", outputVars };
+  }
+
+  private async runGenericLoop(
+    phase: PhaseDefinition,
+    outputs: Readonly<Record<string, unknown>>,
+  ): Promise<PhaseOutcome> {
+    const loop = phase.generic_loop!;
+    const phaseName = phase.name;
+    const MAX_ITER = loop.max_iterations;
+    const { db, workflowId, scratch, config } = this.run;
+    const results: PhaseResult[] = [];
+
+    // Reply-gate loops resume mid-flight: read the saved iteration from scratch.
+    const scratchKey = loop.scratch_key;
+    const scratchSlot = (scratchKey
+      ? (scratch[scratchKey] as Record<string, unknown> | undefined) ?? {}
+      : {}) as Record<string, unknown>;
+    const resumeFromIter =
+      loop.gate_kind === "reply" && typeof scratchSlot.iteration === "number"
+        ? Math.min(scratchSlot.iteration as number, MAX_ITER)
+        : 0;
+
+    let iteration = resumeFromIter;
+    let complete = false;
+    let previousOutput =
+      (scratchSlot.lastOutputExecutionId && db
+        ? db.getExecutionOutput(scratchSlot.lastOutputExecutionId as string) ?? ""
+        : (scratchSlot.lastOutput as string | undefined) ?? "");
+
+    await this.reporter.step(phaseName, "running");
+
+    while (!complete && iteration < MAX_ITER) {
+      iteration++;
+      const iterLabel = PhaseRef.iter(phaseName, iteration).format();
+      await this.reporter.onStart(iterLabel);
+
+      const iterCtx: Partial<TemplateContext> = {
+        iteration,
+        maxIterations: MAX_ITER,
+        previousOutput: loop.fresh_context ? "" : previousOutput,
+        phaseOutputs: outputs,
+        scratch,
+      };
+      const prompt = buildPhasePrompt(phase, this.run.ctx, iterCtx);
+      const { model, variant } = this.resolveModelVariant(phase.model, phase.variant, phaseName);
+
+      const ir = await this.runPhaseCall(iterLabel, prompt, phase, model, variant);
+
+      if (ir.skipped) {
+        if (ir.reason === "running") {
+          await this.reporter.message(phase.messages?.on_skipped_done, { iteration });
+          return { results, status: "failed", aborted: true };
+        }
+        results.push({ phase: iterLabel, success: true, output: "Already completed" });
+        complete = true;
+        break;
+      }
+
+      results.push({ phase: iterLabel, ...pickResult(ir.result) });
+      await this.reporter.onEnd(iterLabel, results[results.length - 1]);
+
+      if (!ir.result.success) {
+        if (!isTerminated(ir.result.error)) {
+          await this.reporter.step(phaseName, "failed", phase.messages?.on_failure, { iteration });
+        }
+        this.reporter.failWorkflow(ir.result.error);
+        const outputVars = phase.output_var
+          ? { [phase.output_var]: { completed: false, iterations: iteration } }
+          : undefined;
+        return { results, status: "failed", outputVars };
+      }
+
+      const iterOutput = ir.result.output || "";
+      if (!loop.fresh_context) {
+        const combined = previousOutput ? `${previousOutput}\n${iterOutput}` : iterOutput;
+        previousOutput = combined.length > MAX_PREV_OUTPUT_BYTES ? combined.slice(-MAX_PREV_OUTPUT_BYTES) : combined;
+      }
+
+      let conditionMet = false;
+      if (loop.until) {
+        conditionMet = evalUntilExpression(loop.until, {
+          output: iterOutput,
+          scratch,
+          ...Object.fromEntries(
+            Object.entries(this.run.ctx)
+              .filter(([, v]) => typeof v === "string")
+              .map(([k, v]) => [k, v as string]),
+          ),
+        });
+      }
+      if (!conditionMet && loop.until_bash) {
+        try {
+          validateShellCommand(loop.until_bash);
+          execSync(loop.until_bash, { timeout: 30_000, stdio: "pipe", cwd: config.sandboxDir ?? config.cwd });
+          conditionMet = true;
+        } catch {
+          conditionMet = false;
+        }
+      }
+
+      const iterExecutionId = "executionId" in ir ? ir.executionId : undefined;
+      if (iterExecutionId && db) db.recordOutputText(iterExecutionId, iterOutput);
+
+      if (conditionMet) {
+        complete = true;
+        if (scratchKey && db && workflowId) {
+          const slot: Record<string, unknown> = { ...scratchSlot, iteration, ready: true };
+          if (iterExecutionId) slot.lastOutputExecutionId = iterExecutionId;
+          delete slot.lastOutput;
+          db.updateWorkflowRunScratch(workflowId, { [scratchKey]: slot });
+          scratch[scratchKey] = slot;
+        }
+        this.reporter.persistPhase(iterLabel, `iteration ${iteration} — condition met`);
+        await this.reporter.step(phaseName, "done");
+        break;
+      }
+
+      // Interactive gate between iterations.
+      if (loop.interactive && !complete && db && workflowId) {
+        const isReply = loop.gate_kind === "reply";
+        const gateMsg = loop.gate_message
+          ? renderTemplate(loop.gate_message, { ...this.run.ctx, phaseOutputs: outputs, iteration, maxIterations: MAX_ITER, scratch })
+          : `Loop iteration ${iteration}/${MAX_ITER} complete.`;
+
+        if (scratchKey) {
+          const slot: Record<string, unknown> = {
+            ...(scratch[scratchKey] as Record<string, unknown> | undefined),
+            iteration,
+          };
+          if (iterExecutionId) slot.lastOutputExecutionId = iterExecutionId;
+          delete slot.lastOutput;
+          scratch[scratchKey] = slot;
+          db.updateWorkflowRunScratch(workflowId, { [scratchKey]: slot });
+        }
+
+        const approvalId = randomUUID();
+        db.createApproval({
+          id: approvalId,
+          workflowRunId: workflowId,
+          gate: iterLabel,
+          summary: gateMsg,
+          kind: isReply ? "reply" : "approve",
+          requestedBy: this.run.ctx.sender,
+          createdAt: new Date().toISOString(),
+        });
+        db.updateWorkflowPhase(workflowId, "waiting_approval", {
+          phase: "waiting_approval",
+          timestamp: new Date().toISOString(),
+          success: true,
+          summary: `Waiting for ${isReply ? "reply" : "approval"}: ${iterLabel} (${approvalId})`,
+        });
+        db.pauseWorkflowRun(workflowId);
+        await this.reporter.step(phaseName, "awaiting");
+
+        if (isReply) {
+          const parts = [iterOutput.trim(), gateMsg.trim()].filter(Boolean);
+          if (parts.length > 0) await this.reporter.postNote(parts.join("\n\n---\n\n"));
+        } else {
+          await this.reporter.postNote(
+            `**${phaseName} iteration ${iteration}/${MAX_ITER} complete** — approval required to continue.\n\n` +
+              `${gateMsg}\n\n` +
+              `**To continue:** comment \`@last-light approve\`\n` +
+              `**To abort:** comment \`@last-light reject [reason]\``,
+          );
+        }
+        return { results, status: "succeeded", paused: true };
+      }
+
+      this.reporter.persistPhase(iterLabel);
+    }
+
+    if (!complete) {
+      await this.reporter.step(phaseName, "failed", phase.messages?.on_failure, {
+        iteration,
+        maxIterations: MAX_ITER,
+      });
+    }
+
+    const outputVars = phase.output_var
+      ? { [phase.output_var]: { completed: complete, iterations: iteration } }
+      : undefined;
+    return { results, status: "succeeded", outputVars };
+  }
+}
+
+// Keep a re-export path stable for any external consumer of these helpers.
+export type { ProgressStep };

--- a/src/workflows/phase-executor.ts
+++ b/src/workflows/phase-executor.ts
@@ -582,9 +582,20 @@ export class PhaseExecutor {
     const loop = phase.loop!;
     const phaseName = phase.name;
     const MAX_CYCLES = loop.max_cycles;
+    const { db, workflowId, triggerId, scratch } = this.run;
+    const wf = this.run.definition.name;
     const results: PhaseResult[] = [];
     let approved = false;
     let fixCycles = 0;
+
+    // Loop resume state. When the loop pauses at `loop.approval_gate` after a
+    // REQUEST_CHANGES verdict, we persist the cycle we paused at so that on
+    // resume we can tell "approved — continue with the fix cycle" apart from
+    // "review approved → done". Without this, a dedup-`done` review on resume
+    // would be misread as APPROVED and skip the required fix. (#94 follow-up)
+    const loopKey = `rloop:${phaseName}`;
+    const slot = (scratch[loopKey] as Record<string, unknown> | undefined) ?? {};
+    const pausedAtCycle = typeof slot.pausedAtCycle === "number" ? slot.pausedAtCycle : undefined;
 
     while (!approved && fixCycles <= MAX_CYCLES) {
       const reviewLabel =
@@ -611,47 +622,65 @@ export class PhaseExecutor {
       const { model, variant } = this.resolveModelVariant(phase.model, phase.variant, phaseName);
       const rr = await this.runPhaseCall(reviewLabel, reviewPrompt, phase, model, variant);
 
+      // Derive this review's verdict. A dedup-`done` review (resume) is NOT
+      // assumed approved — re-parse the verdict from its persisted output.
+      let verdict: string | undefined;
+      const reviewRan = !rr.skipped;
       if (rr.skipped) {
         if (rr.reason === "running") {
           await this.reporter.message(phase.messages?.on_skipped_done);
           return { results, status: "failed", aborted: true };
         }
-        approved = true;
+        const prevOutput = db?.getPhaseOutput(`${wf}:${reviewLabel}`, triggerId, workflowId) ?? "";
+        verdict = parseReviewerVerdict(prevOutput).verdict;
         results.push({ phase: reviewLabel, success: true, output: "Already completed" });
-        break;
+      } else {
+        results.push({ phase: reviewLabel, ...pickResult(rr.result) });
+        await this.reporter.onEnd(reviewLabel, results[results.length - 1]);
+        const reviewerOutput = (rr.result.output || "").trim();
+        const parsed = parseReviewerVerdict(reviewerOutput);
+        verdict = parsed.verdict;
+        if (parsed.viaFallback) {
+          console.warn(
+            `[runner] Reviewer output missing VERDICT: marker — using fallback detection (isApproved=${verdict === "APPROVED"})`,
+          );
+        }
+        // Persist the review output so a resumed run can re-derive this verdict.
+        const execId = "executionId" in rr ? rr.executionId : undefined;
+        if (execId && db) db.recordOutputText(execId, reviewerOutput);
       }
 
-      results.push({ phase: reviewLabel, ...pickResult(rr.result) });
-      await this.reporter.onEnd(reviewLabel, results[results.length - 1]);
-
-      const reviewerOutput = (rr.result.output || "").trim();
-      const { verdict, viaFallback } = parseReviewerVerdict(reviewerOutput);
       const isApproved = verdict === "APPROVED";
-      if (viaFallback) {
-        console.warn(
-          `[runner] Reviewer output missing VERDICT: marker — using fallback detection (isApproved=${isApproved})`,
-        );
-      }
 
       if (isApproved) {
         approved = true;
-        this.reporter.persistPhase(reviewLabel, "APPROVED");
+        if (reviewRan) this.reporter.persistPhase(reviewLabel, "APPROVED");
         await this.reporter.step(reviewLabel, "done", loop.messages?.on_approved, { cycle: fixCycles + 1 });
       } else if (fixCycles < MAX_CYCLES) {
         fixCycles++;
-        this.reporter.persistPhase(reviewLabel, "REQUEST_CHANGES");
+        if (reviewRan) this.reporter.persistPhase(reviewLabel, "REQUEST_CHANGES");
 
-        // Approval gate before the fix loop.
-        if (this.resolver.gateEnabled(loop.approval_gate) && this.run.db && this.run.workflowId) {
-          await this.pauseForApproval(
-            reviewLabel,
-            loop.approval_gate!,
-            `Reviewer requested changes (cycle ${fixCycles}/${MAX_CYCLES}) on phase ${phaseName}.`,
-            "approve",
-            loop.messages?.on_pause_for_approval,
-            { cycle: fixCycles, maxCycles: MAX_CYCLES, gateKey: loop.approval_gate },
-          );
-          return { results, status: "succeeded", paused: true };
+        // Approval gate before the fix loop. Pause only on a *fresh* gate hit:
+        // not when the fix for this cycle has already run (gate was approved in
+        // a prior entry), and not when we're resuming right after approving
+        // exactly this cycle's gate.
+        if (this.resolver.gateEnabled(loop.approval_gate) && db && workflowId) {
+          const fixLabel = PhaseRef.fix(phaseName, fixCycles).format();
+          const fixAlreadyDone = db.shouldRunPhase(`${wf}:${fixLabel}`, triggerId, workflowId) === "done";
+          const resumingThisGate = pausedAtCycle === fixCycles;
+          if (!fixAlreadyDone && !resumingThisGate) {
+            scratch[loopKey] = { ...slot, pausedAtCycle: fixCycles };
+            db.updateWorkflowRunScratch(workflowId, { [loopKey]: scratch[loopKey] });
+            await this.pauseForApproval(
+              reviewLabel,
+              loop.approval_gate!,
+              `Reviewer requested changes (cycle ${fixCycles}/${MAX_CYCLES}) on phase ${phaseName}.`,
+              "approve",
+              loop.messages?.on_pause_for_approval,
+              { cycle: fixCycles, maxCycles: MAX_CYCLES, gateKey: loop.approval_gate },
+            );
+            return { results, status: "succeeded", paused: true };
+          }
         }
 
         await this.reporter.step(reviewLabel, "done", loop.messages?.on_request_changes, {

--- a/src/workflows/phase-ref.test.ts
+++ b/src/workflows/phase-ref.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { PhaseRef, phaseIndexInDefinition, nextPhaseAfter } from "./phase-ref.js";
-import type { AgentWorkflowDefinition } from "./schema.js";
-
-const def = (...names: string[]): AgentWorkflowDefinition =>
-  ({ phases: names.map((name) => ({ name })) }) as AgentWorkflowDefinition;
+import { PhaseRef } from "./phase-ref.js";
 
 describe("PhaseRef.format — the single label authority", () => {
   it("pins the literal generated label strings", () => {
@@ -14,42 +10,18 @@ describe("PhaseRef.format — the single label authority", () => {
   });
 });
 
-describe("phaseIndexInDefinition — definition-aware resolution", () => {
-  const definition = def("architect", "executor", "reviewer", "pr");
-
-  it("round-trips every generated label back to its base phase", () => {
-    for (const ref of [
-      PhaseRef.review("reviewer"),
-      PhaseRef.fix("reviewer", 2),
-      PhaseRef.recheck("reviewer", 2),
-      PhaseRef.iter("reviewer", 3),
-    ]) {
-      expect(phaseIndexInDefinition(definition, ref.format())).toBe(2);
-    }
+describe("PhaseRef.parse — round-trips generated labels back to base + kind", () => {
+  it("parses each generated suffix", () => {
+    expect(PhaseRef.parse("reviewer_fix_2")).toMatchObject({ base: "reviewer", kind: "fix", index: 2 });
+    expect(PhaseRef.parse("reviewer_recheck_2")).toMatchObject({ base: "reviewer", kind: "recheck", index: 2 });
+    expect(PhaseRef.parse("reviewer_iter_3")).toMatchObject({ base: "reviewer", kind: "iter", index: 3 });
   });
 
-  it("prefers an exact literal phase name over suffix-stripping", () => {
-    const literal = def("reviewer", "reviewer_fix_1");
-    expect(phaseIndexInDefinition(literal, "reviewer_fix_1")).toBe(1);
+  it("parses a bare declared name as a plain phase", () => {
+    expect(PhaseRef.parse("reviewer")).toMatchObject({ base: "reviewer", kind: "phase" });
   });
 
-  it("resolves the dropped legacy reviewer_2 form to -1", () => {
-    expect(phaseIndexInDefinition(definition, "reviewer_2")).toBe(-1);
-  });
-
-  it("returns -1 for unknown / untracked labels", () => {
-    expect(phaseIndexInDefinition(definition, "waiting_approval")).toBe(-1);
-  });
-});
-
-describe("nextPhaseAfter", () => {
-  const definition = def("architect", "executor", "reviewer", "pr");
-
-  it("steps to the next declared phase, even from a generated label", () => {
-    expect(nextPhaseAfter(definition, "reviewer_recheck_1")).toBe("pr");
-  });
-
-  it("returns null at the end of the workflow", () => {
-    expect(nextPhaseAfter(definition, "pr")).toBeNull();
+  it("parses the dropped legacy reviewer_2 form as a plain phase (not a recheck)", () => {
+    expect(PhaseRef.parse("reviewer_2")).toMatchObject({ base: "reviewer_2", kind: "phase" });
   });
 });

--- a/src/workflows/phase-ref.ts
+++ b/src/workflows/phase-ref.ts
@@ -5,8 +5,8 @@
  * A workflow phase named in the YAML (e.g. `reviewer`) keeps that bare name for
  * its initial run. When a reviewer loop fixes-and-rechecks, or a generic loop
  * iterates, the runner mints a derived label. `PhaseRef.format()` is the ONLY
- * place those derived strings are constructed, and `phaseIndexInDefinition`
- * resolves them back to the declared phase.
+ * place those derived strings are constructed, and `PhaseRef.parse()` resolves
+ * them back to their base phase + kind.
  *
  * Scheme (post-#93):
  *
@@ -19,8 +19,6 @@
  * legacy bare-numeric re-review form (`reviewer_2`) is dropped entirely — it is
  * neither produced nor recognized.
  */
-
-import type { AgentWorkflowDefinition } from "./schema.js";
 
 export type PhaseKind = "phase" | "fix" | "recheck" | "iter";
 
@@ -79,42 +77,4 @@ export class PhaseRef {
     if (m) return new PhaseRef(m[1], "iter", Number(m[2]));
     return new PhaseRef(label, "phase");
   }
-}
-
-/**
- * Resolve a recorded phase name to its index in `definition.phases`.
- *
- * Definition-aware and **exact-match-first**: a phase literally named like a
- * generated label (e.g. a YAML phase actually called `reviewer_fix_1`) wins
- * over suffix-stripping. Only when no exact match exists do we strip a
- * generated suffix and resolve to the base phase.
- *
- * Returns -1 when the name doesn't match any phase — unknown/untracked labels
- * (`waiting_approval`, user `set_phase` values like `complete`) and the dropped
- * legacy `reviewer_2` form all land here.
- */
-export function phaseIndexInDefinition(
-  definition: AgentWorkflowDefinition,
-  name: string,
-): number {
-  const exact = definition.phases.findIndex((p) => p.name === name);
-  if (exact >= 0) return exact;
-
-  const ref = PhaseRef.parse(name);
-  if (ref.kind === "phase") return -1;
-  return definition.phases.findIndex((p) => p.name === ref.base);
-}
-
-/**
- * Given the phase the runner last completed, return the name of the phase the
- * runner should run next. Returns `null` when there is no next phase (i.e. the
- * workflow is done).
- */
-export function nextPhaseAfter(
-  definition: AgentWorkflowDefinition,
-  completedPhase: string,
-): string | null {
-  const idx = phaseIndexInDefinition(definition, completedPhase);
-  if (idx < 0 || idx >= definition.phases.length - 1) return null;
-  return definition.phases[idx + 1].name;
 }

--- a/src/workflows/runner.test.ts
+++ b/src/workflows/runner.test.ts
@@ -234,8 +234,12 @@ describe("runWorkflow — guardrails on_output rules", () => {
 
     expect(result.success).toBe(false);
     expect(comments.some((c) => c.includes("BLOCKED"))).toBe(true);
-    // architect should not have run
-    expect(result.phases.map((p) => p.phase)).not.toContain("architect");
+    // architect's agent must not have run — only guardrails was dispatched.
+    expect(mockExecuteAgent).toHaveBeenCalledTimes(1);
+    // Under the unified scheduler a failed phase cascades downstream as a skip,
+    // recorded in phases[] rather than omitted.
+    const architect = result.phases.find((p) => p.phase === "architect");
+    expect(architect?.output).toContain("Skipped");
   });
 
   it("bypasses BLOCKED for bootstrap tasks (by label)", async () => {
@@ -388,6 +392,7 @@ function makeMockDb(currentPhase = "phase_0"): StateDb {
     shouldRunPhase: vi.fn(() => "run"),
     recordStart: vi.fn(),
     recordFinish: vi.fn(),
+    recordSkippedPhase: vi.fn(),
     recordOutputText: vi.fn(),
     getExecutionOutput: vi.fn(() => null),
     markStaleAsFailed: vi.fn(),
@@ -434,10 +439,13 @@ describe("runWorkflow — approval gate", () => {
     expect(result.phases.map((p) => p.phase)).not.toContain("executor");
   });
 
-  it("resumes from executor after post_architect gate approval (currentPhase=architect in DB)", async () => {
-    // Simulate what simple.ts does after approval: update currentPhase to the
-    // gate-owning phase ("architect") so nextPhaseAfter lands on "executor".
+  it("resumes past an approved gate via the executions ledger (architect already done)", async () => {
+    // Ledger-driven resume: architect's execution row is success=1 ("done"),
+    // so runPhase skips it and the gate isn't re-hit — executor + pr run.
     const db = makeMockDb("architect");
+    vi.mocked(db.shouldRunPhase).mockImplementation((skill: string) =>
+      skill === "gated:architect" ? "done" : "run",
+    );
     const approvalConfig: ApprovalGateConfig = { post_architect: true };
 
     mockExecuteAgent
@@ -455,11 +463,10 @@ describe("runWorkflow — approval gate", () => {
       "wf-gate-1",
     );
 
-    // Not paused — gate phase (architect) was skipped, executor and pr ran
+    // Not paused — architect was deduped (done), executor and pr ran.
     expect(result.paused).toBeUndefined();
     expect(result.success).toBe(true);
     expect(result.prNumber).toBe(5);
-    // Only executor + pr ran (architect skipped by shouldRun check)
     expect(mockExecuteAgent).toHaveBeenCalledTimes(2);
   });
 
@@ -905,7 +912,7 @@ describe("runWorkflow — DAG parallel execution", () => {
     expect(mockExecuteAgent).toHaveBeenCalledTimes(4);
   });
 
-  it("runs executor_a and executor_b concurrently (both called)", async () => {
+  it("runs every ready node sequentially in declaration order", async () => {
     mockExecuteAgent.mockResolvedValue(makeSuccessResult("done"));
 
     const started: string[] = [];
@@ -914,9 +921,9 @@ describe("runWorkflow — DAG parallel execution", () => {
     });
 
     expect(result.success).toBe(true);
-    expect(started).toContain("executor_a");
-    expect(started).toContain("executor_b");
-    expect(started).toContain("merge");
+    // Sequential, declaration order — the two independent executors no longer
+    // run in parallel; the earliest-declared ready node goes first.
+    expect(started).toEqual(["phase_0", "architect", "executor_a", "executor_b", "merge"]);
   });
 
   it("skips downstream nodes when upstream fails (all_success rule)", async () => {
@@ -980,7 +987,34 @@ describe("runWorkflow — DAG parallel execution", () => {
     expect(mockExecuteAgent).toHaveBeenCalledTimes(2); // architect + executor
   });
 
-  it.todo("placeholder for future DAG tests");
+  it("uses ONE shared workspace (taskId) for every phase of a DAG run", async () => {
+    mockExecuteAgent.mockResolvedValue(makeSuccessResult());
+
+    await runWorkflow(PARALLEL_WORKFLOW, BASE_CTX, {} as never, {});
+
+    // Every executeAgent call carries the same taskId — the per-phase
+    // `${taskId}-${phaseName}` clones of the old DAG runner are gone.
+    const taskIds = mockExecuteAgent.mock.calls.map((c) => (c[2] as { taskId: string }).taskId);
+    expect(taskIds.length).toBe(4);
+    expect(new Set(taskIds)).toEqual(new Set([BASE_CTX.taskId]));
+  });
+
+  it("records skipped phases in the executions ledger", async () => {
+    mockExecuteAgent
+      .mockResolvedValueOnce(makeSuccessResult("architect done"))
+      .mockResolvedValueOnce(makeFailResult("executor_a exploded"))
+      .mockResolvedValue(makeSuccessResult("done"));
+
+    const db = makeMockDb("phase_0");
+    const recordSkipped = vi.fn();
+    (db as unknown as { recordSkippedPhase: typeof recordSkipped }).recordSkippedPhase = recordSkipped;
+
+    await runWorkflow(PARALLEL_WORKFLOW, BASE_CTX, {} as never, {}, db, undefined, undefined, "wf-skip-1");
+
+    // merge is skipped (executor_a failed) → one skip row in the ledger.
+    const skippedSkills = recordSkipped.mock.calls.map((c) => c[0]);
+    expect(skippedSkills).toContain("parallel-test:merge");
+  });
 });
 
 describe("runWorkflow — definition-driven resume + YAML messages", () => {
@@ -1000,19 +1034,27 @@ describe("runWorkflow — definition-driven resume + YAML messages", () => {
         { name: "ship", type: "agent", prompt: "prompts/ship.md" },
       ],
     };
-    // Simulate the DB row saying we already completed "plan" → resume from "implement"
+    // Ledger-driven resume: discover + plan are already done; implement + ship
+    // still need to run. The runner re-runs from the top and dedups the
+    // completed phases via shouldRunPhase.
     const db = makeMockDb("plan");
+    const done = new Set(["custom:discover", "custom:plan"]);
+    vi.mocked(db.shouldRunPhase).mockImplementation((skill: string) =>
+      done.has(skill) ? "done" : "run",
+    );
     mockExecuteAgent
       .mockResolvedValueOnce(makeSuccessResult("implement done"))
       .mockResolvedValueOnce(makeSuccessResult("ship done"));
 
     const result = await runWorkflow(workflow, BASE_CTX, {} as never, {}, db, undefined, undefined, "wf-custom-resume");
     expect(result.success).toBe(true);
+    // Only implement + ship actually dispatched an agent — discover + plan deduped.
     expect(mockExecuteAgent).toHaveBeenCalledTimes(2);
-    const phaseNames = result.phases.map((p) => p.phase);
-    expect(phaseNames).toEqual(expect.arrayContaining(["implement", "ship"]));
-    expect(phaseNames).not.toContain("discover");
-    expect(phaseNames).not.toContain("plan");
+    const startedSkills = vi.mocked(db.recordStart).mock.calls.map((c) => c[0].skill);
+    expect(startedSkills).toContain("custom:implement");
+    expect(startedSkills).toContain("custom:ship");
+    expect(startedSkills).not.toContain("custom:discover");
+    expect(startedSkills).not.toContain("custom:plan");
   });
 
   it("renders phase.messages.on_start through the template engine", async () => {

--- a/src/workflows/runner.ts
+++ b/src/workflows/runner.ts
@@ -1,135 +1,29 @@
-import { randomUUID } from "crypto";
-import { execSync } from "child_process";
 import type {
   ExecutorConfig,
-  ExecutionResult,
   GitAccessProfile,
   GitSandboxAccess,
 } from "../engine/profiles.js";
-import { executeAgent } from "../engine/agent-executor.js";
 import type { StateDb } from "../state/db.js";
 import type { PhaseHistoryEntry } from "../state/db.js";
 import type { ModelConfig, VariantConfig } from "../config.js";
 import { resolveModel, resolveVariant } from "../config.js";
-import { listRunningContainers } from "../admin/docker.js";
-import type { AgentWorkflowDefinition, PhaseDefinition } from "./schema.js";
-import { phaseSkillNames } from "./schema.js";
-import { loadPromptTemplate, resolveSkillPaths } from "./loader.js";
+import type { AgentWorkflowDefinition } from "./schema.js";
+import { loadPromptTemplate } from "./loader.js";
 import { renderTemplate, type TemplateContext } from "./templates.js";
-import { evalUntilExpression } from "./loop-eval.js";
-import { parseReviewerVerdict } from "./verdict.js";
-import { PhaseRef, phaseIndexInDefinition, nextPhaseAfter } from "./phase-ref.js";
 import { buildDag, getReadyNodes, getNodesToSkip, isComplete } from "./dag.js";
+import {
+  PhaseExecutor,
+  isTerminated,
+  type PhaseReporter,
+  type PhaseResolver,
+  type PhaseRunContext,
+  type ReportStepOpts,
+} from "./phase-executor.js";
 import type { ProgressReporter, StepStatus, ProgressStep } from "../notify/types.js";
-import { recordError, recordExecutionMetrics, withSpan } from "../telemetry/index.js";
 import { collapseDetail } from "../notify/render.js";
 
-/**
- * Reject shell commands containing mustache template markers to prevent
- * accidental template injection into until_bash values.
- */
-function validateShellCommand(cmd: string): void {
-  if (cmd.includes("{{")) {
-    throw new Error(`until_bash command rejected: contains template marker '{{'. Render templates before passing to shell.`);
-  }
-}
-
-/**
- * Build the agent prompt for a phase, handling both `prompt:` (template file)
- * and `skill:`/`skills:` (skill references) phase definitions, including
- * phases that declare both.
- *
- * Skill content is not embedded in the prompt — instead, the named skills
- * are staged at `<workspace>/.agents/skills/<name>/` by the executor (see
- * `phaseConfigFor` → `ExecutorConfig.skillPaths` → agent-executor's
- * staging step), and pi-coding-agent's built-in auto-discovery surfaces
- * them in the system prompt as an XML catalogue. The agent reads the
- * full SKILL.md via its `read` tool on demand.
- *
- * Resolution order:
- *   1. `prompt:` set — render the template as the user prompt. If
- *      `skills:` is also set, the staged catalogue is available; the
- *      template can reference skills by name (the staging happens
- *      regardless of which branch this function takes).
- *   2. `skills:` only — emit a short auto-generated nudge that points
- *      the agent at the primary skill and lists the rest.
- *   3. Neither — throw.
- */
-function buildPhasePrompt(
-  phase: PhaseDefinition,
-  ctx: TemplateContext,
-  extraCtx?: Partial<TemplateContext>,
-): string {
-  const fullCtx = extraCtx ? { ...ctx, ...extraCtx } : ctx;
-
-  if (phase.prompt) {
-    const template = loadPromptTemplate(phase.prompt);
-    return renderTemplate(template, fullCtx);
-  }
-
-  const skills = phaseSkillNames(phase);
-  if (skills.length) {
-    const [primary, ...rest] = skills;
-    const contextLines = Object.entries(fullCtx)
-      .filter(([, v]) => v !== undefined && v !== null)
-      .map(([k, v]) => `${k}: ${typeof v === "object" ? JSON.stringify(v) : v}`)
-      .join("\n");
-    const others = rest.length
-      ? `Other skills available if you need them: ${rest.join(", ")}.`
-      : "";
-    // The staged skill is listed in pi-coding-agent's `<available_skills>`
-    // system-prompt catalogue, and the agent loads SKILL.md on demand —
-    // so we only name the primary skill and pass context. No need to
-    // spell out the file path; that just burns a tool call telling the
-    // agent to do what its progressive-disclosure loop already does.
-    return [
-      `Use the **${primary}** skill to handle this request.`,
-      others,
-      "",
-      "Context:",
-      contextLines,
-    ]
-      .filter((line) => line !== "")
-      .join("\n");
-  }
-
-  throw new Error(`Phase "${phase.name}" has neither prompt: nor skills: — cannot build prompt`);
-}
-
-/**
- * Overlay per-phase executor config fields that live on the YAML phase
- * itself (not on the runner-level config or env): `unrestricted_egress`,
- * `web_search`, and the resolved skill directory paths derived from
- * `skill:`/`skills:`. The agent-executor then stages each skill at
- * `<workspace>/.agents/skills/<name>/` for pi-coding-agent's
- * auto-discovery to find.
- *
- * All callers route through here, so loop fix/re-review cycles inherit
- * the parent phase's skills automatically.
- */
-function phaseConfigFor(config: ExecutorConfig, phase: PhaseDefinition): ExecutorConfig {
-  const skills = phaseSkillNames(phase);
-  const skillPaths = skills.length ? resolveSkillPaths(skills) : undefined;
-
-  if (
-    phase.unrestricted_egress === undefined &&
-    phase.web_search === undefined &&
-    !skillPaths
-  ) {
-    return config;
-  }
-  const next: ExecutorConfig = { ...config };
-  if (phase.unrestricted_egress !== undefined) {
-    next.unrestrictedEgress = phase.unrestricted_egress;
-  }
-  if (phase.web_search !== undefined) {
-    next.webSearch = phase.web_search;
-  }
-  if (skillPaths) {
-    next.skillPaths = skillPaths;
-  }
-  return next;
-}
+// `isTerminated` used to live here; re-exported for API stability.
+export { isTerminated };
 
 /**
  * Map of approval gate name → enabled. Gate names are arbitrary strings
@@ -152,17 +46,12 @@ export interface RunnerCallbacks {
   /**
    * In-place "task list" progress surface. When set (workflows that opt in via
    * `status_checklist: true`), the runner drives this instead of posting a new
-   * comment per phase — phase transitions become checklist step updates and the
-   * `messages.on_*` strings become each step's one-line detail. When unset, the
-   * runner falls back to `postComment` (legacy one-comment-per-phase). See
-   * `src/notify/`.
+   * comment per phase. When unset, the runner falls back to `postComment`.
    */
   reporter?: ProgressReporter;
   /**
-   * Fires once the workflow_runs row is known — either freshly created or
-   * reused from a running/paused trigger. Used by the Slack dispatch path
+   * Fires once the workflow_runs row is known. Used by the Slack dispatch path
    * to post the "Starting <skill>" reply with a deep link to the run.
-   * Fire-and-forget: the workflow does not await this, so failures only log.
    */
   onRunStart?: (runId: string) => Promise<void>;
 }
@@ -172,43 +61,6 @@ export interface WorkflowResult {
   phases: PhaseResult[];
   prNumber?: number;
   paused?: boolean;
-}
-
-// ── Phase-level deduplication ────────────────────────────────────────────────
-
-/**
- * Check if a sandbox container is actually running for a given taskId prefix.
- */
-async function isContainerAlive(taskId: string): Promise<boolean> {
-  try {
-    const containers = await listRunningContainers();
-    return containers.some((c) => c.taskId === taskId);
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Check if an error was caused by manual termination.
- */
-export function isTerminated(error?: string): boolean {
-  if (!error) return false;
-  const lower = error.toLowerCase();
-  return (
-    lower.includes("terminated") ||
-    lower.includes("killed") ||
-    lower.includes("exit undefined") ||
-    (lower.includes("container") && lower.includes("not running"))
-  );
-}
-
-function pickResult(r: ExecutionResult): Pick<ExecutionResult, "success" | "output" | "error"> {
-  return { success: r.success, output: r.output, error: r.error };
-}
-
-function issueNumberFromTrigger(triggerId: string): number | undefined {
-  const m = triggerId.match(/#(\d+)$/);
-  return m ? Number(m[1]) : undefined;
 }
 
 export function gitAccessProfileForWorkflow(workflowName: string): GitAccessProfile {
@@ -242,147 +94,28 @@ export function gitSandboxAccessForWorkflow(
     owner,
     repo,
     profile,
-    // Never forward the App PEM into sandboxes. agentic-pi's github extension
-    // prioritizes App auth whenever GITHUB_APP_* are all present and *skips
-    // entirely* (status: pem-unreadable) when the PEM isn't readable in the
-    // sandbox — which it never is (ALLOW_APP_PEM is not wired up, so the
-    // sandbox-side PEM copy is never materialized). It does NOT fall back to
-    // the minted GITHUB_TOKEN. The harness already mints a profile-scoped
-    // token and forwards it as GITHUB_TOKEN, so the agent gets github tools in
-    // static-token mode without the App private key ever entering the sandbox.
+    // Never forward the App PEM into sandboxes. The harness already mints a
+    // profile-scoped token and forwards it as GITHUB_TOKEN, so the agent gets
+    // github tools in static-token mode without the App private key ever
+    // entering the sandbox.
     allowMcpAppAuth: false,
     prePopulateBranch,
   };
 }
 
-/**
- * Run a single agent phase with DB-tracked deduplication.
- */
-async function runPhase(
-  workflowName: string,
-  phaseName: string,
-  taskId: string,
-  triggerId: string,
-  prompt: string,
-  config: ExecutorConfig,
-  db?: StateDb,
-  modelOverride?: string,
-  workflowRunId?: string,
-  githubAccess?: GitSandboxAccess,
-  variantOverride?: string,
-): Promise<
-  | { result: ExecutionResult; executionId: string; skipped: false }
-  | { result: ExecutionResult; skipped: false }
-  | { skipped: true; reason: "running" | "done" }
-> {
-  const dedupKey = `${workflowName}:${phaseName}`;
-  const attrs = {
-    "workflow.name": workflowName,
-    "phase.name": phaseName,
-    "workflow.run_id": workflowRunId,
-    "trigger.id": triggerId,
-    "task.id": taskId,
-    repo: githubAccess?.repo,
-    "issue.number": issueNumberFromTrigger(triggerId),
-    "sandbox.backend": config.sandbox,
-    model: modelOverride || config.model,
-  };
-  return withSpan("lastlight.workflow.phase", attrs, async (span) => {
-    if (db) {
-      const status = db.shouldRunPhase(dedupKey, triggerId, workflowRunId);
-
-      if (status === "running") {
-        const alive = await isContainerAlive(taskId);
-        if (alive) {
-          console.log(`[runner] Phase ${phaseName} is already running (container alive) — skipping`);
-          span?.addEvent("lastlight.workflow.phase.skipped", { reason: "running" });
-          return { skipped: true, reason: "running" };
-        }
-        console.log(`[runner] Phase ${phaseName} was running but container is dead — cleaning up`);
-        db.markStaleAsFailed(dedupKey, triggerId, workflowRunId);
-      } else if (status === "done") {
-        console.log(`[runner] Phase ${phaseName} already completed successfully — skipping`);
-        span?.addEvent("lastlight.workflow.phase.skipped", { reason: "done" });
-        return { skipped: true, reason: "done" };
-      }
-
-      const executionId = randomUUID();
-      db.recordStart({
-        id: executionId,
-        triggerType: "webhook",
-        triggerId,
-        skill: dedupKey,
-        repo: githubAccess?.repo,
-        issueNumber: issueNumberFromTrigger(triggerId),
-        startedAt: new Date().toISOString(),
-        workflowRunId,
-      });
-
-      const baseConfig = modelOverride ? { ...config, model: modelOverride } : config;
-      const phaseConfigBase = variantOverride ? { ...baseConfig, variant: variantOverride } : baseConfig;
-      const phaseConfig: ExecutorConfig = {
-        ...phaseConfigBase,
-        telemetry: { workflowName, phaseName, triggerId, workflowRunId },
-      };
-      try {
-        const result = await executeAgent(prompt, phaseConfig, {
-          taskId,
-          githubAccess,
-          // Persist the session id as soon as it arrives so the dashboard can
-          // show live agent logs for an in-flight phase, not just completed ones.
-          onSessionId: (sessionId) => {
-            try {
-              db.recordSessionId(executionId, sessionId);
-            } catch (err) {
-              console.warn(`[runner] Failed to persist session id mid-run for ${phaseName}:`, err);
-            }
-          },
-        });
-
-        db.recordFinish(executionId, {
-          success: result.success,
-          error: result.error,
-          turns: result.turns,
-          durationMs: result.durationMs,
-          sessionId: result.sessionId,
-          costUsd: result.costUsd,
-          inputTokens: result.inputTokens,
-          cacheCreationInputTokens: result.cacheCreationInputTokens,
-          cacheReadInputTokens: result.cacheReadInputTokens,
-          outputTokens: result.outputTokens,
-          apiDurationMs: result.apiDurationMs,
-          stopReason: result.stopReason,
-          extensionStatus: result.extensions ? JSON.stringify(result.extensions) : undefined,
-        });
-        span?.setAttributes({ success: result.success, stop_reason: result.stopReason ?? "unknown" });
-        recordExecutionMetrics("phase", { ...attrs, success: result.success, stop_reason: result.stopReason, durationMs: result.durationMs, costUsd: result.costUsd, inputTokens: result.inputTokens, outputTokens: result.outputTokens });
-        return { result, executionId, skipped: false };
-      } catch (err) {
-        recordError("phase", err, attrs);
-        throw err;
-      }
-    }
-
-    const baseConfig = modelOverride ? { ...config, model: modelOverride } : config;
-    const phaseConfigBase = variantOverride ? { ...baseConfig, variant: variantOverride } : baseConfig;
-    const phaseConfig: ExecutorConfig = { ...phaseConfigBase, telemetry: { workflowName, phaseName, triggerId, workflowRunId } };
-    const result = await executeAgent(prompt, phaseConfig, { taskId, githubAccess });
-    recordExecutionMetrics("phase", { ...attrs, success: result.success, stop_reason: result.stopReason, durationMs: result.durationMs, costUsd: result.costUsd, inputTokens: result.inputTokens, outputTokens: result.outputTokens });
-    return { result, skipped: false };
-  });
-}
-
-// ── Main workflow runner ─────────────────────────────────────────────────────
-
-/** Returns true if any phase declares explicit dependencies — triggers DAG execution path. */
-function hasDependencies(definition: AgentWorkflowDefinition): boolean {
-  return definition.phases.some((p) => p.depends_on && p.depends_on.length > 0);
-}
+// ── Unified workflow scheduler ───────────────────────────────────────────────
 
 /**
  * Run an agent workflow defined by a YAML definition.
- * Interprets phases, approval gates, and loops generically — the runner has
- * no knowledge of specific phase names.
+ *
+ * Every workflow executes as a DAG: workflows that declare no `depends_on`
+ * are run as a synthesized chain (each phase depends on the one before it),
+ * reproducing the old linear semantics including the failure cascade. Ready
+ * nodes are executed **one at a time in declaration order** (sequential).
+ * Each node's body — context / standard agent / reviewer-loop / generic-loop,
+ * plus approval and reply gates — lives in {@link PhaseExecutor}; the
+ * scheduler here owns the DAG, the `phases[]`/`outputs{}` accumulation, and
+ * the in-memory node status.
  */
 export async function runWorkflow(
   definition: AgentWorkflowDefinition,
@@ -396,7 +129,7 @@ export async function runWorkflow(
   variants?: VariantConfig,
 ): Promise<WorkflowResult> {
   const phases: PhaseResult[] = [];
-  const phaseOutputs: Record<string, unknown> = {};
+  const outputs: Record<string, unknown> = {};
   const { taskId } = ctx;
   // Slack-originated runs carry an explicit `slack:` trigger id — everything
   // else (GitHub webhook, CLI) uses the legacy owner/repo#N shape.
@@ -409,10 +142,7 @@ export async function runWorkflow(
     ? { ...(ctx.scratch as Record<string, unknown>) }
     : (db && workflowId ? { ...(db.getWorkflowRun(workflowId)?.scratch ?? {}) } : {});
   ctx.scratch = scratch;
-  // `prePopulateBranch` is set upstream (in src/index.ts dispatch) for
-  // workflows that operate on an existing branch (pr-review, pr-fix). The
-  // executor uses it to clone that branch into the workspace before the
-  // sandbox starts — agent enters a workspace already checked out.
+
   const prePopulateBranch = typeof ctx.prePopulateBranch === "string"
     ? ctx.prePopulateBranch
     : undefined;
@@ -433,53 +163,45 @@ export async function runWorkflow(
   const variantFor = (taskType: string): string | undefined =>
     variants ? resolveVariant(variants, taskType) : undefined;
 
-  /** Render a prompt template with current context. */
+  /** Render a prompt template with current context + outputs. */
   const renderPrompt = (promptPath: string, extraCtx?: Partial<TemplateContext>): string => {
     const template = loadPromptTemplate(promptPath);
-    return renderTemplate(template, { ...ctx, phaseOutputs, ...(extraCtx || {}) });
+    return renderTemplate(template, { ...ctx, phaseOutputs: outputs, ...(extraCtx || {}) });
   };
 
   /**
-   * Render a YAML message template and post it as a *standalone* message — a
-   * new GitHub comment / Slack message. Used for genuine notes (approval
-   * prompts, reply-gate questions, abort notices). When the in-place checklist
-   * is active it routes through `reporter.note()` (a real ping); otherwise it
-   * falls back to the legacy `postComment`.
+   * Render a YAML message template and post it as a *standalone* message.
+   * Routes through `reporter.note()` when the in-place checklist is active,
+   * else the legacy `postComment`.
    */
   const notifyMessage = async (
     template: string | undefined,
     extraCtx?: Partial<TemplateContext>,
   ): Promise<void> => {
     if (!template) return;
-    const rendered = renderTemplate(template, { ...ctx, phaseOutputs, ...(extraCtx || {}) });
+    const rendered = renderTemplate(template, { ...ctx, phaseOutputs: outputs, ...(extraCtx || {}) });
     if (!rendered.trim()) return;
     if (reporter) await reporter.note(rendered);
     else await notify(rendered);
   };
 
-  /** Post a pre-rendered standalone message (already-built string, no template). */
+  /** Post a pre-rendered standalone message (already-built string). */
   const postNote = async (text: string): Promise<void> => {
     if (!text.trim()) return;
     if (reporter) await reporter.note(text);
     else await notify(text);
   };
 
-  /**
-   * Transition a checklist step (and optionally render a YAML message as its
-   * one-line detail). When no reporter is wired this falls back to posting the
-   * full rendered message as a legacy comment, so opted-out workflows behave
-   * exactly as before. `insert` adds a dynamic step (loop iterations); `note`
-   * additionally posts the full message as a standalone ping (approval gates).
-   */
+  /** Transition a checklist step (and optionally render a YAML message detail). */
   const reportStep = async (
     key: string,
     status: StepStatus,
     template?: string,
     extraCtx?: Partial<TemplateContext>,
-    opts?: { label?: string; insertBefore?: string; insert?: boolean; alsoNote?: boolean },
+    opts?: ReportStepOpts,
   ): Promise<void> => {
     const rendered = template
-      ? renderTemplate(template, { ...ctx, phaseOutputs, ...(extraCtx || {}) }).trim()
+      ? renderTemplate(template, { ...ctx, phaseOutputs: outputs, ...(extraCtx || {}) }).trim()
       : "";
     if (reporter) {
       const detail = collapseDetail(rendered);
@@ -515,662 +237,113 @@ export async function runWorkflow(
     }
   };
 
-  // Determine resume point from the DB row's currentPhase. If the row doesn't
-  // exist (no DB), default to running everything from the first phase.
-  //
-  // `currentPhase` is initialized to `phases[0].name` at row creation, so on a
-  // fresh run it points at the first phase even though nothing has run yet.
-  // We can only treat it as "last completed" once phase_history has at least
-  // one entry (persistPhase only fires when a phase completes successfully).
-  let resumeFromIdx = 0;
-  if (db && workflowId) {
-    const run = db.getWorkflowRun(workflowId);
-    if (run?.currentPhase && run.phaseHistory && run.phaseHistory.length > 0) {
-      const next = nextPhaseAfter(definition, run.currentPhase);
-      if (next) {
-        const idx = phaseIndexInDefinition(definition, next);
-        if (idx >= 0) resumeFromIdx = idx;
-      }
-    }
-  }
-
-  const shouldRun = (phaseName: string): boolean => {
-    const idx = phaseIndexInDefinition(definition, phaseName);
-    // Unknown phases always run — they're not tracked in the definition order.
-    if (idx === -1) return true;
-    return idx >= resumeFromIdx;
-  };
-
   /** Should an approval gate with this name actually pause the workflow? */
   const gateEnabled = (gateName: string | undefined): boolean =>
     !!gateName && approvalConfig?.[gateName] === true;
 
-  // ── Execute phases ────────────────────────────────────────────────────────
+  // ── Collaborators ───────────────────────────────────────────────────────────
 
-  if (hasDependencies(definition)) {
-    return runDagWorkflow(
-      definition, ctx, config, db, workflowId,
-      { phases, phaseOutputs, triggerId, notify, notifyMessage, reportStep, onStart, onEnd, modelFor, variantFor, renderPrompt, persistPhase, failWorkflow, gateEnabled, githubAccess },
-    );
-  }
+  const runScope: PhaseRunContext = {
+    definition,
+    ctx,
+    config,
+    taskId,
+    triggerId,
+    githubAccess,
+    scratch,
+    db,
+    workflowId,
+  };
+  const phaseReporter: PhaseReporter = {
+    onStart,
+    onEnd,
+    step: reportStep,
+    message: notifyMessage,
+    postNote,
+    persistPhase,
+    failWorkflow,
+  };
+  const phaseResolver: PhaseResolver = {
+    modelFor,
+    variantFor,
+    renderPrompt,
+    gateEnabled,
+  };
+  const executor = new PhaseExecutor(runScope, phaseReporter, phaseResolver);
 
-  for (const phase of definition.phases) {
+  // ── Schedule ─────────────────────────────────────────────────────────────────
+
+  const dag = buildDag(definition.phases, { chainIfNoDeps: true });
+
+  while (!isComplete(dag)) {
     // Honour a cancel that landed during the previous phase's execution.
-    // The admin /cancel endpoint both flips status to 'cancelled' and
-    // kills the in-flight sandbox container; this check keeps the runner
-    // from picking up the next phase after the DB flag flips.
     if (db && workflowId) {
       const latest = db.getWorkflowRun(workflowId);
       if (latest?.status === "cancelled") {
-        console.log(`[runner] ${definition.name} cancelled — stopping before phase ${phase.name}`);
+        console.log(`[runner] ${definition.name} cancelled — stopping`);
         return { success: false, phases };
       }
-    } else {
-      // Shouldn't happen for real runs (simple.ts always passes both),
-      // but if a caller wires the runner without db/workflowId the run
-      // becomes uncancellable — log so the misconfiguration is obvious.
-      console.warn(`[runner] cancel check skipped — no db/workflowId context`);
     }
 
-    const { name: phaseName, type: phaseType = "agent" } = phase;
-    // Linear workflows share one sandbox workspace across phases via `taskId`.
-    // (DAG path uses phase-scoped taskIds to avoid concurrent write races.)
+    // Skip nodes whose trigger rule fails (deps terminal, rule unsatisfied).
+    // This is how a failure cascades to the end of a chain as skips. Skips are
+    // recorded in the executions ledger — the single source of truth the
+    // dashboard derives phase status from.
+    const toSkip = getNodesToSkip(dag);
+    for (const node of toSkip) {
+      node.status = "skipped";
+      phases.push({ phase: node.name, success: true, output: "Skipped (trigger rule not satisfied)" });
+      db?.recordSkippedPhase(
+        `${definition.name}:${node.name}`,
+        triggerId,
+        workflowId,
+        githubAccess.repo,
+      );
+      await reportStep(node.name, "skipped");
+    }
 
-    // ── Context-only phase (no agent execution) ───────────────────────────
-    if (phaseType === "context") {
-      if (shouldRun(phaseName)) {
-        await onStart(phaseName);
-        phases.push({ phase: phaseName, success: true, output: "Context assembled" });
-        // Persist a phase_history entry so the dashboard pipeline marks
-        // context phases as 'done' instead of leaving them stuck on
-        // 'pending' — they have no execution row to derive status from.
-        persistPhase(phaseName, "Context assembled");
-        await onEnd(phaseName, phases[phases.length - 1]);
-      }
+    const ready = getReadyNodes(dag);
+    if (ready.length === 0) {
+      if (toSkip.length === 0) break; // stuck (shouldn't happen in a valid DAG)
+      continue; // only had skips — loop to process downstream
+    }
+
+    // Sequential: run the earliest-declared ready node, one at a time.
+    // Resume is ledger-driven: a completed phase's `runPhase` call returns
+    // skipped:done via `shouldRunPhase`, so re-running from the top is safe.
+    const node = ready[0];
+    node.status = "running";
+
+    let outcome;
+    try {
+      outcome = await executor.execute(node, outputs);
+    } catch (err) {
+      // An agent call threw (OOM / unexpected). Mark the node failed so the
+      // failure cascades to downstream skips, mirroring a normal failure.
+      console.error(`[runner] Phase "${node.name}" threw unexpectedly:`, err);
+      phases.push({ phase: node.name, success: false, error: String(err), output: "" });
+      node.status = "failed";
       continue;
     }
+    for (const r of outcome.results) phases.push(r);
+    if (outcome.outputVars) Object.assign(outputs, outcome.outputVars);
 
-    // ── Agent phase ───────────────────────────────────────────────────────
-    if (!phase.prompt && !phase.skill) {
-      console.warn(`[runner] Phase "${phaseName}" has type=agent but neither prompt: nor skill: — skipping`);
-      continue;
+    if (outcome.aborted) {
+      // Dedup running-skip — another instance owns this phase. Stop without
+      // cascading skips; this isn't a phase failure.
+      return { success: false, phases };
     }
-
-    // Check if this is a looping phase (e.g. reviewer)
-    if (phase.loop) {
-      const loop = phase.loop;
-      const MAX_CYCLES = loop.max_cycles;
-      let approved = false;
-      let fixCycles = 0;
-
-      if (!shouldRun(phaseName)) {
-        // The phase was already completed — mark as approved and continue to next phase
-        approved = true;
-        phases.push({ phase: phaseName, success: true, output: "Already completed" });
-      }
-
-      while (!approved && fixCycles <= MAX_CYCLES) {
-        const reviewLabel =
-          fixCycles === 0
-            ? PhaseRef.review(phaseName).format()
-            : PhaseRef.recheck(phaseName, fixCycles).format();
-
-        if (!shouldRun(phaseName) && fixCycles === 0) {
-          approved = true;
-          break;
-        }
-
-        await onStart(reviewLabel);
-        // First cycle reuses the seeded review step; re-reviews insert a new
-        // "<Reviewer> (cycle N)" row just above the terminal step.
-        await reportStep(
-          reviewLabel,
-          "running",
-          loop.messages?.on_cycle_start,
-          { cycle: fixCycles + 1, maxCycles: MAX_CYCLES },
-          fixCycles === 0
-            ? undefined
-            : { insert: true, label: `${phase.label ?? phaseName} (cycle ${fixCycles + 1})` },
-        );
-
-        // Choose prompt: first cycle uses phase.prompt or phase.skill (via
-        // buildPhasePrompt), subsequent cycles always use the re_review_prompt
-        // template path defined in loop.on_request_changes.
-        const reviewPrompt =
-          fixCycles === 0
-            ? buildPhasePrompt(phase, { ...ctx, phaseOutputs }, { fixCycle: fixCycles })
-            : renderPrompt(loop.on_request_changes.re_review_prompt, { fixCycle: fixCycles });
-
-        // Resolve model + variant
-        const reviewModelRaw = phase.model ? renderTemplate(phase.model, ctx) : undefined;
-        const reviewModel = reviewModelRaw || modelFor(phaseName);
-        const reviewVariantRaw = phase.variant ? renderTemplate(phase.variant, ctx) : undefined;
-        const reviewVariant = reviewVariantRaw || variantFor(phaseName);
-
-        const rr = await runPhase(
-          definition.name,
-          reviewLabel,
-          taskId,
-          triggerId,
-          reviewPrompt,
-          phaseConfigFor(config, phase),
-          db,
-          reviewModel,
-          workflowId,
-          githubAccess,
-          reviewVariant,
-        );
-
-        if (rr.skipped) {
-          if (rr.reason === "running") {
-            await notifyMessage(phase.messages?.on_skipped_done);
-            return { success: false, phases };
-          }
-          approved = true;
-          phases.push({ phase: reviewLabel, success: true, output: "Already completed" });
-          break;
-        }
-
-        phases.push({ phase: reviewLabel, ...pickResult(rr.result) });
-        await onEnd(reviewLabel, phases[phases.length - 1]);
-
-        // Parse verdict
-        const reviewerOutput = (rr.result.output || "").trim();
-        const { verdict, viaFallback } = parseReviewerVerdict(reviewerOutput);
-        const isApproved = verdict === "APPROVED";
-        if (viaFallback) {
-          console.warn(
-            `[runner] Reviewer output missing VERDICT: marker — using fallback detection (isApproved=${isApproved})`,
-          );
-        }
-
-        if (isApproved) {
-          approved = true;
-          persistPhase(reviewLabel, "APPROVED");
-          await reportStep(reviewLabel, "done", loop.messages?.on_approved, { cycle: fixCycles + 1 });
-        } else if (fixCycles < MAX_CYCLES) {
-          fixCycles++;
-          persistPhase(reviewLabel, "REQUEST_CHANGES");
-
-          // Approval gate before fix loop
-          const gateKey = loop.approval_gate;
-          if (gateEnabled(gateKey) && db && workflowId) {
-            const approvalId = randomUUID();
-            db.createApproval({
-              id: approvalId,
-              workflowRunId: workflowId,
-              gate: gateKey!,
-              summary: `Reviewer requested changes (cycle ${fixCycles}/${MAX_CYCLES}) on phase ${phaseName}.`,
-              requestedBy: ctx.sender,
-              createdAt: new Date().toISOString(),
-            });
-            db.updateWorkflowPhase(workflowId, "waiting_approval", {
-              phase: "waiting_approval",
-              timestamp: new Date().toISOString(),
-              success: true,
-              summary: `Waiting for approval: ${gateKey} (${approvalId})`,
-            });
-            db.pauseWorkflowRun(workflowId);
-            // Mark the review row as awaiting and post a real ping — approval
-            // is an actionable moment, so unlike normal phase transitions it
-            // gets a standalone message rather than only an in-place edit.
-            await reportStep(
-              reviewLabel,
-              "awaiting",
-              loop.messages?.on_pause_for_approval,
-              { cycle: fixCycles, maxCycles: MAX_CYCLES, gateKey },
-              { alsoNote: true },
-            );
-            return { success: true, phases, paused: true };
-          }
-
-          await reportStep(reviewLabel, "done", loop.messages?.on_request_changes, {
-            cycle: fixCycles,
-            maxCycles: MAX_CYCLES,
-          });
-
-          // Run fix phase
-          const fixLabel = PhaseRef.fix(phaseName, fixCycles).format();
-          await onStart(fixLabel);
-          await reportStep(
-            fixLabel,
-            "running",
-            loop.messages?.on_fix_start,
-            { cycle: fixCycles, maxCycles: MAX_CYCLES },
-            { insert: true, label: `Fix (cycle ${fixCycles})` },
-          );
-
-          const fixModelRaw = loop.on_request_changes.fix_model
-            ? renderTemplate(loop.on_request_changes.fix_model, ctx)
-            : undefined;
-          const fixModel = fixModelRaw || modelFor(`${phaseName}_fix`) || modelFor(phaseName);
-          const fixVariantRaw = loop.on_request_changes.fix_variant
-            ? renderTemplate(loop.on_request_changes.fix_variant, ctx)
-            : undefined;
-          const fixVariant = fixVariantRaw || variantFor(`${phaseName}_fix`) || variantFor(phaseName);
-
-          const fixPromptRendered = renderPrompt(loop.on_request_changes.fix_prompt, {
-            fixCycle: fixCycles,
-          });
-
-          const fr = await runPhase(
-            definition.name,
-            fixLabel,
-            taskId,
-            triggerId,
-            fixPromptRendered,
-            phaseConfigFor(config, phase),
-            db,
-            fixModel,
-            workflowId,
-            githubAccess,
-            fixVariant,
-          );
-
-          if (fr.skipped) {
-            if (fr.reason === "running") {
-              await notifyMessage(phase.messages?.on_skipped_done);
-              return { success: false, phases };
-            }
-            phases.push({ phase: fixLabel, success: true, output: "Already completed" });
-          } else {
-            phases.push({ phase: fixLabel, ...pickResult(fr.result) });
-            await onEnd(fixLabel, phases[phases.length - 1]);
-
-            if (!fr.result.success) {
-              if (!isTerminated(fr.result.error)) {
-                await reportStep(fixLabel, "failed", loop.messages?.on_fix_failed, {
-                  cycle: fixCycles,
-                  maxCycles: MAX_CYCLES,
-                });
-              }
-              break;
-            }
-            persistPhase(fixLabel);
-            await reportStep(fixLabel, "done");
-          }
-        } else {
-          persistPhase(reviewLabel, "REQUEST_CHANGES — max cycles reached");
-          await reportStep(reviewLabel, "blocked", loop.messages?.on_max_cycles, {
-            cycle: fixCycles,
-            maxCycles: MAX_CYCLES,
-          }, { alsoNote: true });
-          break;
-        }
-      }
-
-      // Expose loop outcome as a structured phase output so downstream phases
-      // can read {{phaseName.approved}} / {{phaseName.cycles}} in their prompts.
-      if (phase.output_var) {
-        phaseOutputs[phase.output_var] = { approved, cycles: fixCycles };
-      }
-      continue;
+    if (outcome.paused) {
+      return { success: true, phases, paused: true };
     }
-
-    // ── Generic loop phase ────────────────────────────────────────────────
-    if (phase.generic_loop) {
-      const loop = phase.generic_loop;
-      const MAX_ITER = loop.max_iterations;
-      const MAX_PREV_OUTPUT_BYTES = 10 * 1024; // cap accumulated output at 10KB
-
-      if (!shouldRun(phaseName)) {
-        phases.push({ phase: phaseName, success: true, output: "Already completed" });
-        continue;
-      }
-
-      // Reply-gate loops resume mid-flight: read the saved iteration out
-      // of scratch[scratch_key] so we pick up at N+1 instead of 1 and
-      // don't re-run iterations whose dedup rows are already "done".
-      const scratchKey = loop.scratch_key;
-      const scratchSlot = (scratchKey
-        ? (scratch[scratchKey] as Record<string, unknown> | undefined) ?? {}
-        : {}) as Record<string, unknown>;
-      const resumeFromIter =
-        loop.gate_kind === "reply" && typeof scratchSlot.iteration === "number"
-          ? Math.min(scratchSlot.iteration as number, MAX_ITER)
-          : 0;
-
-      let iteration = resumeFromIter;
-      let complete = false;
-      // On resume, `lastOutputExecutionId` points at an `executions` row
-      // whose `output_text` column holds the previous iteration's full
-      // LLM output. The legacy inline `lastOutput` string is honored too
-      // so runs paused on the old code path still resume cleanly.
-      let previousOutput =
-        (scratchSlot.lastOutputExecutionId && db
-          ? db.getExecutionOutput(scratchSlot.lastOutputExecutionId as string) ?? ""
-          : (scratchSlot.lastOutput as string | undefined) ?? "");
-
-      await reportStep(phaseName, "running");
-
-      while (!complete && iteration < MAX_ITER) {
-        iteration++;
-        const iterLabel = PhaseRef.iter(phaseName, iteration).format();
-
-        await onStart(iterLabel);
-
-        // Build prompt with loop context vars
-        const iterCtx: Partial<TemplateContext> = {
-          iteration,
-          maxIterations: MAX_ITER,
-          previousOutput: loop.fresh_context ? "" : previousOutput,
-          phaseOutputs,
-          scratch,
-        };
-        const prompt = buildPhasePrompt(phase, ctx, iterCtx);
-
-        const modelRaw = phase.model ? renderTemplate(phase.model, ctx) : undefined;
-        const model = modelRaw || modelFor(phaseName);
-        const variantRaw = phase.variant ? renderTemplate(phase.variant, ctx) : undefined;
-        const variant = variantRaw || variantFor(phaseName);
-
-        const ir = await runPhase(
-          definition.name,
-          iterLabel,
-          taskId,
-          triggerId,
-          prompt,
-          phaseConfigFor(config, phase),
-          db,
-          model,
-          workflowId,
-          githubAccess,
-          variant,
-        );
-
-        if (ir.skipped) {
-          if (ir.reason === "running") {
-            await notifyMessage(phase.messages?.on_skipped_done, { iteration });
-            return { success: false, phases };
-          }
-          // Already done — treat as complete
-          phases.push({ phase: iterLabel, success: true, output: "Already completed" });
-          complete = true;
-          break;
-        }
-
-        phases.push({ phase: iterLabel, ...pickResult(ir.result) });
-        await onEnd(iterLabel, phases[phases.length - 1]);
-
-        if (!ir.result.success) {
-          if (!isTerminated(ir.result.error)) {
-            await reportStep(phaseName, "failed", phase.messages?.on_failure, { iteration });
-          }
-          failWorkflow(ir.result.error);
-          return { success: false, phases };
-        }
-
-        const iterOutput = ir.result.output || "";
-
-        // Accumulate previousOutput (cap at MAX_PREV_OUTPUT_BYTES)
-        if (!loop.fresh_context) {
-          const combined = previousOutput ? `${previousOutput}\n${iterOutput}` : iterOutput;
-          previousOutput = combined.length > MAX_PREV_OUTPUT_BYTES
-            ? combined.slice(-MAX_PREV_OUTPUT_BYTES)
-            : combined;
-        }
-
-        // Evaluate until expression
-        let conditionMet = false;
-        if (loop.until) {
-          conditionMet = evalUntilExpression(loop.until, {
-            output: iterOutput,
-            scratch,
-            ...Object.fromEntries(
-              Object.entries(ctx)
-                .filter(([, v]) => typeof v === "string")
-                .map(([k, v]) => [k, v as string]),
-            ),
-          });
-        }
-
-        // Evaluate until_bash
-        if (!conditionMet && loop.until_bash) {
-          try {
-            validateShellCommand(loop.until_bash);
-            execSync(loop.until_bash, { timeout: 30_000, stdio: "pipe", cwd: config.sandboxDir ?? config.cwd });
-            conditionMet = true; // exit 0
-          } catch {
-            conditionMet = false; // non-zero exit
-          }
-        }
-
-        // Persist this iteration's output text on its execution row so
-        // the resume path can resolve `lastOutputExecutionId` through the
-        // DB instead of inlining the full LLM string into scratch.
-        const iterExecutionId = "executionId" in ir ? ir.executionId : undefined;
-        if (iterExecutionId && db) {
-          db.recordOutputText(iterExecutionId, iterOutput);
-        }
-
-        if (conditionMet) {
-          complete = true;
-          if (scratchKey && db && workflowId) {
-            const slot: Record<string, unknown> = {
-              ...scratchSlot,
-              iteration,
-              ready: true,
-            };
-            if (iterExecutionId) slot.lastOutputExecutionId = iterExecutionId;
-            delete slot.lastOutput;
-            db.updateWorkflowRunScratch(workflowId, { [scratchKey]: slot });
-            scratch[scratchKey] = slot;
-          }
-          persistPhase(iterLabel, `iteration ${iteration} — condition met`);
-          await reportStep(phaseName, "done");
-          break;
-        }
-
-        // Interactive gate between iterations
-        if (loop.interactive && !complete && db && workflowId) {
-          const isReply = loop.gate_kind === "reply";
-          const gateMsg = loop.gate_message
-            ? renderTemplate(loop.gate_message, { ...ctx, phaseOutputs, iteration, maxIterations: MAX_ITER, scratch })
-            : `Loop iteration ${iteration}/${MAX_ITER} complete.`;
-
-          // Persist iteration + pointer to the last output's execution row
-          // BEFORE pausing so the resume path can pick up at N+1 instead of
-          // re-running from 1.
-          if (scratchKey) {
-            const slot: Record<string, unknown> = {
-              ...(scratch[scratchKey] as Record<string, unknown> | undefined),
-              iteration,
-            };
-            if (iterExecutionId) slot.lastOutputExecutionId = iterExecutionId;
-            delete slot.lastOutput;
-            scratch[scratchKey] = slot;
-            db.updateWorkflowRunScratch(workflowId, { [scratchKey]: slot });
-          }
-
-          const approvalId = randomUUID();
-          db.createApproval({
-            id: approvalId,
-            workflowRunId: workflowId,
-            gate: iterLabel,
-            summary: gateMsg,
-            kind: isReply ? "reply" : "approve",
-            requestedBy: ctx.sender,
-            createdAt: new Date().toISOString(),
-          });
-          db.updateWorkflowPhase(workflowId, "waiting_approval", {
-            phase: "waiting_approval",
-            timestamp: new Date().toISOString(),
-            success: true,
-            summary: `Waiting for ${isReply ? "reply" : "approval"}: ${iterLabel} (${approvalId})`,
-          });
-          db.pauseWorkflowRun(workflowId);
-          await reportStep(phaseName, "awaiting");
-
-          if (isReply) {
-            // Combine the agent's questions + gate hint into one message
-            // so it reads as a single comment on GitHub / Slack.
-            const parts = [iterOutput.trim(), gateMsg.trim()].filter(Boolean);
-            if (parts.length > 0) await postNote(parts.join("\n\n---\n\n"));
-          } else {
-            await postNote(
-              `**${phaseName} iteration ${iteration}/${MAX_ITER} complete** — approval required to continue.\n\n` +
-                `${gateMsg}\n\n` +
-                `**To continue:** comment \`@last-light approve\`\n` +
-                `**To abort:** comment \`@last-light reject [reason]\``,
-            );
-          }
-          return { success: true, phases, paused: true };
-        }
-
-        persistPhase(iterLabel);
-      }
-
-      if (!complete) {
-        await reportStep(phaseName, "failed", phase.messages?.on_failure, {
-          iteration,
-          maxIterations: MAX_ITER,
-        });
-      }
-
-      if (phase.output_var) {
-        phaseOutputs[phase.output_var] = { completed: complete, iterations: iteration };
-      }
-      continue;
-    }
-
-    // ── Standard (non-looping) agent phase ───────────────────────────────
-    if (!shouldRun(phaseName)) continue;
-
-    await onStart(phaseName);
-    await reportStep(phaseName, "running", phase.messages?.on_start);
-
-    // Resolve model + variant
-    const modelRaw = phase.model ? renderTemplate(phase.model, ctx) : undefined;
-    const model = modelRaw || modelFor(phaseName);
-    const variantRaw = phase.variant ? renderTemplate(phase.variant, ctx) : undefined;
-    const variant = variantRaw || variantFor(phaseName);
-
-    const prompt = buildPhasePrompt(phase, ctx, { phaseOutputs });
-
-    const pr = await runPhase(
-      definition.name,
-      phaseName,
-      taskId,
-      triggerId,
-      prompt,
-      phaseConfigFor(config, phase),
-      db,
-      model,
-      workflowId,
-      githubAccess,
-      variant,
-    );
-
-    if (pr.skipped) {
-      if (pr.reason === "running") {
-        await notifyMessage(phase.messages?.on_skipped_done);
-        return { success: false, phases };
-      }
-      phases.push({ phase: phaseName, success: true, output: "Already completed" });
-      // Persist a phase_history entry even when the phase was deduped, so
-      // the dashboard's pipeline view shows the phase as 'done' instead of
-      // stuck on 'active'/pending. Without this the run looks half-finished
-      // even though it succeeded.
-      persistPhase(phaseName, "Already completed (deduplicated)");
-      await onEnd(phaseName, { phase: phaseName, success: true, output: "Already completed" });
-      await reportStep(phaseName, "done", phase.messages?.on_skipped_done);
-    } else {
-      phases.push({ phase: phaseName, ...pickResult(pr.result) });
-      await onEnd(phaseName, phases[phases.length - 1]);
-
-      // Record phase output (raw string) for downstream ${phaseName.output}
-      // substitution and, when phase.output_var is set, under the aliased key
-      // so prompts can read {{aliased}} / ${aliased.output} / {{aliased.field}}.
-      const rawOutput = pr.result.output ?? "";
-      phaseOutputs[phaseName] = rawOutput;
-      if (phase.output_var) {
-        phaseOutputs[phase.output_var] = rawOutput;
-      }
-
-      if (!pr.result.success) {
-        if (!isTerminated(pr.result.error)) {
-          await reportStep(phaseName, "failed", phase.messages?.on_failure);
-        }
-        failWorkflow(pr.result.error);
-        return { success: false, phases };
-      }
-
-      // Check on_output rules
-      if (phase.on_output) {
-        const outputUpper = (pr.result.output?.toUpperCase() || "");
-
-        if (phase.on_output.contains_BLOCKED && outputUpper.includes("BLOCKED")) {
-          const rule = phase.on_output.contains_BLOCKED;
-          const hasUnlessLabel =
-            rule.unless_label && ctx.issueLabels.includes(rule.unless_label);
-          const titleMatches = (() => {
-            if (!rule.unless_title_matches) return false;
-            if (rule.unless_title_matches.length > 200) return false;
-            // Reject patterns with nested quantifiers (catastrophic backtracking risk)
-            if (/[+*]\{0,\}.*[+*]/.test(rule.unless_title_matches) || /(\([^)]*[+*][^)]*\))[+*?]/.test(rule.unless_title_matches)) return false;
-            try {
-              return new RegExp(rule.unless_title_matches, "i").test(ctx.issueTitle || "");
-            } catch {
-              return false;
-            }
-          })();
-
-          if (hasUnlessLabel || titleMatches) {
-            // Rule bypassed — fall through to phase success path.
-            await notifyMessage(rule.bypass_message || phase.messages?.on_blocked_bypassed);
-          } else if (rule.action === "fail") {
-            db?.markLatestAsFailed(
-              `${definition.name}:${phaseName}`,
-              triggerId,
-              rule.message || "BLOCKED",
-              workflowId,
-            );
-            failWorkflow(rule.message || "BLOCKED");
-            const blockedTemplate = rule.message || phase.messages?.on_blocked;
-            if (blockedTemplate) {
-              await reportStep(phaseName, "blocked", blockedTemplate);
-            }
-            return { success: false, phases };
-          }
-        }
-      }
-
-      // Approval gate
-      if (phase.approval_gate && gateEnabled(phase.approval_gate) && db && workflowId) {
-        const gateKey = phase.approval_gate;
-        const approvalId = randomUUID();
-        db.createApproval({
-          id: approvalId,
-          workflowRunId: workflowId,
-          gate: gateKey,
-          summary: `${phaseName} complete — awaiting ${gateKey} approval.`,
-          requestedBy: ctx.sender,
-          createdAt: new Date().toISOString(),
-        });
-        db.updateWorkflowPhase(workflowId, "waiting_approval", {
-          phase: "waiting_approval",
-          timestamp: new Date().toISOString(),
-          success: true,
-          summary: `Waiting for approval: ${gateKey} (${approvalId})`,
-        });
-        db.pauseWorkflowRun(workflowId);
-        // Awaiting human approval — show it on the checklist and post a real
-        // ping (an in-place edit alone wouldn't notify the approver).
-        await reportStep(phaseName, "awaiting", phase.approval_gate_message, { gateKey }, { alsoNote: true });
-        return { success: true, phases, paused: true };
-      }
-
-      persistPhase(phaseName);
-      await reportStep(phaseName, "done", phase.messages?.on_success);
-    }
+    node.status = outcome.status;
   }
 
   // ── Workflow wrap-up ──────────────────────────────────────────────────────
   //
   // If the definition declares an `on_success.set_phase` terminal marker on any
-  // phase, record it so the DB row shows the workflow as fully complete. We
-  // also try to extract a PR number from the terminal phase's output so
-  // callers can surface it — purely opportunistic, no hardcoded phase names.
+  // phase, record it so the DB row shows the workflow as fully complete. Also
+  // opportunistically extract a PR number from the terminal phase's output.
   const anyFailed = phases.some((p) => !p.success);
   const success = !anyFailed;
 
@@ -1181,8 +354,6 @@ export async function runWorkflow(
     const terminalResult = phases.find((p) => p.phase === terminalPhase.name);
     const prMatch = terminalResult?.output?.match(/#(\d+)/);
     if (prMatch) prNumber = parseInt(prMatch[1], 10);
-    // The PR phase outputs the PR URL; pull it out so we can link it straight
-    // from the checklist instead of a separate "PR opened" comment.
     const urlMatch = terminalResult?.output?.match(/https?:\/\/[^\s)]+\/pull\/\d+/);
     if (urlMatch) prUrl = urlMatch[0];
     if (success && terminalPhase.on_success?.set_phase) {
@@ -1203,14 +374,10 @@ export async function runWorkflow(
   }
 
   if (reporter) {
-    // Put the PR link in the checklist itself (on the terminal step) so the
-    // list is self-contained — no separate "PR opened" comment.
     if (success && prNumber && terminalPhase) {
       const link = prUrl ? `[PR #${prNumber}](${prUrl})` : `PR #${prNumber}`;
       await reporter.step(terminalPhase.name, "done", link);
     }
-    // Completion ping — only to surfaces that want one (Slack). GitHub keeps
-    // just the finished checklist; the PR-opened event already notifies there.
     const prSuffix = prNumber ? ` — PR #${prNumber}` : "";
     await reporter.noteTerminal(
       success
@@ -1220,436 +387,4 @@ export async function runWorkflow(
   }
 
   return { success, phases, prNumber };
-}
-
-/** Shared runner context threaded into DAG execution (avoids re-deriving these). */
-interface DagRunnerCtx {
-  phases: PhaseResult[];
-  phaseOutputs: Record<string, unknown>;
-  triggerId: string;
-  githubAccess: GitSandboxAccess;
-  notify: (msg: string) => Promise<void>;
-  notifyMessage: (template: string | undefined, extraCtx?: Partial<TemplateContext>) => Promise<void>;
-  reportStep: (
-    key: string,
-    status: StepStatus,
-    template?: string,
-    extraCtx?: Partial<TemplateContext>,
-    opts?: { label?: string; insertBefore?: string; insert?: boolean; alsoNote?: boolean },
-  ) => Promise<void>;
-  onStart: (phase: string) => Promise<void>;
-  onEnd: (phase: string, result: PhaseResult) => Promise<void>;
-  modelFor: (taskType: string) => string | undefined;
-  variantFor: (taskType: string) => string | undefined;
-  renderPrompt: (promptPath: string, extraCtx?: Partial<TemplateContext>) => string;
-  persistPhase: (phase: string, summary?: string) => void;
-  failWorkflow: (errorMsg?: string) => void;
-  gateEnabled: (gateName: string | undefined) => boolean;
-}
-
-/**
- * DAG-based workflow execution. Called when any phase declares `depends_on`.
- * Runs independent phases concurrently via Promise.allSettled.
- */
-async function runDagWorkflow(
-  definition: AgentWorkflowDefinition,
-  ctx: TemplateContext,
-  config: ExecutorConfig,
-  db: StateDb | undefined,
-  workflowId: string | undefined,
-  runnerCtx: DagRunnerCtx,
-): Promise<WorkflowResult> {
-  const {
-    phases,
-    phaseOutputs: outputs,
-    triggerId,
-    githubAccess,
-    notifyMessage,
-    reportStep,
-    onStart,
-    onEnd,
-    modelFor,
-    variantFor,
-    renderPrompt,
-    persistPhase,
-    failWorkflow,
-    gateEnabled,
-  } = runnerCtx;
-  const { taskId } = ctx;
-
-  const dag = buildDag(definition.phases);
-  const phaseMap = new Map(definition.phases.map((p) => [p.name, p]));
-
-  /**
-   * Execute a single standard agent phase (no loop). Returns PhaseResult and
-   * whether the workflow should pause (approval gate).
-   */
-  async function executeSinglePhase(
-    phase: NonNullable<ReturnType<typeof phaseMap.get>>,
-    phaseName: string,
-  ): Promise<{ result: PhaseResult; paused?: boolean }> {
-    await reportStep(phaseName, "running", phase.messages?.on_start);
-    const phaseCtx: Partial<TemplateContext> = { phaseOutputs: { ...outputs } };
-    const prompt = buildPhasePrompt(phase, ctx, phaseCtx);
-    const modelRaw = phase.model ? renderTemplate(phase.model, ctx) : undefined;
-    const model = modelRaw || modelFor(phaseName);
-    const variantRaw = phase.variant ? renderTemplate(phase.variant, ctx) : undefined;
-    const variant = variantRaw || variantFor(phaseName);
-
-    const pr = await runPhase(
-      definition.name,
-      phaseName,
-      `${taskId}-${phaseName}`,
-      triggerId,
-      prompt,
-      phaseConfigFor(config, phase),
-      db,
-      model,
-      workflowId,
-      githubAccess,
-      variant,
-    );
-
-    if (pr.skipped) {
-      return { result: { phase: phaseName, success: true, output: "Already completed" } };
-    }
-
-    const result: PhaseResult = { phase: phaseName, ...pickResult(pr.result) };
-
-    if (!pr.result.success) {
-      await reportStep(phaseName, "failed", phase.messages?.on_failure);
-      return { result };
-    }
-
-    // Check on_output rules
-    if (phase.on_output?.contains_BLOCKED && (pr.result.output?.toUpperCase() || "").includes("BLOCKED")) {
-      const rule = phase.on_output.contains_BLOCKED;
-      const hasUnlessLabel = rule.unless_label && ctx.issueLabels.includes(rule.unless_label);
-      const titleMatches = !!rule.unless_title_matches &&
-        new RegExp(rule.unless_title_matches, "i").test(ctx.issueTitle || "");
-      if (hasUnlessLabel || titleMatches) {
-        await notifyMessage(rule.bypass_message || phase.messages?.on_blocked_bypassed);
-      } else if (rule.action === "fail") {
-        db?.markLatestAsFailed(`${definition.name}:${phaseName}`, triggerId, rule.message || "BLOCKED", workflowId);
-        failWorkflow(rule.message || "BLOCKED");
-        await reportStep(phaseName, "blocked", rule.message || phase.messages?.on_blocked);
-        return { result: { phase: phaseName, success: false, output: pr.result.output ?? "", error: "BLOCKED" } };
-      }
-    }
-
-    // Approval gate
-    if (phase.approval_gate && gateEnabled(phase.approval_gate) && db && workflowId) {
-      const gateKey = phase.approval_gate;
-      const approvalId = randomUUID();
-      db.createApproval({
-        id: approvalId,
-        workflowRunId: workflowId,
-        gate: gateKey,
-        summary: `${phaseName} complete — awaiting ${gateKey} approval.`,
-        requestedBy: ctx.sender,
-        createdAt: new Date().toISOString(),
-      });
-      db.updateWorkflowPhase(workflowId, "waiting_approval", {
-        phase: "waiting_approval",
-        timestamp: new Date().toISOString(),
-        success: true,
-        summary: `Waiting for approval: ${gateKey} (${approvalId})`,
-      });
-      db.pauseWorkflowRun(workflowId);
-      await reportStep(phaseName, "awaiting", phase.approval_gate_message, { gateKey }, { alsoNote: true });
-      return { result, paused: true };
-    }
-
-    persistPhase(phaseName);
-    await reportStep(phaseName, "done", phase.messages?.on_success);
-    return { result };
-  }
-
-  // ── Main DAG execution loop ────────────────────────────────────────────────
-
-  while (!isComplete(dag)) {
-    // Cancel check (DAG path) — mirror the linear runner's between-phase
-    // guard so a /cancel dispatch halts the next scheduling round.
-    if (db && workflowId) {
-      const latest = db.getWorkflowRun(workflowId);
-      if (latest?.status === "cancelled") {
-        console.log(`[runner:dag] ${definition.name} cancelled — stopping DAG`);
-        return { success: false, phases };
-      }
-    } else {
-      console.warn(`[runner:dag] cancel check skipped — no db/workflowId context`);
-    }
-
-    // First, mark nodes that should be skipped (trigger rule fails but deps are terminal)
-    const toSkip = getNodesToSkip(dag);
-    for (const node of toSkip) {
-      node.status = "skipped";
-      phases.push({ phase: node.name, success: true, output: "Skipped (trigger rule not satisfied)" });
-      if (db && workflowId) {
-        db.updateNodeStatus(workflowId, node.name, "skipped");
-      }
-    }
-
-    const ready = getReadyNodes(dag);
-
-    if (ready.length === 0) {
-      if (toSkip.length === 0) break; // stuck (shouldn't happen in a valid DAG)
-      continue; // only had skips — loop to process downstream
-    }
-
-    // Mark all ready nodes as running before dispatching
-    for (const node of ready) {
-      node.status = "running";
-      if (db && workflowId) {
-        db.updateNodeStatus(workflowId, node.name, "running");
-      }
-    }
-
-    // Dispatch all ready nodes concurrently
-    const nodePromises = ready.map(async (node) => {
-      try {
-      const phase = phaseMap.get(node.name)!;
-      await onStart(node.name);
-
-      // Context phase — immediate
-      if (phase.type === "context" || !phase.type) {
-        const r: PhaseResult = { phase: node.name, success: true, output: "Context assembled" };
-        // Same persist-history fix as the linear runner so the dashboard
-        // marks context nodes done.
-        persistPhase(node.name, "Context assembled");
-        await onEnd(node.name, r);
-        return { node, result: r, paused: false, alreadyPushed: false };
-      }
-
-      // Phase with neither prompt nor skill — skip
-      if (!phase.prompt && !phase.skill) {
-        console.warn(`[dag] Phase "${node.name}" has type=agent but neither prompt: nor skill: — skipping`);
-        const r: PhaseResult = { phase: node.name, success: true, output: "Skipped (no prompt or skill)" };
-        return { node, result: r, paused: false, alreadyPushed: false };
-      }
-
-      // Loop phase (reviewer-style) — run sequentially as a single DAG node
-      if (phase.loop) {
-        const loop = phase.loop;
-        const MAX_CYCLES = loop.max_cycles;
-        let approved = false;
-        let fixCycles = 0;
-
-        while (!approved && fixCycles <= MAX_CYCLES) {
-          const reviewLabel =
-            fixCycles === 0
-              ? PhaseRef.review(node.name).format()
-              : PhaseRef.recheck(node.name, fixCycles).format();
-          const reviewPrompt =
-            fixCycles === 0
-              ? buildPhasePrompt(phase, ctx, { phaseOutputs: { ...outputs }, fixCycle: fixCycles })
-              : renderPrompt(loop.on_request_changes.re_review_prompt, { phaseOutputs: { ...outputs }, fixCycle: fixCycles });
-          const reviewModelRaw = phase.model ? renderTemplate(phase.model, ctx) : undefined;
-          const reviewModel = reviewModelRaw || modelFor(node.name);
-          const reviewVariantRaw = phase.variant ? renderTemplate(phase.variant, ctx) : undefined;
-          const reviewVariant = reviewVariantRaw || variantFor(node.name);
-
-          const rr = await runPhase(
-            definition.name,
-            reviewLabel,
-            `${taskId}-${reviewLabel}`,
-            triggerId,
-            reviewPrompt,
-            phaseConfigFor(config, phase),
-            db,
-            reviewModel,
-            workflowId,
-            githubAccess,
-            reviewVariant,
-          );
-          if (rr.skipped) {
-            approved = true;
-            phases.push({ phase: reviewLabel, success: true, output: "Already completed" });
-            break;
-          }
-
-          phases.push({ phase: reviewLabel, ...pickResult(rr.result) });
-          await onEnd(reviewLabel, phases[phases.length - 1]);
-
-          const reviewerOutput = (rr.result.output || "").trim();
-          const { verdict, viaFallback } = parseReviewerVerdict(reviewerOutput);
-          const isApproved = verdict === "APPROVED";
-          if (viaFallback) {
-            console.warn(
-              `[runner] Reviewer output missing VERDICT: marker — using fallback detection (isApproved=${isApproved})`,
-            );
-          }
-
-          if (isApproved) {
-            approved = true;
-          } else if (fixCycles < MAX_CYCLES) {
-            fixCycles++;
-            const fixLabel = PhaseRef.fix(node.name, fixCycles).format();
-            const fixPromptRendered = renderPrompt(loop.on_request_changes.fix_prompt, { phaseOutputs: { ...outputs }, fixCycle: fixCycles });
-            const fixModelRaw = loop.on_request_changes.fix_model ? renderTemplate(loop.on_request_changes.fix_model, ctx) : undefined;
-            const fixModel = fixModelRaw || modelFor(`${node.name}_fix`) || modelFor(node.name);
-            const fixVariantRaw = loop.on_request_changes.fix_variant ? renderTemplate(loop.on_request_changes.fix_variant, ctx) : undefined;
-            const fixVariant = fixVariantRaw || variantFor(`${node.name}_fix`) || variantFor(node.name);
-            const fr = await runPhase(
-              definition.name,
-              fixLabel,
-              `${taskId}-fix${fixCycles}`,
-              triggerId,
-              fixPromptRendered,
-              phaseConfigFor(config, phase),
-              db,
-              fixModel,
-              workflowId,
-              githubAccess,
-              fixVariant,
-            );
-            if (!fr.skipped) {
-              phases.push({ phase: fixLabel, ...pickResult(fr.result) });
-              await onEnd(fixLabel, phases[phases.length - 1]);
-            }
-          } else {
-            break;
-          }
-        }
-
-        const loopResult: PhaseResult = { phase: node.name, success: approved, output: approved ? "Approved" : "Request changes" };
-        if (phase.output_var) {
-          outputs[phase.output_var] = { approved, cycles: fixCycles };
-        }
-        return { node, result: loopResult, paused: false, alreadyPushed: true };
-      }
-
-      // Generic loop phase
-      if (phase.generic_loop) {
-        const loop = phase.generic_loop;
-        const MAX_ITER = loop.max_iterations;
-        const MAX_PREV_OUTPUT_BYTES = 10 * 1024;
-        let iteration = 0;
-        let complete = false;
-        let previousOutput = "";
-
-        while (!complete && iteration < MAX_ITER) {
-          iteration++;
-          const iterLabel = PhaseRef.iter(node.name, iteration).format();
-          const iterCtx: Partial<TemplateContext> = {
-            iteration,
-            maxIterations: MAX_ITER,
-            previousOutput: loop.fresh_context ? "" : previousOutput,
-            phaseOutputs: { ...outputs },
-          };
-          const iterPrompt = buildPhasePrompt(phase, ctx, iterCtx);
-          const modelRaw = phase.model ? renderTemplate(phase.model, ctx) : undefined;
-          const model = modelRaw || modelFor(node.name);
-          const variantRaw = phase.variant ? renderTemplate(phase.variant, ctx) : undefined;
-          const variant = variantRaw || variantFor(node.name);
-
-          const ir = await runPhase(
-            definition.name,
-            iterLabel,
-            `${taskId}-${iterLabel}`,
-            triggerId,
-            iterPrompt,
-            phaseConfigFor(config, phase),
-            db,
-            model,
-            workflowId,
-            githubAccess,
-            variant,
-          );
-          if (ir.skipped) { complete = true; break; }
-
-          phases.push({ phase: iterLabel, ...pickResult(ir.result) });
-          await onEnd(iterLabel, phases[phases.length - 1]);
-
-          if (!ir.result.success) {
-            failWorkflow(ir.result.error);
-            return { node, result: { phase: node.name, success: false, output: "", error: ir.result.error }, paused: false, alreadyPushed: true };
-          }
-
-          const iterOutput = ir.result.output || "";
-          if (!loop.fresh_context) {
-            const combined = previousOutput ? `${previousOutput}\n${iterOutput}` : iterOutput;
-            previousOutput = combined.length > MAX_PREV_OUTPUT_BYTES ? combined.slice(-MAX_PREV_OUTPUT_BYTES) : combined;
-          }
-
-          let conditionMet = false;
-          if (loop.until) {
-            conditionMet = evalUntilExpression(loop.until, { output: iterOutput, ...Object.fromEntries(Object.entries(ctx).filter(([, v]) => typeof v === "string").map(([k, v]) => [k, v as string])) });
-          }
-          if (!conditionMet && loop.until_bash) {
-            try { validateShellCommand(loop.until_bash); execSync(loop.until_bash, { timeout: 30_000, stdio: "pipe", cwd: config.sandboxDir ?? config.cwd }); conditionMet = true; }
-            catch { conditionMet = false; }
-          }
-          if (conditionMet) { complete = true; }
-        }
-
-        if (!complete) {
-          await reportStep(node.name, "failed", phase.messages?.on_failure, { iteration, maxIterations: MAX_ITER });
-        }
-        if (phase.output_var) {
-          outputs[phase.output_var] = { completed: complete, iterations: iteration };
-        }
-        return { node, result: { phase: node.name, success: true, output: previousOutput || "" }, paused: false, alreadyPushed: true };
-      }
-
-      // Standard agent phase
-      const { result, paused } = await executeSinglePhase(phase, node.name);
-      await onEnd(node.name, result);
-      return { node, result, paused: paused ?? false, alreadyPushed: false };
-      } catch (err) {
-        console.error(`[dag] Phase "${node.name}" threw unexpectedly:`, err);
-        const result: PhaseResult = { phase: node.name, success: false, error: String(err), output: "" };
-        return { node, result, paused: false, alreadyPushed: false };
-      }
-    });
-
-    const settled = await Promise.allSettled(nodePromises);
-
-    let anyPaused = false;
-    for (const settledItem of settled) {
-      if (settledItem.status === "rejected") {
-        console.error("[dag] Phase promise rejected:", settledItem.reason);
-        continue;
-      }
-
-      const { node, result, paused, alreadyPushed } = settledItem.value;
-
-      if (!alreadyPushed) {
-        phases.push(result);
-      }
-
-      if (paused) {
-        anyPaused = true;
-        node.status = "succeeded"; // treat paused as succeeded so downstream trigger rules fire correctly — the workflow will resume from this node's successors after approval
-        continue;
-      }
-
-      node.status = result.success ? "succeeded" : "failed";
-      if (db && workflowId) {
-        db.updateNodeStatus(workflowId, node.name, node.status);
-      }
-
-      // Always record the raw phase output (both by phase name and any
-      // configured output_var alias) so downstream prompts can interpolate via
-      // ${phaseName.output} or {{alias}}. Loop phases that emit structured
-      // objects set their output_var themselves above — don't clobber those.
-      const phaseDef = phaseMap.get(node.name)!;
-      if (result.output != null) {
-        if (outputs[node.name] === undefined || typeof outputs[node.name] === "string") {
-          outputs[node.name] = result.output;
-        }
-        if (phaseDef.output_var && outputs[phaseDef.output_var] === undefined) {
-          outputs[phaseDef.output_var] = result.output;
-        }
-      }
-    }
-
-    if (anyPaused) {
-      return { success: true, phases, paused: true };
-    }
-  }
-
-  // Determine overall success
-  const anyFailed = phases.some((p) => !p.success);
-  return { success: !anyFailed, phases };
 }

--- a/src/workflows/simple.ts
+++ b/src/workflows/simple.ts
@@ -9,7 +9,7 @@ import {
   type RunnerCallbacks,
   type WorkflowResult,
 } from "./runner.js";
-import { nextPhaseAfter } from "./phase-ref.js";
+import { PhaseRef } from "./phase-ref.js";
 import type { TemplateContext } from "./templates.js";
 import { slugify } from "./templates.js";
 import { wrapUntrusted } from "../engine/screen.js";
@@ -142,8 +142,8 @@ export async function runSimpleWorkflow(
   // ── Resume handling ────────────────────────────────────────────────────────
   //
   // If a workflow_run already exists for this trigger, reuse its id. The
-  // runner's `nextPhaseAfter(definition, currentPhase)` derives the resume
-  // point — no per-workflow branching needed.
+  // runner re-runs from the top and the executions ledger (`shouldRunPhase`)
+  // skips already-completed phases — no per-workflow branching needed.
 
   // Only reuse a workflow_run row when the existing run is still live
   // (running/paused). `getWorkflowRunByTrigger` already filters out
@@ -347,53 +347,32 @@ async function handleExistingRun(
   notify: (msg: string) => Promise<void>,
   db: StateDb,
 ): Promise<WorkflowResult | null> {
-  // Workflow already completed (currentPhase points past the last real phase
-  // — e.g. a set_phase terminal marker like "complete"). Don't re-run.
-  // "waiting_approval" is a synthetic phase set when the runner pauses at a
-  // gate — it's NOT a terminal marker, so exclude it from this check.
+  // Workflow already completed: currentPhase is a terminal set_phase marker
+  // (e.g. "complete") — i.e. not a declared phase, not a generated loop label
+  // (`*_fix_N` / `*_recheck_N` / `*_iter_N`), and not the synthetic
+  // "waiting_approval" pause marker. Don't re-run.
   if (
     run.currentPhase &&
     run.currentPhase !== "waiting_approval" &&
-    nextPhaseAfter(definition, run.currentPhase) === null
+    !definition.phases.some((p) => p.name === run.currentPhase) &&
+    PhaseRef.parse(run.currentPhase).kind === "phase"
   ) {
-    const exactIdx = definition.phases.findIndex((p) => p.name === run.currentPhase);
-    if (exactIdx === -1) {
-      await notify(`Workflow \`${run.workflowName}\` is already complete for this trigger.`);
-      return {
-        success: true,
-        phases: [{ phase: "resume", success: true, output: "Already complete" }],
-      };
-    }
+    await notify(`Workflow \`${run.workflowName}\` is already complete for this trigger.`);
+    return {
+      success: true,
+      phases: [{ phase: "resume", success: true, output: "Already complete" }],
+    };
   }
 
   // Paused awaiting approval — see if a human has responded.
   if (run.status === "paused" && run.currentPhase === "waiting_approval") {
     const pendingApproval = db.getPendingApprovalForWorkflow(run.id);
     if (pendingApproval?.status === "approved") {
-      // Reply gates are a different shape than approve gates: the runner
-      // needs to RE-ENTER the same phase (to run the next loop iteration)
-      // rather than skip past it. Find the phase that owns the gate, and
-      // set currentPhase to the phase BEFORE it so nextPhaseAfter lands
-      // on the owning phase on resume.
-      const owningPhase = findPhaseOwningLoopGate(definition, pendingApproval.gate)
-        ?? findPhaseOwningGate(definition, pendingApproval.gate);
-      if (owningPhase && pendingApproval.kind === "reply") {
-        const ownIdx = definition.phases.findIndex((p) => p.name === owningPhase);
-        const priorPhase = ownIdx > 0 ? definition.phases[ownIdx - 1].name : "";
-        db.updateWorkflowPhase(run.id, priorPhase || owningPhase, {
-          phase: priorPhase || owningPhase,
-          timestamp: new Date().toISOString(),
-          success: true,
-          summary: `Resumed after reply on gate: ${pendingApproval.gate}`,
-        });
-      } else if (owningPhase) {
-        db.updateWorkflowPhase(run.id, owningPhase, {
-          phase: owningPhase,
-          timestamp: new Date().toISOString(),
-          success: true,
-          summary: `Resumed after gate approval: ${pendingApproval.gate}`,
-        });
-      }
+      // Resume is ledger-driven: the runner re-runs from the top and every
+      // completed phase skips via `shouldRunPhase` (the executions ledger).
+      // No currentPhase manipulation is needed — for an approve gate the
+      // gated phase is already `done` so the runner proceeds past it; for a
+      // reply gate the loop node resumes from `scratch.iteration`.
       console.log(
         `[simple] ${pendingApproval.kind === "reply" ? "Reply" : "Approval"} received for gate ${pendingApproval.gate} — resuming ${run.workflowName}`,
       );
@@ -420,33 +399,5 @@ async function handleExistingRun(
   console.log(
     `[simple] Resuming ${run.workflowName} for ${run.triggerId} (last phase: ${run.currentPhase})`,
   );
-  return null;
-}
-
-/** Walk definition.phases and return the phase that declares this gate. */
-function findPhaseOwningGate(
-  definition: ReturnType<typeof getWorkflow>,
-  gateName: string,
-): string | null {
-  for (const p of definition.phases) {
-    if (p.approval_gate === gateName) return p.name;
-    if (p.loop?.approval_gate === gateName) return p.name;
-  }
-  return null;
-}
-
-/**
- * Generic-loop gates are named `${phaseName}_iter_${N}`, so walk the phases
- * with `generic_loop` set and match by prefix. Used for reply-gate resume
- * where the gate name isn't declared up front.
- */
-function findPhaseOwningLoopGate(
-  definition: ReturnType<typeof getWorkflow>,
-  gateName: string,
-): string | null {
-  for (const p of definition.phases) {
-    if (!p.generic_loop) continue;
-    if (gateName.startsWith(`${p.name}_iter_`)) return p.name;
-  }
   return null;
 }


### PR DESCRIPTION
Closes #94.

Collapses the duplicated linear `runWorkflow` loop and `runDagWorkflow` into **one sequential scheduler** that executes every workflow as a DAG (linear = a chain-synthesized degenerate DAG). Built test-first across the three stages the issue suggested.

## What changed

### Stage 1 — `PhaseExecutor` (`src/workflows/phase-executor.ts`, new)
Every per-phase body (context / standard agent / reviewer-loop / generic-loop, plus approval & reply gates) now lives behind one `execute(node, outputs) → PhaseOutcome` method, built from three grouped collaborators (run-scoped data / `PhaseReporter` / `PhaseResolver`). Directly unit-tested with fakes (`phase-executor.test.ts`). Because DAG nodes now route through the same executor, **loop nodes finally support approval/reply gates**.

### Stage 2 — one sequential scheduler (`runner.ts`: ~1656 → ~390 lines)
- `buildDag(phases, { chainIfNoDeps })` synthesizes a previous-phase chain when no `depends_on` is declared (reproducing linear semantics incl. the failure cascade); declared edges used as-is otherwise.
- `runDagWorkflow` / `DagRunnerCtx` / `hasDependencies` deleted. Ready nodes run **one at a time in declaration order** (real concurrency via worktrees deferred).
- **One `ctx.taskId` workspace** for every phase + loop iteration — drops the old `${taskId}-${phaseName}` clones and fixes the DAG fix-loop-ran-in-a-different-clone bug.
- Uniform trigger-rule skip semantics; `isTerminated` + error propagation preserved.

### Stage 3 — ledger-driven resume + dead-code deletion
- Resume re-runs from the top; `shouldRunPhase` (the `executions` ledger) skips completed phases. The `currentPhase`-reset scaffolding is gone from `simple.ts` **and** `index.ts`; gates resolve purely via approval status.
- Skipped phases recorded in the ledger (`recordSkippedPhase`).
- Deleted: `node_statuses` (column ALTER, `updateNodeStatus`, field/mapping), `nextPhaseAfter`, `phaseIndexInDefinition`. Kept `PhaseRef.format`/`parse` + `parseReviewerVerdict`.

## Tests
`dag.test.ts` chain synthesis; rewritten resume/routing tests; new tests for `PhaseExecutor`, one-workspace, sequential ordering, skip-in-ledger, loop-gate-in-node, `node_statuses` removal; and a **golden test** pinning `build.yaml`'s phase sequence. `src/workflows/CLAUDE.md` updated.

- ✅ `npx vitest run` — 590 passed
- ✅ `tsc --noEmit` clean, `npm run build` clean, `cd dashboard && npx tsc -b` clean

## Deviation to note
The AC asks for **one literal `resumeWorkflow(run)`** funneling fresh-dispatch + boot recovery. This PR unifies the resume **mechanism** (both paths now rely on the identical ledger re-run-from-top; scaffolding deleted) but does **not** extract a single function — the two callers reconstruct the template context very differently (live request data vs. GitHub refetch + Slack/checklist reattach), which is entangled with the `StateDb → WorkflowRunStore` change deferred to #97. Also: `handleExistingRun` in `simple.ts` has no direct unit test (no `simple.test.ts` harness); its change is a reasoned 1:1 equivalence, and runner-level resume is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)