### PR TITLE
feat(prompts): enforceable build-cycle quality guardrails (#117)

### DIFF
--- a/skills/building/SKILL.md
+++ b/skills/building/SKILL.md
@@ -39,6 +39,13 @@ The **only** acceptable "couldn't verify" is when the install or build command
 *itself* fails — quote the exact command and error, and scope your work to what
 you could check. Never cite "deps aren't installed" as the reason: you install them.
 
+**If the repo's only test path needs an external service that won't run in the
+sandbox** (a live database, a cloud API, a running daemon), do **not** report
+that verification "could not run." Add a focused unit or CLI test project that
+exercises your change against in-memory fixtures or fakes, run *that*, and paste
+its output. A change you couldn't execute even once is unverified — building a
+runnable path is part of the work, not an optional extra.
+
 ## The gate
 
 While iterating, run **only the tests covering the files you touched** — not the
@@ -59,3 +66,30 @@ When you are *writing* code (not just verifying a PR): write the **failing test
 first**, watch it go red, then implement until it goes green, then refactor.
 Test behaviour through the public interface, not implementation details. The red
 test is the proof the test can fail — a test that was never red proves nothing.
+
+## Decomposition budget (when implementing)
+
+The gate passing is necessary, not sufficient — a green test does not excuse an
+unmaintainable function. Before you commit, decompose:
+
+- Keep each function under **roughly 15 cyclomatic complexity** (branches +
+  loops + boolean operators). If you're past that, extract helpers.
+- One function = one responsibility. A function that **parses, validates, and
+  emits is three functions** — split it before committing, not "later."
+- The refactor step of red-green-refactor is where this happens. Don't skip it
+  because the tests already pass.
+
+## Type safety — no compiler-silencing assertions
+
+The gate requires `tsc` (or the project's typechecker) to pass — but passing it
+by *suppressing* it is a regression, not a fix. **Never** use `as any`, an
+unchecked `as`-cast, `@ts-ignore`/`@ts-expect-error`, `# type: ignore`, or the
+equivalent to:
+
+- silence a compiler error instead of fixing the underlying type, or
+- bypass a validator/guard the same code path defines (e.g. casting past a Zod
+  schema, a runtime type guard, or a parse function so the value skips the very
+  check that file exists to enforce).
+
+If the types genuinely can't express something, narrow with a real type guard or
+fix the type — don't assert your way past it.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -21,17 +21,30 @@ not just the happy path.
 
 Categorise every finding into exactly one tier:
 
-- **Critical** — security issues, data loss, breaking changes. Blocks merge.
-- **Important** — missing tests, performance problems, type errors. Should fix.
-- **Suggestions** — clarity, naming, DRY opportunities. Nice to have.
+- **Critical** — security issues, data loss, breaking changes, silent
+  data-dropping (see Correctness below). Blocks merge.
+- **Important** — missing tests, performance problems, type errors, **avoidable
+  duplication**, **excessive complexity**, **compiler-silencing assertions**.
+  Should fix.
+- **Suggestions** — clarity, naming, minor DRY tidy-ups. Nice to have.
 - **Nits** — style, formatting. Optional.
 
 ## What to check
 
 - **Correctness** — does it do what it claims? Logic errors, off-by-one, wrong
-  conditions, mishandled async.
+  conditions, mishandled async. **A silent default or a dropped output for an
+  input the code doesn't support is a correctness bug, not graceful handling** —
+  flag any unsupported case that is silently defaulted, skipped, or omitted
+  instead of warned-and-skipped or warned-and-surfaced.
 - **Edge cases** — empty/null inputs, boundaries, error paths, concurrency.
 - **Security** — injection, auth/authorization, secret handling, untrusted input.
+- **Complexity** — flag functions past ~15 cyclomatic complexity or that mix
+  parse/validate/emit responsibilities; ask for helper extraction. This is an
+  **Important** finding, not a nit.
+- **Duplication** — flag avoidable duplicated logic (two or more clone groups of
+  the same code/branching). DRY is **should-fix** here, not merely "nice to have."
+- **Type safety** — flag `as any`, unchecked `as`-casts, or `@ts-ignore` used to
+  silence the compiler or to bypass a validator the same code path defines.
 - **Regression risk** — existing callers of changed functions; behaviour changes
   that ripple.
 - **Test coverage** — do the tests exercise the real risk, or just the happy path?

--- a/spec/08-skills.md
+++ b/spec/08-skills.md
@@ -241,8 +241,8 @@ chat runtime:
 | `repo-health` | Weekly health report (open / stale / velocity / labels) | `repo-health.yaml`, `cron-health.yaml`, chat |
 | `security-review` | Diff-based security scan since last review | `security-review.yaml`, `cron-security.yaml` |
 | `security-feedback` | Break out scan findings into individual issues | `security-feedback.yaml` |
-| `building` | Shared craft: install deps + run the test/lint/typecheck gate in the sandbox (package-manager detection from lockfile, install-first, TDD discipline when implementing) | build executor + reviewer, `pr-fix.yaml`, `pr-review.yaml` |
-| `code-review` | Shared review rubric: finding tiers (Critical / Important / Suggestions / Nits) + what to check (correctness, security, edge cases, regression risk, test coverage) | build cycle's branch-diff reviewer, `pr-review.yaml` (same rubric, different procedure) |
+| `building` | Shared craft: install deps + run the test/lint/typecheck gate in the sandbox (package-manager detection from lockfile, install-first, TDD discipline when implementing, a decomposition budget (~15 cyclomatic), no compiler-silencing assertions, and building a runnable in-sandbox verification path when the only test path needs an unavailable external service) | build executor + reviewer, `pr-fix.yaml`, `pr-review.yaml` |
+| `code-review` | Shared review rubric: finding tiers (Critical / Important / Suggestions / Nits) + what to check (correctness incl. silent-default/dropped-output as a bug, security, edge cases, complexity, duplication, type-safety, regression risk, test coverage) | build cycle's branch-diff reviewer, `pr-review.yaml` (same rubric, different procedure) |
 | `issue-answer` | Answer a question directly: sourced neutral reply to a GitHub issue or Slack thread; research repo docs + web; label `question` (GitHub only); never write a brief, mark ready-for-agent, or change code | `answer.yaml` |
 | `chat` | Conversational assistant persona | chat (always-on) |
 

--- a/workflows/prompts/architect.md
+++ b/workflows/prompts/architect.md
@@ -26,6 +26,11 @@ OUTPUT — write the plan to {{issueDir}}/architect-plan.md:
   guardrails-report.md into the plan so the executor uses them directly.
 - Implementation approach (step-by-step)
 - Risks and edge cases
+  - For every input the design does NOT fully support, specify **warn-and-skip**
+    or **warn-and-surface** behaviour explicitly. A silent default, a silently
+    skipped case, or a dropped output is a correctness bug — never plan for one.
+    If an input can't be handled, the plan must say how the user is told (a
+    warning, a surfaced error), not let it disappear.
 - Test strategy
 - Estimated complexity: simple / medium / complex
 

--- a/workflows/prompts/executor.md
+++ b/workflows/prompts/executor.md
@@ -19,6 +19,14 @@ write the failing test before implementing (TDD), and run the full
 test/lint/typecheck gate once before committing — all of it must pass before you
 commit or claim done.
 
+Before committing, also honour the building skill's **decomposition budget** and
+**type-safety** rules: keep functions under ~15 cyclomatic complexity (a
+function that parses, validates, and emits is three functions — extract helpers),
+and never use `as any` or other compiler-silencing assertions to pass the gate or
+to skip a validator the same code defines. If the repo's only test path needs an
+unavailable external service, add a runnable unit/CLI test with in-memory
+fixtures rather than declaring the change unverified.
+
 AFTER THE GATE PASSES:
 1. Write {{issueDir}}/executor-summary.md:
    - What was done, files changed


### PR DESCRIPTION
Closes #117

Promotes advisory build/review rules to enforceable thresholds (items 2–6 from the issue): a decomposition budget, no compiler-silencing assertions, a runnable in-sandbox verification path, complexity/duplication as should-fix in review, and warn-and-surface for unsupported input.

**Item 1 skipped** — we're retaining the `.lastlight/` artifacts on the branch as-is, so the scratch-out-of-diff / PR-link-block changes are not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)