### PR TITLE
perf(sandbox): per-PR workspace reuse, shallow clones, shared package cache (#107)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,6 +406,32 @@ Sandbox egress (docker backend only):
 - `LASTLIGHT_DNS_STRICT` / `LASTLIGHT_DNS_OPEN` — override the IP of the
   coredns sidecar passed to `docker run --dns ...` (defaults: `172.30.0.10`
   and `172.30.0.11`, matching the static IPs in docker-compose.yml).
+- `LASTLIGHT_PKG_CACHE_VOLUME` — docker named volume mounted at `/cache` in
+  every sandbox as the shared package-manager download cache (issue #107).
+  Default `lastlight_pkg-cache` (declared in docker-compose.yml). The
+  sandbox env points `npm_config_cache` → `/cache/npm`,
+  `npm_config_store_dir` (pnpm) → `/cache/pnpm`, and `YARN_CACHE_FOLDER` →
+  `/cache/yarn`; the agent picks the package manager from the repo's
+  lockfile (see `skills/pr-review/SKILL.md`), so repeated installs reuse
+  already-fetched tarballs regardless of which one a repo uses. This is the
+  *download* cache only — per-workspace `node_modules` stays per-workspace
+  (a shared store can't hardlink across separate container mounts). Disk is
+  bounded instead by per-PR workspace reuse (`PER_TARGET_REUSE_WORKFLOWS`
+  in `src/workflows/simple.ts`) plus #106's reaping.
+
+Sandbox workspace provisioning (issue #107):
+
+- **Shallow clone** — read-only workflows (everything except the
+  `repo-write` profiles `build` / `pr-fix` / `security-feedback`) pre-clone
+  at `--depth 1 --single-branch`; code-pushing workflows keep `--depth 50`.
+  See `gitSandboxAccessForWorkflow` (`src/workflows/runner.ts`) →
+  `prePopulateWorkspace` (`src/sandbox/index.ts`).
+- **Per-PR workspace reuse** — `pr-review` / `pr-fix` workspaces are keyed
+  by (repo, PR) and reused across runs. A `<workDir>/.lastlight-run` marker
+  records the owning run: same run → preserve the checkout for the next
+  phase; a different run reusing the dir → `git fetch` + `reset --hard` +
+  `git clean -fdx -e node_modules` (deps stay warm). See the workflows
+  guide's "taskId scoping" section.
 
 OpenTelemetry (optional):
 

--- a/deploy/sandbox-entrypoint.sh
+++ b/deploy/sandbox-entrypoint.sh
@@ -21,6 +21,18 @@ chown agent:agent "$AGENT_HOME"
 mkdir -p "$AGENT_HOME/.config"
 chown agent:agent "$AGENT_HOME/.config"
 
+# ── Shared package-manager cache (issue #107) ──
+# /cache is a Docker named volume shared across every sandbox so npm / pnpm /
+# yarn reuse already-downloaded tarballs. A freshly-created volume is root-owned;
+# chown the per-PM subdirs (non-recursive — existing children are already
+# agent-owned from prior runs) so the agent user can write to them.
+if [ -d /cache ]; then
+  for sub in npm pnpm yarn; do
+    mkdir -p "/cache/$sub"
+    chown agent:agent "/cache/$sub" 2>/dev/null || true
+  done
+fi
+
 # ── App PEM: keep shared copy unreadable by the agent by default ──
 if [ -f /data/secrets/app.pem ]; then
   chmod 600 /data/secrets/app.pem 2>/dev/null || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,6 +205,13 @@ services:
 
 volumes:
   agent-data:       # contains: lastlight.db, agent-sessions/, sandboxes/, secrets/, logs/, proxy/
+  # Shared package-manager download cache (npm/pnpm/yarn), mounted at /cache in
+  # every dynamically-created sandbox container by src/sandbox/docker.ts so
+  # repeated installs reuse already-fetched tarballs (issue #107). Declared
+  # here so the stack manages its lifecycle; the agent service does not mount
+  # it. Override the name with LASTLIGHT_PKG_CACHE_VOLUME (defaults to the
+  # compose-prefixed `lastlight_pkg-cache`).
+  pkg-cache:
   caddy-data:
   caddy-config:
 

--- a/src/engine/agent-executor.ts
+++ b/src/engine/agent-executor.ts
@@ -190,6 +190,8 @@ export async function executeAgent(
           repo: access.repo,
           branch: access.prePopulateBranch,
           token: mintedToken,
+          runId: access.runId,
+          shallow: access.shallow,
         }
       : undefined;
 
@@ -451,7 +453,7 @@ async function executeDocker(
     taskId: string;
     stateDir: string;
     env: Record<string, string>;
-    prePopulate?: { owner: string; repo: string; branch: string; token: string };
+    prePopulate?: { owner: string; repo: string; branch: string; token: string; runId?: string; shallow?: boolean };
     access?: GitSandboxAccess;
     onSessionId?: (sessionId: string) => void;
   },

--- a/src/engine/profiles.ts
+++ b/src/engine/profiles.ts
@@ -164,6 +164,23 @@ export interface GitSandboxAccess {
    * branch fresh.
    */
   prePopulateBranch?: string;
+  /**
+   * The owning workflow run id. Stamped into a `<workDir>/.lastlight-run`
+   * marker by the pre-clone so a reused per-PR workspace (see
+   * `workflowScopedTaskId` for pr-review / pr-fix) can tell "next phase of
+   * the same run" (preserve the checkout — build's plan.md lives here) from
+   * "a fresh run reusing an old PR dir" (fetch + hard-reset + clean, keeping
+   * node_modules warm). Unset for non-workflow callers, which keep the old
+   * skip-if-`.git`-exists behaviour.
+   */
+  runId?: string;
+  /**
+   * Clone shallowly (`--depth 1 --single-branch`). Set for read-only
+   * workflows that never need history; repo-write workflows (build, pr-fix,
+   * security-feedback) keep the deeper `--depth 50` clone so rebases / amends
+   * have headroom.
+   */
+  shallow?: boolean;
 }
 
 export const GITHUB_PERMISSION_PROFILES: Record<GitAccessProfile, GitHubTokenPermissions> = {

--- a/src/sandbox/docker.test.ts
+++ b/src/sandbox/docker.test.ts
@@ -3,7 +3,18 @@ import { EventEmitter } from "events";
 
 vi.mock("child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("child_process")>();
-  return { ...actual, spawn: vi.fn() };
+  return {
+    ...actual,
+    spawn: vi.fn(),
+    // create() runs `docker run` via execFileSync and polls readiness via
+    // execFile (promisified). Stub both so create() can be exercised without a
+    // real docker daemon.
+    execFileSync: vi.fn().mockReturnValue("container-xyz\n"),
+    execFile: vi.fn((_cmd: string, _args: string[], opts: unknown, cb?: unknown) => {
+      const done = (typeof opts === "function" ? opts : cb) as (e: unknown, r: unknown) => void;
+      done(null, { stdout: "", stderr: "" });
+    }),
+  };
 });
 
 vi.mock("fs", async (importOriginal) => {
@@ -11,10 +22,11 @@ vi.mock("fs", async (importOriginal) => {
   return { ...actual, existsSync: vi.fn().mockReturnValue(true), readFileSync: vi.fn().mockReturnValue("{}") };
 });
 
-import { spawn } from "child_process";
+import { spawn, execFileSync } from "child_process";
 import { DockerSandbox } from "./docker.js";
 
 const mockSpawn = vi.mocked(spawn);
+const mockExecFileSync = vi.mocked(execFileSync);
 
 function makeFakeChild() {
   const stdin = { write: vi.fn(), end: vi.fn() };
@@ -100,5 +112,50 @@ describe("DockerSandbox.runAgent — prompt via stdin, not shell arg", () => {
     expect(shCmd).toContain("--sandbox none");
     expect(shCmd).not.toContain("--no-file-search");
     expect(shCmd).not.toContain("test prompt");
+  });
+});
+
+describe("DockerSandbox.create — shared package cache (issue #107)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecFileSync.mockReturnValue("container-xyz\n");
+  });
+
+  function dockerRunArgv(): string[] {
+    const call = mockExecFileSync.mock.calls.find(
+      (c) => Array.isArray(c[1]) && (c[1] as string[])[0] === "run",
+    );
+    return (call?.[1] as string[]) ?? [];
+  }
+
+  it("mounts the shared cache volume and wires npm/pnpm/yarn env", async () => {
+    const manager = new DockerSandbox({ imageName: "img", env: {} });
+    await manager.create({
+      taskId: "repo-1-pr-review",
+      worktreePath: "/tmp/work",
+      workspaceMount: { type: "bind", hostPath: "/tmp/work" },
+    });
+    const argv = dockerRunArgv();
+    expect(argv).toContain("lastlight_pkg-cache:/cache");
+    expect(argv).toContain("npm_config_cache=/cache/npm");
+    expect(argv).toContain("npm_config_store_dir=/cache/pnpm");
+    expect(argv).toContain("YARN_CACHE_FOLDER=/cache/yarn");
+  });
+
+  it("honours LASTLIGHT_PKG_CACHE_VOLUME override", async () => {
+    const prev = process.env.LASTLIGHT_PKG_CACHE_VOLUME;
+    process.env.LASTLIGHT_PKG_CACHE_VOLUME = "my-cache";
+    try {
+      const manager = new DockerSandbox({ imageName: "img", env: {} });
+      await manager.create({
+        taskId: "t",
+        worktreePath: "/tmp/work",
+        workspaceMount: { type: "bind", hostPath: "/tmp/work" },
+      });
+      expect(dockerRunArgv()).toContain("my-cache:/cache");
+    } finally {
+      if (prev === undefined) delete process.env.LASTLIGHT_PKG_CACHE_VOLUME;
+      else process.env.LASTLIGHT_PKG_CACHE_VOLUME = prev;
+    }
   });
 });

--- a/src/sandbox/docker.ts
+++ b/src/sandbox/docker.ts
@@ -79,6 +79,8 @@ export type WorkspaceMount =
   | { type: "volume-subpath"; volume: string; subpath: string };
 
 const WORKSPACE_DIR = "/home/agent/workspace";
+/** Shared package-manager download cache mount (issue #107). */
+const PKG_CACHE_DIR = "/cache";
 
 export class DockerSandbox {
   private config: SandboxConfig;
@@ -134,6 +136,31 @@ export class DockerSandbox {
         `type=volume,source=${volume},target=${WORKSPACE_DIR},volume-subpath=${subpath}`,
       );
     }
+
+    // Shared package-manager cache, mounted at /cache and shared across every
+    // sandbox (issue #107). Each ecosystem's download cache is content-
+    // addressed, so sharing across repos is safe and avoids re-fetching the
+    // same tarballs on every run. We point npm / pnpm / yarn at subdirs of it
+    // via env below; the entrypoint chowns them to the agent user. This is the
+    // *download* cache only — per-workspace `node_modules` stays per-workspace
+    // (a shared store can't hardlink across separate container mounts anyway).
+    //
+    // A Docker named volume (auto-created on first use); override the name with
+    // LASTLIGHT_PKG_CACHE_VOLUME. In local path-mode this is still a named
+    // volume — it needs no host-path view, so the volume/bind split that the
+    // workspace mount needs doesn't apply here.
+    const pkgCacheVolume = process.env.LASTLIGHT_PKG_CACHE_VOLUME || "lastlight_pkg-cache";
+    dockerArgs.push("-v", `${pkgCacheVolume}:${PKG_CACHE_DIR}`);
+    // Point each package manager at its shared subdir. npm reads npm_config_cache;
+    // pnpm reads npm-style env config (npm_config_store_dir → store-dir); yarn
+    // (classic + berry) reads YARN_CACHE_FOLDER. The agent already picks the PM
+    // from the repo's lockfile (see skills/pr-review/SKILL.md), so all three are
+    // wired regardless of which one a given repo uses.
+    dockerArgs.push(
+      "-e", `npm_config_cache=${PKG_CACHE_DIR}/npm`,
+      "-e", `npm_config_store_dir=${PKG_CACHE_DIR}/pnpm`,
+      "-e", `YARN_CACHE_FOLDER=${PKG_CACHE_DIR}/yarn`,
+    );
 
     // Resolve git mounts for worktrees (if .git is a file pointing elsewhere).
     // In volume-subpath mode these are still emitted as bind mounts; the

--- a/src/sandbox/index.test.ts
+++ b/src/sandbox/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("child_process")>();
@@ -6,11 +6,26 @@ vi.mock("child_process", async (importOriginal) => {
 });
 
 import { execFileSync } from "child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { __prePopulateWorkspaceForTest as prePopulateWorkspace } from "./index.js";
 
 const mockExec = vi.mocked(execFileSync);
 
 const TOKEN = "ghs_secret123ABC_xyz";
+
+/** Flatten every execFileSync invocation's argv (args[1]) for assertions. */
+function calledArgs(): string[][] {
+  return mockExec.mock.calls.map((c) => (c[1] as string[]) ?? []);
+}
 
 describe("prePopulateWorkspace token-leak protection", () => {
   afterEach(() => {
@@ -69,5 +84,100 @@ describe("prePopulateWorkspace token-leak protection", () => {
     })).toThrow(/outside \[A-Za-z0-9_-\]/);
     expect(mockExec).not.toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+});
+
+describe("prePopulateWorkspace clone depth + per-PR reuse (issue #107)", () => {
+  let workDir: string;
+  const REPO = "lastlight";
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "ll-prepop-"));
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExec.mockReturnValue(Buffer.from(""));
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockExec.mockReset();
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  /** Pretend the workspace already has a clone, with `marker` as last run. */
+  function seedExistingClone(marker?: string): void {
+    mkdirSync(join(workDir, REPO, ".git"), { recursive: true });
+    if (marker !== undefined) writeFileSync(join(workDir, ".lastlight-run"), marker);
+  }
+
+  it("clones read-only workflows shallow (--depth 1 --single-branch)", () => {
+    prePopulateWorkspace(workDir, {
+      owner: "cliftonc", repo: REPO, branch: "main", token: TOKEN,
+      runId: "run-1", shallow: true,
+    });
+    const clone = calledArgs().find((a) => a[0] === "clone")!;
+    expect(clone).toContain("--depth");
+    expect(clone[clone.indexOf("--depth") + 1]).toBe("1");
+    expect(clone).toContain("--single-branch");
+    // Marker stamped so a later same-run phase preserves the workspace.
+    expect(readFileSync(join(workDir, ".lastlight-run"), "utf-8")).toBe("run-1");
+  });
+
+  it("clones code-writing workflows deep (--depth 50, no --single-branch)", () => {
+    prePopulateWorkspace(workDir, {
+      owner: "cliftonc", repo: REPO, branch: "main", token: TOKEN,
+      runId: "run-1", shallow: false,
+    });
+    const clone = calledArgs().find((a) => a[0] === "clone")!;
+    expect(clone[clone.indexOf("--depth") + 1]).toBe("50");
+    expect(clone).not.toContain("--single-branch");
+  });
+
+  it("preserves the workspace when a later phase of the SAME run revisits it", () => {
+    seedExistingClone("run-1");
+    prePopulateWorkspace(workDir, {
+      owner: "cliftonc", repo: REPO, branch: "main", token: TOKEN, runId: "run-1",
+    });
+    // No git ops — the architect's uncommitted scratch must survive.
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("preserves the workspace for callers that don't track a run id", () => {
+    seedExistingClone();
+    prePopulateWorkspace(workDir, {
+      owner: "cliftonc", repo: REPO, branch: "main", token: TOKEN,
+    });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("refreshes (fetch+reset+clean) when a DIFFERENT run reuses the PR dir", () => {
+    seedExistingClone("old-run");
+    prePopulateWorkspace(workDir, {
+      owner: "cliftonc", repo: REPO, branch: "pr-head", token: TOKEN,
+      runId: "new-run", shallow: true,
+    });
+    const verbs = calledArgs().map((a) => a[a.indexOf("-C") + 2]);
+    expect(verbs).toEqual(["fetch", "checkout", "reset", "clean"]);
+    // node_modules is kept warm so the next install is incremental.
+    const clean = calledArgs().find((a) => a.includes("clean"))!;
+    expect(clean).toContain("-e");
+    expect(clean).toContain("node_modules");
+    // Never re-clones from scratch.
+    expect(calledArgs().some((a) => a[0] === "clone")).toBe(false);
+    // Marker advanced to the new run.
+    expect(readFileSync(join(workDir, ".lastlight-run"), "utf-8")).toBe("new-run");
+  });
+
+  it("does not advance the marker if the refresh fetch fails", () => {
+    seedExistingClone("old-run");
+    mockExec.mockImplementation((_cmd, args) => {
+      if ((args as string[]).includes("fetch")) throw new Error("network down");
+      return Buffer.from("");
+    });
+    prePopulateWorkspace(workDir, {
+      owner: "cliftonc", repo: REPO, branch: "pr-head", token: TOKEN,
+      runId: "new-run", shallow: true,
+    });
+    // Stale marker retained → the next run retries the refresh.
+    expect(readFileSync(join(workDir, ".lastlight-run"), "utf-8")).toBe("old-run");
   });
 });

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { existsSync, mkdirSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { isAbsolute, join, relative, resolve, sep } from "path";
 import { DockerSandbox, type WorkspaceMount } from "./docker.js";
 
@@ -89,6 +89,11 @@ export function setupTaskWorktree(opts: {
     repo: string;
     branch: string;
     token: string;
+    /** Owning run id — stamped into a marker so a reused per-PR workspace
+     * refreshes across runs but is preserved between phases of one run. */
+    runId?: string;
+    /** Clone shallowly (`--depth 1 --single-branch`) for read-only workflows. */
+    shallow?: boolean;
   };
 }): string {
   const sandboxBase = resolve(opts.sandboxDir || join(opts.stateDir, "sandboxes"));
@@ -130,6 +135,11 @@ export async function createTaskSandbox(opts: {
     repo: string;
     branch: string;
     token: string;
+    /** Owning run id — stamped into a marker so a reused per-PR workspace
+     * refreshes across runs but is preserved between phases of one run. */
+    runId?: string;
+    /** Clone shallowly (`--depth 1 --single-branch`) for read-only workflows. */
+    shallow?: boolean;
   };
   /**
    * IP of the coredns sidecar to use as the sandbox's DNS resolver.
@@ -224,16 +234,39 @@ function isPathLike(value: string): boolean {
     value.startsWith("~");
 }
 
+/** Marker file (at the workspace root, outside the repo so `git clean` can't
+ * touch it) recording which run last provisioned this workspace. */
+const RUN_MARKER = ".lastlight-run";
+
+type PrePopulate = {
+  owner: string;
+  repo: string;
+  branch: string;
+  token: string;
+  runId?: string;
+  shallow?: boolean;
+};
+
 /**
- * Shallow-clone the repo into workDir at the given branch. Re-clones if the
- * workDir already contains a .git (cheaper than a full clone the second time
- * via `git fetch`, but rare — sandbox dirs are usually one-shot per taskId).
+ * Clone the repo into `<workDir>/<repo>` at the given branch.
+ *
+ * Three cases:
+ * - **Fresh dir** (no `.git`): clone. `--depth 1 --single-branch` for
+ *   read-only workflows (`pre.shallow`), `--depth 50` otherwise.
+ * - **Same run revisiting the workspace** (`.git` exists, run marker matches
+ *   `pre.runId`): preserve — this is a later phase of the same run reading
+ *   what an earlier phase wrote (architect's `plan.md`, the reviewer's
+ *   checkout). No git ops.
+ * - **A fresh run reusing an old per-PR workspace** (`.git` exists, marker
+ *   differs/absent): fetch + hard-reset to the remote branch + `git clean`
+ *   that **keeps `node_modules`** so the next `npm install` is incremental.
+ *   This is the re-review fast path from issue #107.
  */
 export { prePopulateWorkspace as __prePopulateWorkspaceForTest };
 
 function prePopulateWorkspace(
   workDir: string,
-  pre: { owner: string; repo: string; branch: string; token: string },
+  pre: PrePopulate,
 ): void {
   // Token shape is asserted in src/engine/git-auth.ts before we get here,
   // but re-check the narrow set here too — defense in depth, this string
@@ -249,27 +282,39 @@ function prePopulateWorkspace(
   // clone, and leaves room for `.lastlight/issue-N/` scratch space at
   // the workspace root.
   const repoDir = join(workDir, pre.repo);
-  // Repo dir might already exist from a resumed run — guard against
-  // git clone's "destination not empty" error by skipping when there's
-  // already a .git inside.
+  const markerPath = join(workDir, RUN_MARKER);
+  // Repo dir might already exist — from a later phase of the same run, or a
+  // *different* run reusing a stable per-PR workspace (issue #107).
   if (existsSync(join(repoDir, ".git"))) {
-    console.log(
-      `[sandbox] Pre-clone skipped: ${repoDir} already a git repo (resumed run).`,
-    );
+    const lastRun = readMarker(markerPath);
+    // Same run (or a caller that doesn't track runs): preserve the workspace
+    // exactly — earlier phases may have written uncommitted scratch here.
+    if (!pre.runId || lastRun === pre.runId) {
+      console.log(
+        `[sandbox] Pre-clone skipped: ${repoDir} already a git repo (same run).`,
+      );
+      return;
+    }
+    // Different run reusing this PR's workspace — refresh in place.
+    refreshExistingClone(repoDir, markerPath, pre);
     return;
   }
   const scrub = (s: unknown): string =>
     typeof s === "string" ? s.replaceAll(pre.token, "[REDACTED-TOKEN]") : "";
   const start = Date.now();
+  const depth = pre.shallow ? "1" : "50";
+  const shallowArgs = pre.shallow ? ["--single-branch"] : [];
   try {
     execFileSync(
       "git",
-      ["clone", "--branch", pre.branch, "--depth", "50", url, repoDir],
+      ["clone", "--branch", pre.branch, "--depth", depth, ...shallowArgs, url, repoDir],
       { stdio: "pipe", timeout: 120_000 },
     );
+    writeMarker(markerPath, pre.runId);
     const ms = Date.now() - start;
     console.log(
-      `[sandbox] Pre-cloned ${pre.owner}/${pre.repo}@${pre.branch} into ${repoDir} (${ms}ms)`,
+      `[sandbox] Pre-cloned ${pre.owner}/${pre.repo}@${pre.branch} into ${repoDir} ` +
+      `(depth ${depth}, ${ms}ms)`,
     );
   } catch (err: any) {
     const firstError = scrub(err?.message) || scrub(err?.stderr?.toString?.()) || "unknown error";
@@ -283,7 +328,7 @@ function prePopulateWorkspace(
       try {
         execFileSync(
           "git",
-          ["clone", "--depth", "50", url, repoDir],
+          ["clone", "--depth", depth, ...shallowArgs, url, repoDir],
           { stdio: "pipe", timeout: 120_000 },
         );
         execFileSync(
@@ -291,6 +336,7 @@ function prePopulateWorkspace(
           ["-C", repoDir, "checkout", "-b", pre.branch],
           { stdio: "pipe", timeout: 30_000 },
         );
+        writeMarker(markerPath, pre.runId);
         const ms = Date.now() - start;
         console.log(
           `[sandbox] Pre-cloned ${pre.owner}/${pre.repo} (default branch) into ${repoDir} ` +
@@ -315,6 +361,85 @@ function prePopulateWorkspace(
     console.warn(
       `[sandbox] Pre-clone of ${pre.owner}/${pre.repo}@${pre.branch} failed (${firstError}). ` +
       `Agent will need to clone via MCP.`,
+    );
+  }
+}
+
+function readMarker(markerPath: string): string | null {
+  try {
+    return readFileSync(markerPath, "utf-8").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function writeMarker(markerPath: string, runId: string | undefined): void {
+  if (!runId) return;
+  try {
+    writeFileSync(markerPath, runId);
+  } catch {
+    // Best-effort — a missing marker just means the next reuse refreshes
+    // (the safe direction), never a wrong-preserve.
+  }
+}
+
+/**
+ * Refresh a reused per-PR workspace in place: fetch the branch, hard-reset the
+ * checkout to it, and `git clean` away stale tracked/untracked build output —
+ * but **keep `node_modules`** (and any nested ones) so the next install is
+ * incremental against a warm tree. The shared package cache (docker backend)
+ * lives on a separate mount and is untouched by `git clean`.
+ *
+ * On any failure we leave the workspace as-is and do NOT advance the marker,
+ * so the next run retries the refresh rather than reviewing a half-reset tree.
+ */
+function refreshExistingClone(
+  repoDir: string,
+  markerPath: string,
+  pre: PrePopulate,
+): void {
+  const scrub = (s: unknown): string =>
+    typeof s === "string" ? s.replaceAll(pre.token, "[REDACTED-TOKEN]") : "";
+  const url = `https://x-access-token:${pre.token}@github.com/${pre.owner}/${pre.repo}.git`;
+  const depth = pre.shallow ? ["--depth", "1"] : ["--depth", "50"];
+  const start = Date.now();
+  try {
+    // Fetch the branch from the authenticated URL directly so we don't depend
+    // on the stored remote (and never persist the token into .git/config).
+    execFileSync(
+      "git",
+      ["-C", repoDir, "fetch", ...depth, url, pre.branch],
+      { stdio: "pipe", timeout: 120_000 },
+    );
+    execFileSync(
+      "git",
+      ["-C", repoDir, "checkout", "-B", pre.branch, "FETCH_HEAD"],
+      { stdio: "pipe", timeout: 30_000 },
+    );
+    execFileSync(
+      "git",
+      ["-C", repoDir, "reset", "--hard", "FETCH_HEAD"],
+      { stdio: "pipe", timeout: 30_000 },
+    );
+    // -x removes ignored files (stale dist/, .turbo, coverage, …); -e keeps the
+    // dependency trees warm so install is incremental. `node_modules` with no
+    // leading slash matches at any depth (monorepos / workspaces).
+    execFileSync(
+      "git",
+      ["-C", repoDir, "clean", "-fdx", "-e", "node_modules"],
+      { stdio: "pipe", timeout: 60_000 },
+    );
+    writeMarker(markerPath, pre.runId);
+    const ms = Date.now() - start;
+    console.log(
+      `[sandbox] Refreshed reused workspace ${repoDir} → ${pre.branch} ` +
+      `(fetch+reset+clean, node_modules kept, ${ms}ms)`,
+    );
+  } catch (err: any) {
+    const reason = scrub(err?.message) || scrub(err?.stderr?.toString?.()) || "unknown error";
+    console.warn(
+      `[sandbox] Refresh of reused workspace ${repoDir} failed (${reason}). ` +
+      `Leaving it untouched; agent can re-fetch via MCP.`,
     );
   }
 }

--- a/src/workflows/CLAUDE.md
+++ b/src/workflows/CLAUDE.md
@@ -275,6 +275,21 @@ ${repo}-${issueNumber}-${workflowName}-${runId.slice(0, 8)}
 `resume.ts` reconstructs the taskId from the stored `context.taskId` so
 a resumed run lands in the same sandbox dir the original started in.
 
+**Per-PR reuse exception (issue #107).** The workflows in
+`PER_TARGET_REUSE_WORKFLOWS` (`pr-review`, `pr-fix`) **drop** the run-id
+suffix — their taskId is `${repo}-${prNumber}-${workflowName}`, keyed by
+(repo, PR) rather than per-run. A re-review of the same PR (push →
+`synchronize`, cron PR-review fanout) therefore lands in the **same**
+sandbox dir, so `prePopulateWorkspace` does `git fetch` + `reset --hard` +
+`git clean -fdx -e node_modules` instead of a fresh 1.3G clone + full
+install, and N dirs/PR collapse to 1 (cutting the #106 churn at its
+source). `build` is excluded — it creates a new branch per run and must not
+reuse. Concurrency is held off by the dispatcher's
+`isRunning(skill, triggerId)` guard plus `runs.getByTrigger` reuse; the
+cross-run vs same-run distinction is made by a `<workDir>/.lastlight-run`
+marker stamped with the owning run id (same id → preserve the checkout for
+the next phase; different id → refresh). See `src/sandbox/index.ts`.
+
 ## Templates
 
 `templates.ts` renders phase prompts, approval-gate messages, and

--- a/src/workflows/runner.ts
+++ b/src/workflows/runner.ts
@@ -88,6 +88,7 @@ export function gitSandboxAccessForWorkflow(
   owner: string,
   repo: string,
   prePopulateBranch?: string,
+  runId?: string,
 ): GitSandboxAccess {
   const profile = gitAccessProfileForWorkflow(workflowName);
   return {
@@ -100,6 +101,11 @@ export function gitSandboxAccessForWorkflow(
     // entering the sandbox.
     allowMcpAppAuth: false,
     prePopulateBranch,
+    runId,
+    // Read-only workflows never need git history — clone at --depth 1. Only
+    // the code-pushing profiles (build / pr-fix / security-feedback) keep the
+    // deeper clone for rebase/amend headroom.
+    shallow: profile !== "repo-write",
   };
 }
 
@@ -146,7 +152,7 @@ export async function runWorkflow(
   const prePopulateBranch = typeof ctx.prePopulateBranch === "string"
     ? ctx.prePopulateBranch
     : undefined;
-  const githubAccess = gitSandboxAccessForWorkflow(definition.name, ctx.owner, ctx.repo, prePopulateBranch);
+  const githubAccess = gitSandboxAccessForWorkflow(definition.name, ctx.owner, ctx.repo, prePopulateBranch, workflowId);
   const notify = callbacks.postComment || (async () => {});
   const reporter = callbacks.reporter;
   const onStart = callbacks.onPhaseStart || (async () => {});

--- a/src/workflows/simple.test.ts
+++ b/src/workflows/simple.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { workflowScopedTaskId, PER_TARGET_REUSE_WORKFLOWS } from "./simple.js";
+
+const RUN = "abcdef12-3456-7890-abcd-ef1234567890";
+
+describe("workflowScopedTaskId", () => {
+  it("keys pr-review / pr-fix by (repo, PR) with no run suffix so they reuse one workspace", () => {
+    for (const wf of PER_TARGET_REUSE_WORKFLOWS) {
+      const a = workflowScopedTaskId("drizzle-cube", 918, wf, RUN);
+      const b = workflowScopedTaskId("drizzle-cube", 918, wf, "different-run-id");
+      expect(a).toBe(`drizzle-cube-918-${wf}`);
+      // Two separate runs on the same PR resolve to the same dir → reuse.
+      expect(a).toBe(b);
+    }
+  });
+
+  it("keeps the run suffix for build so each run gets a fresh workspace", () => {
+    const id = workflowScopedTaskId("drizzle-cube", 918, "build", RUN);
+    expect(id).toBe("drizzle-cube-918-build-abcdef12");
+  });
+
+  it("keeps the run suffix for repo-scoped (no number) workflows", () => {
+    const id = workflowScopedTaskId("drizzle-cube", undefined, "health", RUN);
+    expect(id).toBe("drizzle-cube-health-abcdef12");
+  });
+
+  it("does not reuse when a per-PR workflow has no number", () => {
+    const id = workflowScopedTaskId("drizzle-cube", undefined, "pr-review", RUN);
+    expect(id).toBe("drizzle-cube-pr-review-abcdef12");
+  });
+});

--- a/src/workflows/simple.ts
+++ b/src/workflows/simple.ts
@@ -62,12 +62,30 @@ export interface SimpleWorkflowRequest {
   prePopulateBranch?: string;
 }
 
-function workflowScopedTaskId(
+/**
+ * Workflows whose workspace is keyed by **(repo, PR)** rather than per-run.
+ * For these the taskId drops the run-id suffix so re-reviews of the same PR
+ * (push → `synchronize`, cron PR-review fanout) reuse one sandbox dir — a
+ * warm `node_modules` + an incremental `git fetch` instead of a fresh
+ * 1.3G clone + full install each time, and N dirs/PR collapse to 1 (issue
+ * #107, cutting the #106 churn at its source). Concurrency is held off by
+ * the dispatcher's `isRunning(skill, triggerId)` guard plus
+ * `runs.getByTrigger` reuse — two runs never share the dir live; the
+ * cross-run refresh in `prePopulateWorkspace` resets it cleanly between them.
+ * `build` is excluded — it creates a new branch per run and must not reuse.
+ */
+export const PER_TARGET_REUSE_WORKFLOWS = new Set(["pr-review", "pr-fix"]);
+
+export function workflowScopedTaskId(
   repo: string,
   number: number | undefined,
   workflowName: string,
   workflowId: string,
 ): string {
+  // Reusable per-PR workspaces are keyed by (repo, PR) only — no run suffix.
+  if (number !== undefined && PER_TARGET_REUSE_WORKFLOWS.has(workflowName)) {
+    return `${repo}-${number}-${workflowName}`;
+  }
   const suffix = workflowId.slice(0, 8);
   return number !== undefined
     ? `${repo}-${number}-${workflowName}-${suffix}`


### PR DESCRIPTION
Closes #107.

Three composable wins to cut sandbox provisioning time/disk and the #106 churn.

## 1. Per-PR workspace reuse (the main ask)
`pr-review` / `pr-fix` taskIds drop the run-id suffix → keyed by `${repo}-${prNumber}-${workflowName}`, so re-reviews of the same PR (push → `synchronize`, cron PR-review fanout) reuse one sandbox dir. A `<workDir>/.lastlight-run` marker distinguishes:
- **same run revisiting** (marker matches) → preserve the checkout — keeps build's `plan.md` / the reviewer's tree between phases.
- **a different run reusing the PR dir** (marker differs) → `git fetch` + `reset --hard FETCH_HEAD` + `git clean -fdx -e node_modules` (deps stay warm, install is incremental). On fetch failure the tree is left untouched and the marker isn't advanced, so the next run retries.

`build` is excluded (new branch per run). Concurrency is held off by the dispatcher's `isRunning(skill, triggerId)` guard + `runs.getByTrigger` reuse.

Collapses N dirs/PR → 1 and turns a re-review from "fresh 1.3G clone + full install" into "incremental fetch + warm install".

## 2. Shallow clone for read-only workflows
Non-`repo-write` workflows pre-clone at `--depth 1 --single-branch`; `build` / `pr-fix` / `security-feedback` keep `--depth 50`.

## 3. Shared package cache across sandboxes
A `lastlight_pkg-cache` volume mounted at `/cache` in every sandbox, with `npm_config_cache` / `npm_config_store_dir` (pnpm) / `YARN_CACHE_FOLDER` pointed at it. PM-agnostic — the agent already picks the manager from the repo's lockfile (`skills/pr-review/SKILL.md`). This is the *download* cache only; per-workspace `node_modules` stays per-workspace (a shared store can't hardlink across separate container mounts). Disk is bounded by reuse (#1) + #106's reaping.

## Acceptance criteria
- [x] pr-review/pr-fix reuse a single workspace per (repo, PR); re-review does fetch+checkout, not a fresh clone.
- [x] Shared package cache mounted across sandboxes.
- [x] Read-only workflows clone at `--depth 1`.
- [x] No cross-repo `node_modules` sharing; reused workspaces reset cleanly between runs.
- [ ] Measured speedup — needs verification on prod after deploy (rebuilds the sandbox image for the entrypoint chown).

## Tests
Shallow vs deep clone, same-run preserve, no-runId preserve, cross-run refresh (asserts fetch→checkout→reset→clean + `node_modules` kept + marker advance), fetch-failure marker retention, taskId reuse matrix, docker cache mount/env wiring. Full suite 646/646, tsc clean.

## Deploy note
The entrypoint change (chown `/cache` subdirs) means this needs the full `deploy.sh` (sandbox image rebuild), not just an `instance/` restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)