### PR TITLE
ci: run typecheck + test on pull requests and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# Cancel superseded runs on the same ref (e.g. a force-push to a PR branch).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck (server)
+        run: npx tsc --noEmit
+
+      - name: Typecheck (dashboard)
+        run: npx tsc -b dashboard
+
+      - name: Test
+        run: npx vitest run


### PR DESCRIPTION
## Why

The only workflow today, `publish.yml`, runs typecheck → test → build **only on `v*` tags** (the publish path). Nothing guards pull requests or pushes to `main`, so a regression can only be caught at release time.

## What

Adds `.github/workflows/ci.yml`, running on every PR and push to `main`:

- **Typecheck (server)** — `tsc --noEmit`
- **Typecheck (dashboard)** — `tsc -b dashboard`
- **Test** — `vitest run`

Commands mirror what `publish.yml` already proves, plus the dashboard typecheck documented in CLAUDE.md. Concurrency cancels superseded runs on the same ref.

## No lint step

The repo has no linter configured (no eslint/biome/config/script), so there's nothing to run — typecheck is the static-analysis gate. (Decision: typecheck + test only.)

## Note

This is independent of #103. Once merged, CI guards all subsequent PRs; #103 will pick it up on its next push/rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)