### PR TITLE
Capture skill loading and surface it in a phase-detail tab

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -212,6 +212,18 @@ export interface WorkflowRunExecution {
     string,
     { status: string; mode?: string; provider?: string; toolCount?: number; reason?: string }
   >;
+  /**
+   * agentic-pi skill-loading status for this phase — the skill-loading
+   * counterpart to {@link extensions}. Present only when the run reported
+   * skills (agentic-pi gates the underlying `skills_status` event).
+   */
+  skills?: {
+    status: string;
+    discovered: number;
+    skills: { name: string; source: string; modelInvocable: boolean }[];
+    mappedPaths: string[];
+    noSkills: boolean;
+  };
 }
 
 export interface ContainerInfo {

--- a/dashboard/src/components/PhaseDetailPanel.tsx
+++ b/dashboard/src/components/PhaseDetailPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import clsx from "clsx";
 import type {
   WorkflowDefinition,
@@ -109,8 +110,16 @@ export function PhaseDetailPanel({ phaseName, run, definition, execution, totalE
     "badge-ghost": statusLabel === "pending",
   });
 
+  // Second tab groups "what got loaded" for this run — agentic-pi extensions
+  // (tool loading) and skills (skill loading). The count drives the tab badge.
+  const extensionCount = execution?.extensions ? Object.keys(execution.extensions).length : 0;
+  const skillCount = execution?.skills?.skills.length ?? 0;
+  const loadedCount = extensionCount + skillCount;
+
+  const [tab, setTab] = useState<"details" | "loaded">("details");
+
   return (
-    <div className="flex flex-col gap-4 p-3 text-xs">
+    <div className="flex flex-col gap-3 p-3 text-xs">
       <div>
         <div className="text-2xs font-semibold uppercase tracking-wider text-base-content/40 mb-1">
           Phase
@@ -126,64 +135,126 @@ export function PhaseDetailPanel({ phaseName, run, definition, execution, totalE
         )}
       </div>
 
-      {phaseDef && (
-        <div className="grid grid-cols-2 gap-3">
-          <Field label="Type">{phaseDef.type}</Field>
-          {phaseDef.hasLoop && <Field label="Loop">yes</Field>}
-          {phaseDef.approvalGate && (
-            <Field label="Approval Gate">{phaseDef.approvalGate}</Field>
+      {/* Tabs — Details (execution/usage/session) vs Loaded (extensions/skills) */}
+      <div className="flex gap-1 border-b border-base-300 -mx-3 px-3">
+        <TabButton active={tab === "details"} onClick={() => setTab("details")}>
+          Details
+        </TabButton>
+        <TabButton active={tab === "loaded"} onClick={() => setTab("loaded")}>
+          Loaded{loadedCount > 0 ? ` (${loadedCount})` : ""}
+        </TabButton>
+      </div>
+
+      {tab === "details" && (
+        <div className="flex flex-col gap-4">
+          {phaseDef && (
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Type">{phaseDef.type}</Field>
+              {phaseDef.hasLoop && <Field label="Loop">yes</Field>}
+              {phaseDef.approvalGate && (
+                <Field label="Approval Gate">{phaseDef.approvalGate}</Field>
+              )}
+            </div>
+          )}
+
+          {!phaseDef && (
+            <div className="text-2xs text-base-content/50 italic">
+              Dynamic phase (not declared in the workflow YAML — likely a loop iteration).
+            </div>
+          )}
+
+          {!execution && (
+            <div className="text-xs text-base-content/50 border border-base-300/40 bg-base-200/30 rounded px-3 py-2">
+              No execution recorded yet.
+            </div>
+          )}
+
+          {execution && (
+            <>
+              <div>
+                <div className="text-2xs font-semibold uppercase tracking-wider text-base-content/40 mb-2">
+                  Execution
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <Field label="Started">{fmtTime(execution.startedAt)}</Field>
+                  <Field label="Finished">{fmtTime(execution.finishedAt)}</Field>
+                  <Field label="Duration">{fmtDuration(execution.durationMs)}</Field>
+                  <Field label="API Time">{fmtDuration(execution.apiDurationMs)}</Field>
+                  <Field label="Turns">{execution.turns ?? "—"}</Field>
+                  <Field label="Stop Reason">{execution.stopReason ?? "—"}</Field>
+                </div>
+              </div>
+
+              <div>
+                <div className="text-2xs font-semibold uppercase tracking-wider text-base-content/40 mb-2">
+                  Usage
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <Field label="Cost">{fmtCost(execution.costUsd)}</Field>
+                  <Field label="Output Tokens">{fmtTokens(execution.outputTokens)}</Field>
+                  <Field label="Input Tokens">{fmtTokens(execution.inputTokens)}</Field>
+                  <Field label="Cache Read">{fmtTokens(execution.cacheReadInputTokens)}</Field>
+                  <Field label="Cache Create">{fmtTokens(execution.cacheCreationInputTokens)}</Field>
+                </div>
+              </div>
+
+              {execution.error && (
+                <div>
+                  <div className="text-2xs font-semibold uppercase tracking-wider text-error/80 mb-1">
+                    Error
+                  </div>
+                  <div className="text-2xs text-error/80 font-mono break-words border border-error/30 bg-error/5 rounded px-2 py-1">
+                    {execution.error}
+                  </div>
+                </div>
+              )}
+
+              <div>
+                <div className="text-2xs font-semibold uppercase tracking-wider text-base-content/40 mb-1">
+                  Session
+                </div>
+                {execution.sessionId ? (
+                  <div className="text-2xs font-mono text-base-content/70 break-all">
+                    {execution.sessionId}
+                  </div>
+                ) : (
+                  <div className="text-2xs text-base-content/50 italic">
+                    Session not captured for this run.
+                  </div>
+                )}
+              </div>
+
+              {totalExecutions > 1 && (
+                <div className="text-2xs text-base-content/40 italic">
+                  {totalExecutions} executions recorded for this phase — showing the most recent.
+                </div>
+              )}
+            </>
           )}
         </div>
       )}
 
-      {!phaseDef && (
-        <div className="text-2xs text-base-content/50 italic">
-          Dynamic phase (not declared in the workflow YAML — likely a loop iteration).
-        </div>
-      )}
-
-      {!execution && (
-        <div className="text-xs text-base-content/50 border border-base-300/40 bg-base-200/30 rounded px-3 py-2">
-          No execution recorded yet.
-        </div>
-      )}
-
-      {execution && (
-        <>
-          <div>
-            <div className="text-2xs font-semibold uppercase tracking-wider text-base-content/40 mb-2">
-              Execution
+      {tab === "loaded" && (
+        <div className="flex flex-col gap-4">
+          {!execution && (
+            <div className="text-xs text-base-content/50 border border-base-300/40 bg-base-200/30 rounded px-3 py-2">
+              No execution recorded yet.
             </div>
-            <div className="grid grid-cols-2 gap-3">
-              <Field label="Started">{fmtTime(execution.startedAt)}</Field>
-              <Field label="Finished">{fmtTime(execution.finishedAt)}</Field>
-              <Field label="Duration">{fmtDuration(execution.durationMs)}</Field>
-              <Field label="API Time">{fmtDuration(execution.apiDurationMs)}</Field>
-              <Field label="Turns">{execution.turns ?? "—"}</Field>
-              <Field label="Stop Reason">{execution.stopReason ?? "—"}</Field>
-            </div>
-          </div>
+          )}
 
-          <div>
-            <div className="text-2xs font-semibold uppercase tracking-wider text-base-content/40 mb-2">
-              Usage
+          {execution && loadedCount === 0 && (
+            <div className="text-2xs text-base-content/40 italic">
+              No extensions or skills were loaded for this run.
             </div>
-            <div className="grid grid-cols-2 gap-3">
-              <Field label="Cost">{fmtCost(execution.costUsd)}</Field>
-              <Field label="Output Tokens">{fmtTokens(execution.outputTokens)}</Field>
-              <Field label="Input Tokens">{fmtTokens(execution.inputTokens)}</Field>
-              <Field label="Cache Read">{fmtTokens(execution.cacheReadInputTokens)}</Field>
-              <Field label="Cache Create">{fmtTokens(execution.cacheCreationInputTokens)}</Field>
-            </div>
-          </div>
+          )}
 
-          {execution.extensions && Object.keys(execution.extensions).length > 0 && (
+          {extensionCount > 0 && (
             <div>
               <div className="text-2xs font-semibold uppercase tracking-wider text-base-content/40 mb-2">
                 Extensions
               </div>
               <div className="grid grid-cols-2 gap-3">
-                {Object.entries(execution.extensions).map(([name, v]) => (
+                {Object.entries(execution!.extensions!).map(([name, v]) => (
                   <Field key={name} label={name}>
                     {fmtExtension(v)}
                   </Field>
@@ -192,38 +263,65 @@ export function PhaseDetailPanel({ phaseName, run, definition, execution, totalE
             </div>
           )}
 
-          {execution.error && (
-            <div>
-              <div className="text-2xs font-semibold uppercase tracking-wider text-error/80 mb-1">
-                Error
-              </div>
-              <div className="text-2xs text-error/80 font-mono break-words border border-error/30 bg-error/5 rounded px-2 py-1">
-                {execution.error}
-              </div>
-            </div>
-          )}
+          {execution?.skills && <SkillsSection skills={execution.skills} />}
+        </div>
+      )}
+    </div>
+  );
+}
 
-          <div>
-            <div className="text-2xs font-semibold uppercase tracking-wider text-base-content/40 mb-1">
-              Session
-            </div>
-            {execution.sessionId ? (
-              <div className="text-2xs font-mono text-base-content/70 break-all">
-                {execution.sessionId}
-              </div>
-            ) : (
-              <div className="text-2xs text-base-content/50 italic">
-                Session not captured for this run.
-              </div>
-            )}
-          </div>
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        "px-2 py-1 text-2xs font-mono border-b-2 -mb-px transition-colors",
+        active
+          ? "border-primary text-primary"
+          : "border-transparent text-base-content/60 hover:text-base-content",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
 
-          {totalExecutions > 1 && (
-            <div className="text-2xs text-base-content/40 italic">
-              {totalExecutions} executions recorded for this phase — showing the most recent.
-            </div>
-          )}
-        </>
+/** Skill-loading detail — the counterpart to the Extensions grid. */
+function SkillsSection({
+  skills,
+}: {
+  skills: NonNullable<WorkflowRunExecution["skills"]>;
+}) {
+  const summary = [
+    skills.status,
+    `${skills.discovered} discovered`,
+    ...(skills.noSkills ? ["default discovery off"] : []),
+  ].join(" · ");
+  return (
+    <div>
+      <div className="text-2xs font-semibold uppercase tracking-wider text-base-content/40 mb-1">
+        Skills
+      </div>
+      <div className="text-2xs text-base-content/50 font-mono mb-1.5">{summary}</div>
+      {skills.skills.length > 0 ? (
+        <ul className="flex flex-col gap-1">
+          {skills.skills.map((s) => (
+            <li key={s.source} className="flex items-center gap-1.5">
+              <span className="text-xs font-mono text-base-content/80 break-all">{s.name}</span>
+              {!s.modelInvocable && <span className="badge badge-ghost badge-xs">manual</span>}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="text-2xs text-base-content/40 italic">No skills discovered.</div>
       )}
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@opentelemetry/semantic-conventions": "^1.41.1",
         "@sinclair/typebox": "^0.34.49",
         "@slack/bolt": "^4.6.0",
-        "agentic-pi": "^0.2.5",
+        "agentic-pi": "^0.2.6",
         "arctic": "^3.7.0",
         "better-sqlite3": "^11.0.0",
         "chalk": "^5.6.2",
@@ -1973,7 +1973,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -7218,9 +7218,9 @@
       }
     },
     "node_modules/agentic-pi": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/agentic-pi/-/agentic-pi-0.2.5.tgz",
-      "integrity": "sha512-UX+oGYRBGtjvO9PLWqccQAYlNiEUpVd8psKodupCeXjvqXfrcj/yD6DoTmpMVO2uMAy2AZ+0Pq/gUS9ng5h2AA==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/agentic-pi/-/agentic-pi-0.2.6.tgz",
+      "integrity": "sha512-y1G5OEAKzhyO7n+SyWOWsB4i9i5omdNVxhrqZkpu4k4ccnAPnLQRClbA/MTcI7CAlMPjmka/LdZ7MBGmhAwrjQ==",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/gondolin": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@opentelemetry/semantic-conventions": "^1.41.1",
     "@sinclair/typebox": "^0.34.49",
     "@slack/bolt": "^4.6.0",
-    "agentic-pi": "^0.2.5",
+    "agentic-pi": "^0.2.6",
     "arctic": "^3.7.0",
     "better-sqlite3": "^11.0.0",
     "chalk": "^5.6.2",

--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -27,11 +27,11 @@ import { getManagedRepos } from "../managed-repos.js";
 import type { PublicConfigBundle } from "../config.js";
 
 /**
- * Parse the JSON `extension_status` column into the per-phase extensions map
- * the dashboard renders. Tolerates null / malformed JSON (returns undefined)
- * so a bad row never breaks the executions endpoint.
+ * Parse a JSON status column (`extension_status` / `skills_status`) into the
+ * object the dashboard renders. Tolerates null / malformed JSON (returns
+ * undefined) so a bad row never breaks the executions endpoint.
  */
-function parseExtensionStatus(raw: string | undefined): unknown {
+function parseJsonColumn(raw: string | undefined): unknown {
   if (!raw) return undefined;
   try {
     return JSON.parse(raw);
@@ -652,7 +652,8 @@ export function createAdminRoutes(
       outputTokens: r.outputTokens,
       apiDurationMs: r.apiDurationMs,
       stopReason: r.stopReason,
-      extensions: parseExtensionStatus(r.extensionStatus),
+      extensions: parseJsonColumn(r.extensionStatus),
+      skills: parseJsonColumn(r.skillsStatus),
     }));
     return c.json({ executions });
   });

--- a/src/engine/agent-executor.test.ts
+++ b/src/engine/agent-executor.test.ts
@@ -165,6 +165,42 @@ describe("RunResultAccumulator extension status", () => {
   });
 });
 
+describe("RunResultAccumulator skills status", () => {
+  it("captures and normalizes the skills_status event", () => {
+    const acc = new RunResultAccumulator();
+    acc.feed({ type: "session", id: "abc" });
+    acc.feed({
+      type: "skills_status",
+      status: "configured",
+      discovered: 2,
+      skills: [
+        { name: "pr-review", source: "/skills/pr-review/SKILL.md", modelInvocable: true },
+        { name: "issue-triage", source: "/skills/issue-triage/SKILL.md", modelInvocable: false },
+      ],
+      mappedPaths: ["/skills"],
+      noSkills: false,
+    });
+
+    expect(acc.skills()).toEqual({
+      status: "configured",
+      discovered: 2,
+      skills: [
+        { name: "pr-review", source: "/skills/pr-review/SKILL.md", modelInvocable: true },
+        { name: "issue-triage", source: "/skills/issue-triage/SKILL.md", modelInvocable: false },
+      ],
+      mappedPaths: ["/skills"],
+      noSkills: false,
+    });
+  });
+
+  it("returns undefined when no skills_status event was seen", () => {
+    const acc = new RunResultAccumulator();
+    acc.feed({ type: "session", id: "abc" });
+    acc.feed(assistantMessageEnd({ input: 10, output: 5, cost: 0.001 }));
+    expect(acc.skills()).toBeUndefined();
+  });
+});
+
 describe("RunResultAccumulator tool errors", () => {
   it("captures the failing tool name and error text", () => {
     const acc = new RunResultAccumulator();

--- a/src/engine/agent-executor.ts
+++ b/src/engine/agent-executor.ts
@@ -15,6 +15,7 @@ import {
   type ExecutorConfig,
   type ExecutionResult,
   type ExtensionStatusMap,
+  type SkillsStatus,
   type GitSandboxAccess,
 } from "./profiles.js";
 import { AgenticShim, truncateForLog, safeStringify } from "./event-shim.js";
@@ -429,7 +430,7 @@ async function executeInProcess(
   const better = acc.bestStats();
   if (better && (better.tokens?.total ?? 0) > 0) result.stats = better;
 
-  const finalResult = await finalizeFromRunResult(result, prompt, shim, startTime, acc.extensions(), acc.toolError());
+  const finalResult = await finalizeFromRunResult(result, prompt, shim, startTime, acc.extensions(), acc.skills(), acc.toolError());
   recordExecutionMetrics("agent", {
     "sandbox.backend": ctx.backend,
     model,
@@ -608,7 +609,7 @@ async function executeDocker(
     };
   }
   await sbx.cleanup();
-  const finalResult = await finalizeFromRunResult(acc.build(0), prompt, shim, startTime, acc.extensions(), acc.toolError());
+  const finalResult = await finalizeFromRunResult(acc.build(0), prompt, shim, startTime, acc.extensions(), acc.skills(), acc.toolError());
   recordExecutionMetrics("agent", {
     "sandbox.backend": "docker",
     model,
@@ -666,6 +667,11 @@ export class RunResultAccumulator {
   // (minus type/extension) so build() can map them onto the RunResult.
   private ext: Record<string, Record<string, unknown>> = {};
 
+  // Skill-loading status. agentic-pi emits a single (gated) `skills_status`
+  // event at run start; we keep the raw payload (minus type) so skills()
+  // can normalize it onto the RunResult, mirroring `ext` above for tools.
+  private skillsRaw?: Record<string, unknown>;
+
   feed(r: Record<string, unknown>): void {
     switch (r.type) {
       case "session":
@@ -676,6 +682,11 @@ export class RunResultAccumulator {
           const { type: _t, extension: _e, ...rest } = r;
           this.ext[r.extension] = rest;
         }
+        break;
+      }
+      case "skills_status": {
+        const { type: _t, ...rest } = r;
+        this.skillsRaw = rest;
         break;
       }
       case "message_end": {
@@ -821,6 +832,35 @@ export class RunResultAccumulator {
   }
 
   /**
+   * Normalized skill-loading status from the gated `skills_status` event, or
+   * undefined if none was reported (agentic-pi suppresses it on a run that
+   * configured no skills and discovered none). The skill-loading counterpart
+   * to {@link extensions}.
+   */
+  skills(): SkillsStatus | undefined {
+    const s = this.skillsRaw;
+    if (!s || typeof s.status !== "string") return undefined;
+    const skills = Array.isArray(s.skills)
+      ? s.skills
+          .filter((x): x is Record<string, unknown> => !!x && typeof x === "object")
+          .map((x) => ({
+            name: typeof x.name === "string" ? x.name : "",
+            source: typeof x.source === "string" ? x.source : "",
+            modelInvocable: x.modelInvocable === true,
+          }))
+      : [];
+    return {
+      status: s.status,
+      discovered: typeof s.discovered === "number" ? s.discovered : skills.length,
+      skills,
+      mappedPaths: Array.isArray(s.mappedPaths)
+        ? s.mappedPaths.filter((p): p is string => typeof p === "string")
+        : [],
+      noSkills: s.noSkills === true,
+    };
+  }
+
+  /**
    * The last tool result that came back with `isError: true`, including the
    * failure text — or undefined if no tool errored. This is what turns a
    * bare `error_tool` stop reason into a human-readable cause.
@@ -838,6 +878,7 @@ function finalizeFromRunResult(
   shim: AgenticShim,
   startTime: number,
   extensions?: ExtensionStatusMap,
+  skills?: SkillsStatus,
   toolError?: { tool?: string; message: string },
 ): ExecutionResult {
   const durationMs = Date.now() - startTime;
@@ -933,6 +974,7 @@ function finalizeFromRunResult(
     cacheCreationInputTokens: cacheWrite || undefined,
     stopReason,
     extensions,
+    skills,
   };
 }
 

--- a/src/engine/event-shim.ts
+++ b/src/engine/event-shim.ts
@@ -221,6 +221,8 @@ export class AgenticShim {
         return this.translateToolEnd(r, ts, sessionId);
       case "extension_status":
         return this.translateExtensionStatus(r, ts, sessionId);
+      case "skills_status":
+        return this.translateSkillsStatus(r, ts, sessionId);
       case "fatal_error":
         return this.translateFatal(r, ts, sessionId);
       default:
@@ -250,6 +252,33 @@ export class AgenticShim {
         ...(r.provider !== undefined ? { provider: r.provider } : {}),
         ...(r.toolCount !== undefined ? { toolCount: r.toolCount } : {}),
         ...(r.reason !== undefined ? { reason: r.reason } : {}),
+        timestamp: ts,
+        sessionId,
+      },
+    ];
+  }
+
+  /**
+   * Mirror agentic-pi's gated `skills_status` event as a `system` envelope in
+   * the session log — the skill-loading counterpart to
+   * {@link translateExtensionStatus}. Records which skills the agent had
+   * available. SessionReader ignores unknown envelope types, so render-safe.
+   */
+  private translateSkillsStatus(
+    r: EmitterRecord,
+    ts: string,
+    sessionId: string,
+  ): object[] {
+    if (typeof r.status !== "string") return [];
+    return [
+      {
+        type: "system",
+        subtype: "skills_status",
+        status: r.status,
+        ...(r.discovered !== undefined ? { discovered: r.discovered } : {}),
+        ...(Array.isArray(r.skills) ? { skills: r.skills } : {}),
+        ...(Array.isArray(r.mappedPaths) ? { mappedPaths: r.mappedPaths } : {}),
+        ...(r.noSkills !== undefined ? { noSkills: r.noSkills } : {}),
         timestamp: ts,
         sessionId,
       },

--- a/src/engine/profiles.ts
+++ b/src/engine/profiles.ts
@@ -97,6 +97,48 @@ export interface ExtensionStatus {
 export type ExtensionStatusMap = Record<string, ExtensionStatus>;
 
 /**
+ * One skill agentic-pi discovered for a run, flattened from the
+ * `skills_status` event's `skills[]`. Mirrors agentic-pi's `SkillSummary`.
+ */
+export interface SkillSummary {
+  /** Skill name (from SKILL.md frontmatter). */
+  name: string;
+  /** Absolute path to the skill's SKILL.md. */
+  source: string;
+  /**
+   * Whether the model can auto-invoke it. False when the skill set
+   * `disable-model-invocation: true` — present but not surfaced in the
+   * system prompt, so worth flagging in the dashboard.
+   */
+  modelInvocable: boolean;
+}
+
+/**
+ * Normalized status of agentic-pi's skill discovery for a single run — the
+ * skill-loading counterpart to {@link ExtensionStatus} (tool loading).
+ * agentic-pi (≥0.2.6) emits this as a single, gated `skills_status` event at
+ * run start: present only when skills were configured (`skillPaths`/`noSkills`)
+ * or at least one was discovered, absent on a default run with no skills.
+ * lastlight captures it so the dashboard's phase-detail panel can show which
+ * skills the agent had available.
+ */
+export interface SkillsStatus {
+  /**
+   * "default" (rely on auto-discovery), "configured" (explicit `skillPaths`
+   * resolved), or "disabled" (`noSkills` with no explicit paths).
+   */
+  status: string;
+  /** Number of skills the resource loader actually discovered. */
+  discovered: number;
+  /** The discovered skills, flattened. */
+  skills: SkillSummary[];
+  /** Operator-mapped skill paths that resolved (echoed for observability). */
+  mappedPaths: string[];
+  /** Whether agentic-pi's default skill discovery was disabled. */
+  noSkills: boolean;
+}
+
+/**
  * Result from an agent execution.
  */
 export interface ExecutionResult {
@@ -127,6 +169,13 @@ export interface ExecutionResult {
    * `executions.extension_status` column.
    */
   extensions?: ExtensionStatusMap;
+  /**
+   * Skill-loading status captured from agentic-pi's `skills_status` event.
+   * Surfaced alongside {@link extensions} in the dashboard's phase-detail
+   * panel and persisted to the `executions.skills_status` column. Undefined
+   * when the run reported no skills (the event is gated on the agentic-pi side).
+   */
+  skills?: SkillsStatus;
 }
 
 export type GitAccessProfile = "read" | "issues-write" | "review-write" | "repo-write";

--- a/src/state/execution-store.ts
+++ b/src/state/execution-store.ts
@@ -39,6 +39,12 @@ export interface ExecutionRecord {
    */
   extensionStatus?: string;
   /**
+   * JSON-serialized {@link SkillsStatus} — agentic-pi's skill-loading status
+   * for this execution (which skills were discovered/available). Null when
+   * the run reported no skills.
+   */
+  skillsStatus?: string;
+  /**
    * Workflow run that owns this execution. Scopes dedup: a fresh re-trigger
    * creates a new workflow_run_id, so `shouldRunPhase` won't find matching
    * rows from the prior run and will correctly run the phase again.
@@ -139,6 +145,8 @@ export class ExecutionStore {
       stopReason?: string;
       /** JSON-serialized ExtensionStatusMap (extensions active this run). */
       extensionStatus?: string;
+      /** JSON-serialized SkillsStatus (skills available this run). */
+      skillsStatus?: string;
     },
   ): void {
     this.db.prepare(`
@@ -156,7 +164,8 @@ export class ExecutionStore {
           output_tokens = COALESCE(?, output_tokens),
           api_duration_ms = COALESCE(?, api_duration_ms),
           stop_reason = COALESCE(?, stop_reason),
-          extension_status = COALESCE(?, extension_status)
+          extension_status = COALESCE(?, extension_status),
+          skills_status = COALESCE(?, skills_status)
       WHERE id = ?
     `).run(
       new Date().toISOString(),
@@ -173,6 +182,7 @@ export class ExecutionStore {
       result.apiDurationMs ?? null,
       result.stopReason ?? null,
       result.extensionStatus ?? null,
+      result.skillsStatus ?? null,
       id,
     );
   }
@@ -494,6 +504,7 @@ export class ExecutionStore {
         api_duration_ms AS apiDurationMs,
         stop_reason     AS stopReason,
         extension_status AS extensionStatus,
+        skills_status   AS skillsStatus,
         workflow_run_id AS workflowRunId
       FROM executions
       WHERE (workflow_run_id = ? OR (workflow_run_id IS NULL AND trigger_id = ?))
@@ -523,6 +534,7 @@ export class ExecutionStore {
       apiDurationMs: (r.apiDurationMs as number | null) ?? undefined,
       stopReason: (r.stopReason as string | null) ?? undefined,
       extensionStatus: (r.extensionStatus as string | null) ?? undefined,
+      skillsStatus: (r.skillsStatus as string | null) ?? undefined,
       workflowRunId: (r.workflowRunId as string | null) ?? undefined,
     }));
   }

--- a/src/state/migrate.ts
+++ b/src/state/migrate.ts
@@ -147,6 +147,10 @@ export function migrate(db: Database.Database): void {
     // (file-search / github / web-search → {status, mode?, provider?,
     // toolCount?, reason?}). Surfaced in the dashboard phase-detail panel.
     "extension_status TEXT",
+    // JSON object of agentic-pi's skill-loading status for this execution
+    // ({status, discovered, skills[], mappedPaths, noSkills}). The skill-
+    // loading counterpart to extension_status; surfaced in the same panel.
+    "skills_status TEXT",
   ]) {
     try {
       db.exec(`ALTER TABLE executions ADD COLUMN ${col}`);

--- a/src/telemetry/pi-events.test.ts
+++ b/src/telemetry/pi-events.test.ts
@@ -48,6 +48,17 @@ describe("PI event telemetry sanitization", () => {
       "extension.status": "configured",
       "extension.toolCount": 3,
     });
+    expect(sanitizePiEvent({
+      type: "skills_status",
+      status: "configured",
+      discovered: 2,
+      noSkills: false,
+      skills: [{ name: "pr-review" }, { name: "issue-triage" }],
+    })).toMatchObject({
+      "skills.status": "configured",
+      "skills.discovered": 2,
+      "skills.names": "pr-review,issue-triage",
+    });
     expect(sanitizePiEvent({ type: "usage_snapshot", turns: 2, costUsd: 0.2 })).toMatchObject({
       "usage.turns": 2,
       "usage.costUsd": 0.2,

--- a/src/telemetry/pi-events.ts
+++ b/src/telemetry/pi-events.ts
@@ -83,6 +83,18 @@ export function sanitizePiEvent(record: Record<string, unknown>, includeContent 
         if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") out[`extension.${key}`] = value;
       }
       break;
+    case "skills_status":
+      for (const key of ["status", "discovered", "noSkills"]) {
+        const value = record[key];
+        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") out[`skills.${key}`] = value;
+      }
+      if (Array.isArray(record.skills)) {
+        out["skills.names"] = record.skills
+          .map((s) => (s && typeof s === "object" && "name" in s ? String((s as { name?: unknown }).name) : ""))
+          .filter(Boolean)
+          .join(",");
+      }
+      break;
     case "usage_snapshot":
       for (const key of ["turns", "costUsd", "inputTokens", "outputTokens", "cacheReadInputTokens", "cacheCreationInputTokens"]) {
         const value = record[key];

--- a/src/workflows/phase-executor.ts
+++ b/src/workflows/phase-executor.ts
@@ -319,6 +319,7 @@ export async function runPhase(
           apiDurationMs: result.apiDurationMs,
           stopReason: result.stopReason,
           extensionStatus: result.extensions ? JSON.stringify(result.extensions) : undefined,
+          skillsStatus: result.skills ? JSON.stringify(result.skills) : undefined,
         });
         span?.setAttributes({ success: result.success, stop_reason: result.stopReason ?? "unknown" });
         recordExecutionMetrics("phase", { ...attrs, success: result.success, stop_reason: result.stopReason, durationMs: result.durationMs, costUsd: result.costUsd, inputTokens: result.inputTokens, outputTokens: result.outputTokens });


### PR DESCRIPTION
## What

Bumps **agentic-pi to 0.2.6** ([PR #3](https://github.com/cliftonc/agentic-pi/pull/3)) and uses its new gated `skills_status` event to capture **skill loading** — the counterpart to the existing `extension_status` (tool-loading) capture — then surfaces it in the dashboard.

## Backend (mirrors the `extensions` chain end-to-end)

- `RunResultAccumulator` parses `skills_status` and exposes a normalized `skills()`, threaded through `finalizeFromRunResult` onto `ExecutionResult.skills`.
- New types `SkillsStatus` / `SkillSummary` in `profiles.ts` (verified against the installed `agentic-pi` `.d.ts`, not just the PR description).
- Persisted to a new **additive** `executions.skills_status` column and served on the workflow-run executions endpoint.
- Also wired into the two sibling surfaces that already handle `extension_status`: OTEL telemetry (`pi-events.ts`) and the session-log shim (`event-shim.ts`).

## Dashboard

The phase-detail panel now splits into **Details** and **Loaded** tabs. The previously-bottom **Extensions** section moves into **Loaded** alongside the new **Skills** section (lists discovered skills, badges non-model-invocable ones with `manual`). The tab shows a loaded-item count, e.g. `Loaded (3)`.

## Notes

- The `skills_status` column populates on **future** runs only — existing execution rows show an empty section (same behaviour as `extension_status` when it was added). Nothing to backfill.
- The chat execution path doesn't capture extensions/skills (and isn't shown via this panel), so it's intentionally untouched.

## Testing

- Added `skills()` accumulator coverage + a `skills_status` telemetry assertion, mirroring the extension tests.
- Full server suite green (679 passed), server + dashboard typecheck clean, dashboard prod build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)