### PR TITLE
feat(auth): OAuth subscription logins (Codex, Claude Pro, Copilot)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,20 @@ WEBHOOK_SECRET=your-webhook-secret
 # KIMI_API_KEY=...                     # kimi-coding/… models
 # MINIMAX_API_KEY=...                  # minimax/… models
 
+# ── Subscription logins (OAuth — no API key) ───────────────────────────────
+# Instead of a provider API key you can authenticate with a subscription:
+#   ChatGPT Plus/Pro (Codex), Claude Pro/Max, or GitHub Copilot. Log in once
+#   on this host — it writes $STATE_DIR/auth.json (the same shape pi-ai's own
+#   CLI writes) which the harness reads:
+#     lastlight oauth login openai-codex     # ChatGPT Plus/Pro (Codex)
+#     lastlight oauth list                   # see providers + login status
+#   then point the model at that provider and restart:
+#     LASTLIGHT_MODEL=openai-codex/gpt-5.6-terra
+# Reach: Codex works for CHAT only (its chatgpt.com backend has no env-token
+# route, so it can't authenticate inside the agentic-pi sandbox). Anthropic
+# and Copilot OAuth also work for sandbox workflows via ANTHROPIC_OAUTH_TOKEN /
+# COPILOT_GITHUB_TOKEN. Override the store path with LASTLIGHT_AUTH_FILE.
+
 # ── Slack OAuth (optional — enables "Login with Slack" on dashboard) ──
 # Create a Slack app at https://api.slack.com/apps and enable "Sign in with Slack"
 # Redirect URI must be: https://<your-host>/admin/api/oauth/slack/callback

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,22 @@ API credentials are read from the provider env vars in the registry at
 match your `OPENCODE_MODEL` / `OPENCODE_MODELS`. No `claude` CLI, no
 Anthropic SDK in the runtime path.
 
+**Subscription logins (OAuth).** Besides the API-key providers above, three
+providers authenticate by subscription login instead of a static key —
+`openai-codex` (ChatGPT Plus/Pro), `anthropic` (Claude Pro/Max), and
+`github-copilot`. They're registered in `OAUTH_PROVIDERS` in `src/providers.ts`
+(separate from the API-key `PROVIDERS`). `src/engine/oauth.ts` is the shared
+layer: one on-disk store (`$STATE_DIR/auth.json`, override `LASTLIGHT_AUTH_FILE`
+— same JSON shape pi-ai's own CLI writes), `resolveOAuthApiKey()`
+(refresh-if-expired + persist), and the model-prefix→provider-id map.
+`lastlight oauth login|list|status|test|logout` (host-local,
+`src/cli/oauth-cli.ts`) drives the browser flow. **Two seams, different reach:**
+the in-process **chat** path (`chat-runner.ts`) passes the token as a per-call
+`apiKey`, so all three work; the **sandbox** path (`agent-executor.ts`) resolves
+creds from env only and injects `ANTHROPIC_OAUTH_TOKEN` / `COPILOT_GITHUB_TOKEN`
+— Codex has no env-token route, so it's **chat-only** (the executor warns if a
+Codex model is used for a sandbox phase).
+
 The cheap-helper path (`src/engine/llm.ts`, used by screener + classifier)
 bypasses OpenCode and dispatches directly to the same three providers.
 `defaultFastModel()` prefers Anthropic > OpenAI > OpenRouter when multiple
@@ -477,6 +493,15 @@ lastlight fork agent-context [file]    # all agent-context/*.md (soul/rules/secu
 lastlight skills install               # → ~/.claude/skills (user) [--scope project] [--no-marketplace]
 lastlight skills list                  # bundled skills + where they're installed
 lastlight skills uninstall             # remove them [--scope user|project]
+
+# Subscription logins (HOST-LOCAL; src/cli/oauth-cli.ts). Browser OAuth flow +
+# credential store at $STATE_DIR/auth.json (override LASTLIGHT_AUTH_FILE);
+# restart the agent to apply. Codex is chat-only (no sandbox env-token route).
+lastlight oauth login [provider]       # openai-codex | anthropic | github-copilot
+lastlight oauth list                   # providers + login status
+lastlight oauth status                 # store path + token expiry
+lastlight oauth test <provider>        # force a refresh to verify the login
+lastlight oauth logout [provider]      # remove one (or all) [--auth-file f] [--state-dir d]
 
 # Local dev with Docker sandbox isolation
 ./scripts/dev-local.sh                 # builds opencode.json + secrets

--- a/README.md
+++ b/README.md
@@ -163,6 +163,49 @@ The default for a single-issue/PR shorthand is the **cheap** action (triage or r
 
 pi-ai picks credentials from the provider env vars the harness forwards (the full listed set lives in `src/providers.ts` — Anthropic / OpenAI / OpenRouter / Google / Mistral / Groq / Cerebras / xAI / HuggingFace / Moonshot / NVIDIA / Fireworks / Together / DeepSeek / Z.AI / Kimi / MiniMax). The harness forwards them into each sandbox container (or VM) so workflow runs can reach the API.
 
+#### Subscription logins (OAuth) — Codex, Claude Pro, Copilot
+
+Instead of an API key you can authenticate with a paid subscription. pi-ai
+supports three OAuth providers; log in once on the host and Last Light stores
+and refreshes the token for you. In this from-source checkout the CLI runs via
+`tsx` (there's no globally-installed `lastlight` binary yet — that's what a
+published `npm i -g lastlight` gives you):
+
+```bash
+npx tsx src/cli/cli.ts oauth login openai-codex   # ChatGPT Plus/Pro (Codex)
+npx tsx src/cli/cli.ts oauth login anthropic      # Claude Pro/Max
+npx tsx src/cli/cli.ts oauth login github-copilot # GitHub Copilot
+npx tsx src/cli/cli.ts oauth list                 # providers + who's logged in
+npx tsx src/cli/cli.ts oauth status               # store path + token expiry
+npx tsx src/cli/cli.ts oauth test openai-codex    # verify a stored login refreshes
+npx tsx src/cli/cli.ts oauth logout [provider]    # remove one (or all)
+```
+
+> Installed globally, these are just `lastlight oauth login …` etc. — the
+> subcommands are identical.
+
+Then point the model at that provider and restart the agent:
+
+```bash
+LASTLIGHT_MODEL=openai-codex/gpt-5.5   # Codex ids: gpt-5.5 / gpt-5.4 / gpt-5.4-mini / gpt-5.3-codex-spark
+```
+
+The login writes `auth.json` under `$STATE_DIR` (same JSON shape pi-ai's own
+`npx @earendil-works/pi-ai login` writes; override with `LASTLIGHT_AUTH_FILE`).
+It's **host-local** — the browser OAuth flow runs where you type the command,
+so run it on the machine that runs the agent, then restart (`npm run dev:server`
+from source, or `lastlight server restart agent` for the installed deploy) to
+pick it up. Note `tsx watch` does **not** reload on `.env` changes — restart
+after switching `LASTLIGHT_MODEL`.
+
+**Reach differs by execution path.** The in-process **chat** path passes the
+token as a per-call key, so all three providers work there. The **sandbox**
+(agentic-pi workflow phases) resolves credentials from env only —
+`ANTHROPIC_OAUTH_TOKEN` / `COPILOT_GITHUB_TOKEN` cover Anthropic and Copilot,
+but **Codex has no env-token route and therefore can't run sandbox workflows**
+(it's chat-only). Use an API-key provider for build/triage/review workflows if
+you only have a Codex subscription.
+
 ---
 
 ## Docker Deployment

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@sinclair/typebox": "^0.34.49",
         "@slack/bolt": "^4.6.0",
         "@slack/web-api": "^7.16.0",
-        "agentic-pi": "^0.2.11",
+        "agentic-pi": "^0.2.14",
         "arctic": "^3.7.0",
         "better-sqlite3": "^11.0.0",
         "chalk": "^5.6.2",
@@ -1625,7 +1625,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -7935,9 +7935,9 @@
       }
     },
     "node_modules/agentic-pi": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/agentic-pi/-/agentic-pi-0.2.11.tgz",
-      "integrity": "sha512-27pKFXMboJYUN1NpuQXE5tQ0k9V1TW1q6NLHC+BNlId8ilqR62ygo18mHDg9+UOZiAwTr4Y62HvQbMXXnl2mNw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/agentic-pi/-/agentic-pi-0.2.14.tgz",
+      "integrity": "sha512-I1lAS30cYOOLMvb1T5lmXJ75ljGKgXjnP1JhkwVnF0Vf+Ij/3ObayLGGAyXYeJEwl6tBUcg371tzImGiJdjOMw==",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/gondolin": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@sinclair/typebox": "^0.34.49",
     "@slack/bolt": "^4.6.0",
     "@slack/web-api": "^7.16.0",
-    "agentic-pi": "^0.2.11",
+    "agentic-pi": "^0.2.14",
     "arctic": "^3.7.0",
     "better-sqlite3": "^11.0.0",
     "chalk": "^5.6.2",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -289,6 +289,14 @@ ${chalk.bold("Skills")} (host-local — install the Last Light Claude Code skill
   lastlight skills list              List bundled skills + where they're installed
   lastlight skills uninstall         Remove the installed skills [--scope user|project]
 
+${chalk.bold("OAuth")} (host-local — subscription logins for the model provider)
+  lastlight oauth list               List OAuth providers + which are logged in
+  lastlight oauth login [provider]   Log in via ChatGPT/Codex, Claude Pro, or Copilot
+  lastlight oauth status             Show the credential store + token expiry
+  lastlight oauth test <provider>    Verify a stored login still refreshes
+  lastlight oauth logout [provider]  Remove one (or all) stored logins
+                                     Writes auth.json under $STATE_DIR; restart the agent after.
+
 ${chalk.bold("Other")}
   lastlight setup                    First-run wizard — asks client (login) or server (stack)
                                      [--client | --server to skip the prompt]
@@ -1016,6 +1024,23 @@ async function cmdSkills(): Promise<void> {
   });
 }
 
+// ── oauth (host-local) ─────────────────────────────────────────────────────
+
+/**
+ * `lastlight oauth <login|list|status|logout|test>` — manage subscription
+ * logins (Codex / Claude Pro / Copilot). Host-local: runs the browser OAuth
+ * flow and writes auth.json under $STATE_DIR where the harness reads it. See
+ * src/cli/oauth-cli.ts.
+ */
+async function cmdOAuth(): Promise<void> {
+  const { oauth } = await import("./oauth-cli.js");
+  await oauth(positionals.slice(1), {
+    authFile: typeof flags["auth-file"] === "string" ? flags["auth-file"] : undefined,
+    stateDir: typeof flags["state-dir"] === "string" ? flags["state-dir"] : undefined,
+    json: flags.json === true,
+  });
+}
+
 // ── dispatch ─────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -1052,6 +1077,8 @@ async function main() {
     case "approvals": return cmdApprovals();
     case "fork": return cmdFork();
     case "skills": return cmdSkills();
+    case "oauth":
+    case "auth": return cmdOAuth();
     case "server": return cmdServer();
     case "stats": return cmdStats();
     case "chat": return cmdChat();

--- a/src/cli/oauth-cli.ts
+++ b/src/cli/oauth-cli.ts
@@ -1,0 +1,250 @@
+/**
+ * `lastlight oauth <login|list|logout|status>` — HOST-LOCAL.
+ *
+ * Manages subscription-login credentials (ChatGPT Plus/Pro Codex, Claude
+ * Pro/Max, GitHub Copilot) for the model provider pi-ai talks to. Unlike most
+ * of the CLI (a thin HTTP client), this runs entirely on the host: the OAuth
+ * flow needs a local browser + callback server, and it writes the credential
+ * store (`auth.json`) to the same `$STATE_DIR` the running harness reads. So
+ * run it on the machine that runs the agent, then restart the agent to pick up
+ * a new login (`lastlight server restart agent`, or just re-run `npm run dev`).
+ *
+ * The store is a superset-compatible `auth.json` — the same JSON shape pi-ai's
+ * own `npx @earendil-works/pi-ai login` writes — so either tool can produce it.
+ */
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import chalk from "chalk";
+import {
+  getOAuthProvider,
+  getOAuthProviders,
+  loadAuthMap,
+  resolveAuthFile,
+  resolveOAuthApiKey,
+  saveAuthMap,
+  type AuthMap,
+} from "../engine/oauth.js";
+
+interface OAuthCliOpts {
+  /** Explicit auth-file path (--auth-file). */
+  authFile?: string;
+  /** State dir override (--state-dir) used to locate auth.json. */
+  stateDir?: string;
+  json?: boolean;
+}
+
+function openBrowser(url: string): void {
+  const platform = process.platform;
+  const cmd = platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
+  const args = platform === "win32" ? ["", url] : [url];
+  try {
+    const child = spawn(cmd, args, { stdio: "ignore", detached: true, shell: platform === "win32" });
+    child.unref();
+  } catch {
+    /* best-effort — the URL is printed too */
+  }
+}
+
+function ask(rl: ReturnType<typeof createInterface>, question: string): Promise<string> {
+  return new Promise((res) => rl.question(question, res));
+}
+
+function fileFor(opts: OAuthCliOpts): string {
+  return resolveAuthFile(opts.authFile, opts.stateDir);
+}
+
+/** Human label for an expiry epoch-ms, or "no expiry". */
+function expiryLabel(expires: unknown): string {
+  if (typeof expires !== "number" || !Number.isFinite(expires)) return "unknown expiry";
+  const deltaMs = expires - Date.now();
+  if (deltaMs <= 0) return chalk.yellow("expired (auto-refreshes on next use)");
+  const mins = Math.round(deltaMs / 60000);
+  if (mins < 90) return `expires in ${mins}m`;
+  return `expires in ${Math.round(mins / 60)}h`;
+}
+
+async function oauthList(opts: OAuthCliOpts): Promise<void> {
+  const providers = getOAuthProviders();
+  const map = loadAuthMap(opts.authFile, opts.stateDir);
+  if (opts.json) {
+    console.log(
+      JSON.stringify(
+        {
+          authFile: fileFor(opts),
+          providers: providers.map((p) => ({ id: p.id, name: p.name, loggedIn: !!map[p.id] })),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  console.log(chalk.bold("OAuth providers (subscription logins):\n"));
+  for (const p of providers) {
+    const status = map[p.id] ? chalk.green("● logged in") : chalk.dim("○ not logged in");
+    console.log(`  ${chalk.cyan(p.id.padEnd(16))} ${p.name.padEnd(40)} ${status}`);
+  }
+  console.log(`\n${chalk.dim("Store: " + fileFor(opts))}`);
+  console.log(chalk.dim("Log in with: lastlight oauth login <provider>"));
+}
+
+async function oauthStatus(opts: OAuthCliOpts): Promise<void> {
+  const map = loadAuthMap(opts.authFile, opts.stateDir);
+  const ids = Object.keys(map);
+  if (opts.json) {
+    console.log(
+      JSON.stringify(
+        { authFile: fileFor(opts), loggedIn: ids.map((id) => ({ id, expires: map[id]?.expires ?? null })) },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  console.log(`${chalk.bold("Store:")} ${fileFor(opts)}`);
+  if (ids.length === 0) {
+    console.log(chalk.dim("No OAuth logins stored. Run: lastlight oauth login <provider>"));
+    return;
+  }
+  for (const id of ids) {
+    console.log(`  ${chalk.cyan(id.padEnd(16))} ${expiryLabel(map[id]?.expires)}`);
+  }
+}
+
+async function oauthLogin(providerId: string | undefined, opts: OAuthCliOpts): Promise<void> {
+  const providers = getOAuthProviders();
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    // Interactive provider selection when none named.
+    if (!providerId) {
+      console.log(chalk.bold("Select a provider to log in:\n"));
+      providers.forEach((p, i) => console.log(`  ${i + 1}. ${p.name} ${chalk.dim(`(${p.id})`)}`));
+      const choice = await ask(rl, `\nEnter number (1-${providers.length}): `);
+      const idx = Number.parseInt(choice, 10) - 1;
+      if (!(idx >= 0 && idx < providers.length)) {
+        console.error(chalk.red("Invalid selection"));
+        process.exit(1);
+      }
+      providerId = providers[idx].id;
+    }
+
+    const provider = getOAuthProvider(providerId);
+    if (!provider) {
+      console.error(chalk.red(`Unknown provider: ${providerId}`));
+      console.error(chalk.dim(`Available: ${providers.map((p) => p.id).join(", ")}`));
+      process.exit(1);
+    }
+
+    console.log(chalk.bold(`\nLogging in to ${provider.name}…\n`));
+    const credentials = await provider.login({
+      onAuth: (info) => {
+        console.log(`Open this URL in your browser to authorize:\n\n  ${chalk.cyan(info.url)}\n`);
+        if (info.instructions) console.log(chalk.dim(info.instructions) + "\n");
+        openBrowser(info.url);
+      },
+      onDeviceCode: (info) => {
+        console.log(`Open ${chalk.cyan(info.verificationUri)} and enter code: ${chalk.bold(info.userCode)}\n`);
+        openBrowser(info.verificationUri);
+      },
+      onPrompt: async (p) =>
+        (await ask(rl, `${p.message}${p.placeholder ? ` (${p.placeholder})` : ""}: `)).trim(),
+      onSelect: async (p) => {
+        console.log(`\n${p.message}`);
+        p.options.forEach((o, i) => console.log(`  ${i + 1}. ${o.label}`));
+        const choice = await ask(rl, `Enter number (1-${p.options.length}): `);
+        const idx = Number.parseInt(choice, 10) - 1;
+        return p.options[idx]?.id;
+      },
+      onProgress: (msg) => console.log(chalk.dim(msg)),
+    });
+
+    const map: AuthMap = loadAuthMap(opts.authFile, opts.stateDir);
+    map[provider.id] = { type: "oauth", ...credentials };
+    saveAuthMap(map, opts.authFile, opts.stateDir);
+    console.log(chalk.green(`\n✓ Logged in to ${provider.name}.`));
+    console.log(chalk.dim(`  Credentials saved to ${fileFor(opts)}`));
+    console.log(
+      chalk.dim(
+        `  Point the model at it, e.g. LASTLIGHT_MODEL=${sampleModelFor(provider.id)} — ` +
+          `then restart the agent.`,
+      ),
+    );
+  } finally {
+    rl.close();
+  }
+}
+
+/** A representative model spec for the freshly-logged-in provider (docs hint only). */
+function sampleModelFor(id: string): string {
+  switch (id) {
+    case "openai-codex":
+      return "openai-codex/gpt-5.4";
+    case "anthropic":
+      return "anthropic/claude-sonnet-4-6";
+    case "github-copilot":
+      return "github-copilot/gpt-4o";
+    default:
+      return `${id}/<model>`;
+  }
+}
+
+async function oauthLogout(providerId: string | undefined, opts: OAuthCliOpts): Promise<void> {
+  const map = loadAuthMap(opts.authFile, opts.stateDir);
+  if (!providerId) {
+    const n = Object.keys(map).length;
+    saveAuthMap({}, opts.authFile, opts.stateDir);
+    console.log(chalk.green(`✓ Cleared all ${n} OAuth login(s) from ${fileFor(opts)}`));
+    return;
+  }
+  if (!map[providerId]) {
+    console.log(chalk.yellow(`No stored login for '${providerId}'.`));
+    return;
+  }
+  delete map[providerId];
+  saveAuthMap(map, opts.authFile, opts.stateDir);
+  console.log(chalk.green(`✓ Logged out of '${providerId}'.`));
+}
+
+/** Verify a stored login still works by forcing a token resolve/refresh. */
+async function oauthTest(providerId: string | undefined, opts: OAuthCliOpts): Promise<void> {
+  if (!providerId) {
+    console.error(chalk.red("Usage: lastlight oauth test <provider>"));
+    process.exit(1);
+  }
+  try {
+    const res = await resolveOAuthApiKey(providerId, opts.authFile, opts.stateDir);
+    if (!res) {
+      console.log(chalk.yellow(`Not logged in to '${providerId}'. Run: lastlight oauth login ${providerId}`));
+      process.exit(1);
+    }
+    console.log(chalk.green(`✓ '${providerId}' token is valid (refreshed if needed).`));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(chalk.red(`✗ Token refresh failed for '${providerId}': ${msg}`));
+    console.error(chalk.dim(`  Re-run: lastlight oauth login ${providerId}`));
+    process.exit(1);
+  }
+}
+
+/** Entry point invoked by cli.ts: `args` = positionals after "oauth". */
+export async function oauth(args: string[], opts: OAuthCliOpts): Promise<void> {
+  const sub = args[0];
+  const target = args[1];
+  switch (sub) {
+    case undefined:
+    case "list":
+      return oauthList(opts);
+    case "status":
+      return oauthStatus(opts);
+    case "login":
+      return oauthLogin(target, opts);
+    case "logout":
+      return oauthLogout(target, opts);
+    case "test":
+      return oauthTest(target, opts);
+    default:
+      console.error(chalk.red(`Unknown oauth subcommand: ${sub}`));
+      console.error(chalk.dim("Usage: lastlight oauth <login|list|status|logout|test> [provider]"));
+      process.exit(1);
+  }
+}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -25,7 +25,7 @@ import * as p from "@clack/prompts";
 import chalk from "chalk";
 import { OVERLAY_GITIGNORE, detectGh, bootstrapOverlayRepo } from "../config/overlay-bootstrap.js";
 import { serverUpdate } from "./cli-server.js";
-import { PROVIDERS, providerByPrefix, DEFAULT_MODEL, type ProviderSpec } from "../providers.js";
+import { PROVIDERS, providerByPrefix, OAUTH_PROVIDERS, oauthProviderById, type ProviderSpec } from "../providers.js";
 
 // ── Brand colors ───────────────────────────────────────────────────────────
 
@@ -536,7 +536,8 @@ async function collectManagedRepos(): Promise<string[]> {
  */
 async function collectModelAndKey(): Promise<{
   model: string;
-  providerApiKey: { envKey: string; value: string };
+  /** Undefined for OAuth (subscription-login) providers — they use auth.json, not an env key. */
+  providerApiKey: { envKey: string; value: string } | undefined;
 }> {
   p.log.step(gold("Model provider"));
   p.log.info(
@@ -564,10 +565,46 @@ async function collectModelAndKey(): Promise<{
               : spec.displayName,
           hint: spec.prefix,
         })),
+        // OAuth (subscription-login) providers — no API key; the user logs in
+        // separately via `lastlight oauth login`. Value tagged `oauth:<id>`.
+        ...OAUTH_PROVIDERS.map((o) => ({
+          value: `oauth:${o.id}`,
+          label: `${o.displayName} ${dim("(OAuth login)")}`,
+          hint: o.modelPrefix,
+        })),
         { value: "__custom__", label: dim("Enter a custom provider/model...") },
       ],
     }),
   ) as string;
+
+  // OAuth branch: no API key. Pick a model id, return a key-less result, and
+  // remind the user to run the login after setup (the browser flow writes
+  // auth.json, not the .env this wizard produces).
+  if (providerChoice.startsWith("oauth:")) {
+    const oauth = oauthProviderById(providerChoice.slice("oauth:".length))!;
+    const sampleId = oauth.sampleModel.slice(oauth.sampleModel.indexOf("/") + 1);
+    const customModelId = required(
+      await p.text({
+        message: `Model id for ${oauth.displayName} ${dim("(provider prefix added automatically)")}`,
+        placeholder: sampleId,
+        defaultValue: sampleId,
+        validate: (v) =>
+          !v || !v.trim() || /^[A-Za-z0-9][\w/.-]*$/.test(v)
+            ? undefined
+            : "Use the model id (e.g. gpt-5.4).",
+      }),
+    ) as string;
+    const model = `${oauth.modelPrefix}/${(customModelId || sampleId).trim()}`;
+    p.log.success(`Model: ${teal(model)} — auth: ${dim("OAuth (subscription login)")}`);
+    p.note(
+      `After setup finishes, log in on this host:\n\n  ${teal(`lastlight oauth login ${oauth.id}`)}\n\n` +
+        (oauth.sandboxEnvVar
+          ? dim("Works for chat and sandbox workflows.")
+          : dim("Chat only — sandbox workflows can't use this provider (no env-token route).")),
+      "One more step",
+    );
+    return { model, providerApiKey: undefined };
+  }
 
   let spec: ProviderSpec;
   let modelId: string;

--- a/src/engine/agent-executor.ts
+++ b/src/engine/agent-executor.ts
@@ -131,22 +131,28 @@ async function prepareRun(
     if (v) ghEnv[envKey] = v;
   }
 
-  // OAuth-backed providers (subscription logins). agentic-pi resolves creds
-  // from env only — it has no apiKey/auth option — so we hand the sandbox the
-  // token via the env var pi-ai reads for that provider. Refreshed per run
-  // (getOAuthApiKey renews an expired token). Two providers have an env route
-  // (ANTHROPIC_OAUTH_TOKEN, COPILOT_GITHUB_TOKEN); Codex (chatgpt.com backend)
-  // has none, so a Codex model can't authenticate in the sandbox — surface
-  // that as an actionable warning rather than an opaque 401 mid-run.
+  // OAuth-backed providers (subscription logins: Codex / Claude Pro / Copilot).
+  //
+  // In-process backends (none/gondolin) run the model call host-side, so the
+  // orchestrator hands agentic-pi `authFile` = our credential store and Pi's
+  // AuthStorage resolves EVERY OAuth provider (Codex included) from it. Nothing
+  // to do here for those backends.
+  //
+  // Container backends (docker/smol) run the model call inside the guest, where
+  // that host path can't be read — so we inject the refreshed token via the env
+  // var pi reads in-guest (ANTHROPIC_OAUTH_TOKEN / COPILOT_GITHUB_TOKEN). Codex
+  // has no in-guest env route (chatgpt.com backend), so it can't authenticate
+  // there — warn rather than 401 mid-run, and point at a host-side backend.
+  const inProcessBackend = backend === "none" || backend === "gondolin";
   const modelSpec = config.model || DEFAULT_MODEL;
   const oauthId = oauthProviderIdForModel(modelSpec);
-  if (oauthId) {
+  if (oauthId && !inProcessBackend) {
     const oauthEnvVar = oauthEnvVarForProvider(oauthId);
     if (!oauthEnvVar) {
       console.warn(
         `[executor] Model '${modelSpec}' uses OAuth provider '${oauthId}', which has no ` +
-          `sandbox env-var route — the sandboxed run cannot authenticate. Use an API-key ` +
-          `provider for sandbox workflows (chat can use '${oauthId}').`,
+          `in-guest env route — the '${backend}' sandbox can't authenticate it. Use the ` +
+          `gondolin/none backend (host-side auth via the credential store) or an API-key provider.`,
       );
     } else if (!ghEnv[oauthEnvVar] && !process.env[oauthEnvVar]) {
       // Only mint from stored creds when an explicit token isn't already set.

--- a/src/engine/agent-executor.ts
+++ b/src/engine/agent-executor.ts
@@ -12,6 +12,7 @@ import type { PrePopulateSpec, SandboxFactory } from "../sandbox/sandbox.js";
 import { getDockerSandboxOtelEnv, getOtelEnvForSandbox, safeSpanAttributes, withSpan } from "../telemetry/index.js";
 import { DEFAULT_MODEL } from "./executors/shared.js";
 import { PROVIDER_ENV_KEYS } from "../providers.js";
+import { oauthEnvVarForProvider, oauthProviderIdForModel, resolveOAuthApiKey } from "./oauth.js";
 import {
   runSandboxedAgent,
   runSandboxedCommand,
@@ -128,6 +129,42 @@ async function prepareRun(
   for (const envKey of PROVIDER_ENV_KEYS) {
     const v = process.env[envKey];
     if (v) ghEnv[envKey] = v;
+  }
+
+  // OAuth-backed providers (subscription logins). agentic-pi resolves creds
+  // from env only — it has no apiKey/auth option — so we hand the sandbox the
+  // token via the env var pi-ai reads for that provider. Refreshed per run
+  // (getOAuthApiKey renews an expired token). Two providers have an env route
+  // (ANTHROPIC_OAUTH_TOKEN, COPILOT_GITHUB_TOKEN); Codex (chatgpt.com backend)
+  // has none, so a Codex model can't authenticate in the sandbox — surface
+  // that as an actionable warning rather than an opaque 401 mid-run.
+  const modelSpec = config.model || DEFAULT_MODEL;
+  const oauthId = oauthProviderIdForModel(modelSpec);
+  if (oauthId) {
+    const oauthEnvVar = oauthEnvVarForProvider(oauthId);
+    if (!oauthEnvVar) {
+      console.warn(
+        `[executor] Model '${modelSpec}' uses OAuth provider '${oauthId}', which has no ` +
+          `sandbox env-var route — the sandboxed run cannot authenticate. Use an API-key ` +
+          `provider for sandbox workflows (chat can use '${oauthId}').`,
+      );
+    } else if (!ghEnv[oauthEnvVar] && !process.env[oauthEnvVar]) {
+      // Only mint from stored creds when an explicit token isn't already set.
+      try {
+        const res = await resolveOAuthApiKey(oauthId, undefined, stateDir);
+        if (res) {
+          ghEnv[oauthEnvVar] = res.apiKey;
+        } else {
+          console.warn(
+            `[executor] Model '${modelSpec}' needs an OAuth login for '${oauthId}' but none is ` +
+              `stored. Run: lastlight oauth login ${oauthId}`,
+          );
+        }
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[executor] OAuth token refresh failed for '${oauthId}': ${msg}`);
+      }
+    }
   }
 
   // Web-search provider keys. Forwarded only when the workflow opted into

--- a/src/engine/chat/chat-runner.ts
+++ b/src/engine/chat/chat-runner.ts
@@ -29,6 +29,12 @@ import {
 } from "@earendil-works/pi-ai";
 import type { SessionManager } from "../../connectors/messaging/session-manager.js";
 import { buildChatGitHubTools, type ChatGitHubAuth, type ChatGitHubToolset } from "../github/github-tools.js";
+import {
+  OAUTH_ONLY_PROVIDERS,
+  getOAuthProvider,
+  oauthProviderIdForModel,
+  resolveOAuthApiKey,
+} from "../oauth.js";
 
 const MAX_TOOL_ROUNDS = 8;
 
@@ -182,10 +188,18 @@ export class ChatRunner {
   private model: Model<Api> | undefined;
   private modelError: string | undefined;
   private chains = new Map<string, Promise<unknown>>();
+  /**
+   * OAuth provider id backing the chat model (e.g. `openai-codex` for a
+   * `openai-codex/gpt-5.4` spec), or undefined for API-key providers. When
+   * set, each turn resolves a fresh subscription token instead of relying on
+   * a provider env var. Derived once from `cfg.model`.
+   */
+  private oauthProviderId: string | undefined;
 
   constructor(cfg: ChatRunnerConfig, sessionManager: SessionManager) {
     this.cfg = cfg;
     this.sessionManager = sessionManager;
+    this.oauthProviderId = oauthProviderIdForModel(cfg.model);
     if (cfg.github) {
       this.tools = buildChatGitHubTools(cfg.github);
     }
@@ -212,6 +226,22 @@ export class ChatRunner {
     return {
       content: JSON.stringify({ error: `unknown tool: ${call.name}` }),
       isError: true,
+    };
+  }
+
+  /** Build a failed-turn result carrying a single actionable error message. */
+  private errorTurn(agentSessionId: string, message: string): ChatRunnerTurnResult {
+    return {
+      text: "",
+      agentSessionId,
+      tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      costUsd: 0,
+      modelTurns: 0,
+      finish: "error",
+      errors: [message],
+      assistantMessages: [],
+      toolResults: [],
+      modelId: this.cfg.model,
     };
   }
 
@@ -265,18 +295,43 @@ export class ChatRunner {
     // model only fails chat turns, not the whole server.
     const model = this.resolveModelLazy();
     if (!model) {
-      return {
-        text: "",
-        agentSessionId,
-        tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        costUsd: 0,
-        modelTurns: 0,
-        finish: "error",
-        errors: [this.modelError ?? "chat model not configured"],
-        assistantMessages: [],
-        toolResults: [],
-        modelId: this.cfg.model,
-      };
+      return this.errorTurn(agentSessionId, this.modelError ?? "chat model not configured");
+    }
+
+    // Resolve the effective model + credentials. For OAuth-backed chat models
+    // (Codex / Claude Pro / Copilot) we mint a fresh subscription token per
+    // turn (pi-ai refreshes it if expired) and pass it as the per-call apiKey
+    // — the in-process chat path can carry an explicit key, unlike the sandbox.
+    let effectiveModel = model;
+    let apiKey: string | undefined;
+    if (this.oauthProviderId) {
+      try {
+        const res = await resolveOAuthApiKey(this.oauthProviderId);
+        if (res) {
+          apiKey = res.apiKey;
+          // Some providers rewrite the model (e.g. base URL) from credentials.
+          const prov = getOAuthProvider(this.oauthProviderId);
+          if (prov?.modifyModels) {
+            effectiveModel = prov.modifyModels([model], res.credentials)[0] ?? model;
+          }
+        } else if (OAUTH_ONLY_PROVIDERS.has(this.oauthProviderId)) {
+          // OAuth-only provider with no stored credentials — cannot fall back
+          // to an API key, so fail this turn with an actionable message.
+          return this.errorTurn(
+            agentSessionId,
+            `Chat model '${this.cfg.model}' requires an OAuth login. Run: ` +
+              `lastlight oauth login ${this.oauthProviderId}`,
+          );
+        }
+        // Non-OAuth-only (anthropic) with no creds: fall through to env-key auth.
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return this.errorTurn(
+          agentSessionId,
+          `OAuth token refresh failed for '${this.oauthProviderId}': ${msg}. ` +
+            `Re-run: lastlight oauth login ${this.oauthProviderId}`,
+        );
+      }
     }
 
     // Rehydrate conversation context from the DB. Messages were stored
@@ -301,6 +356,7 @@ export class ChatRunner {
     const opts: SimpleStreamOptions = {
       reasoning: pickReasoning(this.cfg.thinking),
       timeoutMs: this.cfg.timeoutMs ?? 120_000,
+      ...(apiKey ? { apiKey } : {}),
     };
 
     let finish = "stop";
@@ -316,7 +372,7 @@ export class ChatRunner {
       modelTurns++;
       let assistant: AssistantMessage;
       try {
-        assistant = await completeWithRetry(completeSimple, model, context, opts, {
+        assistant = await completeWithRetry(completeSimple, effectiveModel, context, opts, {
           onRetry: ({ attempt, delayMs, reason }) =>
             console.warn(
               `[chat] transient model error (retry ${attempt}/${CHAT_RETRY_BACKOFF_MS.length} ` +

--- a/src/engine/executors/orchestrator.ts
+++ b/src/engine/executors/orchestrator.ts
@@ -1,5 +1,6 @@
 import { basename, join } from "path";
-import { mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { resolveAuthFile } from "../oauth.js";
 import { randomUUID } from "crypto";
 import type { SandboxBackend } from "../../config/config.js";
 import {
@@ -185,6 +186,18 @@ export async function runSandboxedAgent(prompt: string, ctx: SandboxRunContext):
       }
     };
 
+    // OAuth credential store for model auth. Only the in-process adapters
+    // (none/gondolin) run the model call host-side, so a host path resolves
+    // there; the docker adapter ignores authFile (its model call is
+    // in-container) and relies on the OAuth env tokens spliced in by the
+    // executor. Pass the path only when the store actually exists so pure
+    // API-key deployments never point agentic-pi at a phantom file.
+    let authFile: string | undefined;
+    if (ctx.backend === "none" || ctx.backend === "gondolin") {
+      const candidate = resolveAuthFile(undefined, ctx.stateDir);
+      if (existsSync(candidate)) authFile = candidate;
+    }
+
     let returned;
     try {
       returned = await sandbox.runAgent(
@@ -194,6 +207,7 @@ export async function runSandboxedAgent(prompt: string, ctx: SandboxRunContext):
           model,
           thinking,
           profile,
+          authFile,
           sandboxEnv: AGENT_GIT_IDENTITY_ENV,
           agentCwd: prov.agentCwd,
           skillDirs,

--- a/src/engine/oauth.ts
+++ b/src/engine/oauth.ts
@@ -1,0 +1,125 @@
+/**
+ * OAuth credential management for LLM providers that authenticate with a
+ * subscription login instead of a static API key — ChatGPT Plus/Pro (Codex),
+ * Claude Pro/Max, and GitHub Copilot.
+ *
+ * pi-ai (`@earendil-works/pi-ai/oauth`) owns the actual OAuth flows, token
+ * refresh, and credential→apiKey conversion; this module is the thin Last
+ * Light layer on top:
+ *   - a single on-disk credential store (`auth.json`, same JSON shape pi-ai's
+ *     own CLI writes) resolved under `$STATE_DIR` so the CLI (writer) and the
+ *     running harness (reader) agree on one path,
+ *   - `resolveOAuthApiKey()` — refresh-if-expired + persist rotated creds +
+ *     return a usable key, used by the in-process chat path,
+ *   - the model-prefix → provider-id map and the sandbox env-var route so the
+ *     chat and sandbox executors can both find the right credential.
+ *
+ * Two consumption seams with different reach:
+ *   - **chat** (in-process pi-ai) — passes `apiKey` in the stream options, so
+ *     ALL three OAuth providers work, Codex included.
+ *   - **sandbox** (agentic-pi) — has no apiKey option; it reads provider creds
+ *     from env only. pi-ai honours `ANTHROPIC_OAUTH_TOKEN` and
+ *     `COPILOT_GITHUB_TOKEN`, but Codex (chatgpt.com backend) has no env route,
+ *     so a Codex model cannot run in the sandbox. See `oauthEnvVarForProvider`.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import {
+  getOAuthApiKey,
+  getOAuthProvider,
+  getOAuthProviders,
+  type OAuthCredentials,
+} from "@earendil-works/pi-ai/oauth";
+import { OAUTH_PROVIDERS, oauthProviderByModelPrefix, oauthProviderById } from "../providers.js";
+
+/** Stored form — pi-ai's CLI tags each entry with `type: "oauth"`; we match it. */
+export type StoredCredentials = OAuthCredentials & { type?: string };
+export type AuthMap = Record<string, StoredCredentials>;
+
+/** OAuth providers that CANNOT fall back to an API key — login is mandatory. */
+export const OAUTH_ONLY_PROVIDERS: ReadonlySet<string> = new Set(
+  OAUTH_PROVIDERS.filter((p) => p.oauthOnly).map((p) => p.id),
+);
+
+/** OAuth provider id backing a model spec, or undefined if it's API-key based. */
+export function oauthProviderIdForModel(spec: string): string | undefined {
+  const prefix = spec.includes("/") ? spec.slice(0, spec.indexOf("/")) : spec;
+  return oauthProviderByModelPrefix(prefix)?.id;
+}
+
+/**
+ * The env var pi-ai reads inside a sandbox for a provider's OAuth token, when
+ * one exists. Returns undefined for providers with no env-var route (Codex),
+ * which therefore cannot authenticate in the agentic-pi sandbox.
+ */
+export function oauthEnvVarForProvider(id: string): string | undefined {
+  return oauthProviderById(id)?.sandboxEnvVar ?? undefined;
+}
+
+/**
+ * Resolve the credential-store path. Precedence:
+ *   1. explicit argument (a caller-computed path),
+ *   2. `LASTLIGHT_AUTH_FILE` (hard override),
+ *   3. `<stateDir | $STATE_DIR | ./data>/auth.json`.
+ * The CLI writes here and the harness reads here, so both must agree; passing
+ * the harness's resolved `stateDir` keeps them aligned even if the process cwd
+ * differs.
+ */
+export function resolveAuthFile(explicit?: string, stateDir?: string): string {
+  if (explicit) return resolve(explicit);
+  if (process.env.LASTLIGHT_AUTH_FILE) return resolve(process.env.LASTLIGHT_AUTH_FILE);
+  return resolve(stateDir || process.env.STATE_DIR || "data", "auth.json");
+}
+
+export function loadAuthMap(file?: string, stateDir?: string): AuthMap {
+  const path = resolveAuthFile(file, stateDir);
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    return parsed && typeof parsed === "object" ? (parsed as AuthMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveAuthMap(map: AuthMap, file?: string, stateDir?: string): void {
+  const path = resolveAuthFile(file, stateDir);
+  mkdirSync(dirname(path), { recursive: true });
+  // Mode 0600 — the file holds long-lived refresh tokens.
+  writeFileSync(path, JSON.stringify(map, null, 2), { mode: 0o600 });
+}
+
+export function hasOAuthCredentials(id: string, file?: string, stateDir?: string): boolean {
+  return !!loadAuthMap(file, stateDir)[id];
+}
+
+export interface OAuthKeyResult {
+  apiKey: string;
+  credentials: OAuthCredentials;
+}
+
+/**
+ * Resolve a usable API key for an OAuth provider from stored credentials,
+ * refreshing an expired token and persisting the rotated credentials back to
+ * the store. Returns null when nothing is stored for `id`. Throws only if a
+ * refresh actually fails (expired refresh token, revoked grant) — callers
+ * should surface that as "re-run login".
+ */
+export async function resolveOAuthApiKey(
+  id: string,
+  file?: string,
+  stateDir?: string,
+): Promise<OAuthKeyResult | null> {
+  const map = loadAuthMap(file, stateDir);
+  if (!map[id]) return null;
+  const res = await getOAuthApiKey(id, map);
+  if (!res) return null;
+  // Persist the rotated credentials so the next refresh chains from the new
+  // token rather than re-using a spent one.
+  map[id] = { type: "oauth", ...res.newCredentials };
+  saveAuthMap(map, file, stateDir);
+  return { apiKey: res.apiKey, credentials: res.newCredentials };
+}
+
+/** Re-exported so callers depend on this module, not pi-ai's oauth entry directly. */
+export { getOAuthProvider, getOAuthProviders };

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -294,3 +294,80 @@ export const PROVIDER_HOSTS: readonly string[] = PROVIDERS.map((p) => p.host);
  */
 export const DEFAULT_PROVIDER = "anthropic";
 export const DEFAULT_MODEL = "anthropic/claude-sonnet-4-6";
+
+/**
+ * OAuth (subscription-login) providers — the ones the API-key registry above
+ * deliberately excludes. These don't authenticate with a static key env var;
+ * a user logs in once (`lastlight oauth login <id>`) and pi-ai manages the
+ * token. Two consumption seams with different reach:
+ *
+ *   - **chat** (in-process pi-ai) supports ALL of these — the chat runner
+ *     passes the resolved token as the per-call `apiKey`.
+ *   - **sandbox** (agentic-pi) resolves creds from ENV only, so a provider is
+ *     sandbox-usable ONLY if `sandboxEnvVar` is set (the env var pi-ai reads
+ *     inside the sandbox). Codex has none → chat-only.
+ *
+ * Egress note: chat is in-process (not behind the sandbox firewall), and the
+ * one sandbox-capable OAuth provider whose models we ship (`anthropic`) reuses
+ * the `anthropic.com` host already in the API-key registry — so no OAuth host
+ * is added to the sandbox allowlist here.
+ */
+export interface OAuthProviderSpec {
+  /** pi-ai OAuth provider id — also `lastlight oauth login <id>`. */
+  readonly id: string;
+  /** Display name (wizard + CLI). */
+  readonly displayName: string;
+  /** pi-ai model-spec prefix (`provider` in `provider/model`) for its models. */
+  readonly modelPrefix: string;
+  /** Representative model spec — wizard placeholder / docs hint. */
+  readonly sampleModel: string;
+  /**
+   * Env var pi-ai reads for this provider's OAuth token inside a sandbox, or
+   * `null` when there's no env route (⇒ chat-only; cannot run sandbox phases).
+   */
+  readonly sandboxEnvVar: string | null;
+  /** True when login is mandatory (no API-key fallback). */
+  readonly oauthOnly: boolean;
+}
+
+export const OAUTH_PROVIDERS: readonly OAuthProviderSpec[] = [
+  {
+    id: "openai-codex",
+    displayName: "ChatGPT Plus/Pro (Codex)",
+    modelPrefix: "openai-codex",
+    sampleModel: "openai-codex/gpt-5.4",
+    sandboxEnvVar: null, // chatgpt.com backend — no env route, chat-only
+    oauthOnly: true,
+  },
+  {
+    id: "anthropic",
+    displayName: "Anthropic (Claude Pro/Max)",
+    modelPrefix: "anthropic",
+    sampleModel: "anthropic/claude-sonnet-4-6",
+    sandboxEnvVar: "ANTHROPIC_OAUTH_TOKEN",
+    oauthOnly: false, // falls back to ANTHROPIC_API_KEY
+  },
+  {
+    id: "github-copilot",
+    displayName: "GitHub Copilot",
+    modelPrefix: "github-copilot",
+    sampleModel: "github-copilot/gpt-4o",
+    sandboxEnvVar: "COPILOT_GITHUB_TOKEN",
+    oauthOnly: true,
+  },
+];
+
+const OAUTH_PREFIX_INDEX = new Map<string, OAuthProviderSpec>(
+  OAUTH_PROVIDERS.map((p) => [p.modelPrefix, p]),
+);
+const OAUTH_ID_INDEX = new Map<string, OAuthProviderSpec>(
+  OAUTH_PROVIDERS.map((p) => [p.id, p]),
+);
+
+export function oauthProviderByModelPrefix(prefix: string): OAuthProviderSpec | undefined {
+  return OAUTH_PREFIX_INDEX.get(prefix);
+}
+
+export function oauthProviderById(id: string): OAuthProviderSpec | undefined {
+  return OAUTH_ID_INDEX.get(id);
+}

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -129,6 +129,14 @@ export interface RunAgentOpts {
   webSearchProvider?: "tavily" | "brave" | "exa";
   /** Test/eval escape hatch — only honoured by the in-process adapter. */
   githubApiBaseUrl?: string;
+  /**
+   * Credential store (`auth.json`) agentic-pi points Pi's AuthStorage at for
+   * model auth — carries OAuth subscription logins (Codex / Claude Pro /
+   * Copilot). Only meaningful for the in-process adapter (none/gondolin), where
+   * the model call runs host-side so a host path resolves; the docker adapter
+   * ignores it (its model call is in-container) and relies on env tokens.
+   */
+  authFile?: string;
 }
 
 export interface RunCommandOpts {
@@ -473,6 +481,7 @@ class InProcessSandbox implements Sandbox {
         prompt,
         thinking: opts.thinking,
         profile: opts.profile,
+        authFile: opts.authFile,
         githubApiBaseUrl: opts.githubApiBaseUrl,
         sandbox: this.mode === "gondolin" ? "gondolin" : "none",
         sandboxEnv: this.innerAgentEnv(opts.sandboxEnv),

--- a/tests/engine/agent-executor.oauth.test.ts
+++ b/tests/engine/agent-executor.oauth.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Executor OAuth env injection — the sandbox path can only carry OAuth creds
+ * via env, so `prepareRun` injects the provider's OAuth env var when the run's
+ * model is OAuth-backed and a login exists:
+ *   - anthropic  → ANTHROPIC_OAUTH_TOKEN
+ *   - copilot    → COPILOT_GITHUB_TOKEN
+ *   - codex      → no env route → nothing injected (chat-only)
+ *
+ * We capture the env handed to the sandbox via FakeSandbox and stub
+ * `resolveOAuthApiKey` so the assertion is about the wiring, not pi-ai's token
+ * internals or the network.
+ */
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveOAuthApiKeySpy = vi.fn();
+vi.mock("#src/engine/oauth.js", async (importActual) => {
+  const actual = await importActual<typeof import("#src/engine/oauth.js")>();
+  return { ...actual, resolveOAuthApiKey: (...a: unknown[]) => resolveOAuthApiKeySpy(...a) };
+});
+
+const { executeAgent } = await import("#src/engine/agent-executor.js");
+const { FakeSandbox } = await import("#src/sandbox/sandbox.js");
+
+function stateDirs() {
+  const stateDir = mkdtempSync(join(tmpdir(), "ll-exec-oauth-"));
+  const sessionsDir = join(stateDir, "agent-sessions");
+  mkdirSync(join(sessionsDir, "projects"), { recursive: true });
+  return { stateDir, sessionsDir };
+}
+
+async function runWithModel(model: string) {
+  const { stateDir, sessionsDir } = stateDirs();
+  const fake = new FakeSandbox({ returnRunResult: { success: true } as any });
+  await executeAgent("noop", { sandbox: "none", stateDir, sessionsDir, model }, {
+    sandboxFactory: fake.asFactory(),
+  });
+  return fake;
+}
+
+const savedEnv = { ...process.env };
+beforeEach(() => {
+  resolveOAuthApiKeySpy.mockReset();
+  delete process.env.ANTHROPIC_OAUTH_TOKEN;
+  delete process.env.COPILOT_GITHUB_TOKEN;
+});
+afterEach(() => {
+  process.env = { ...savedEnv };
+  vi.restoreAllMocks();
+});
+
+describe("executor OAuth env injection", () => {
+  it("injects ANTHROPIC_OAUTH_TOKEN for an Anthropic OAuth model with a login", async () => {
+    resolveOAuthApiKeySpy.mockResolvedValue({ apiKey: "ant-oauth-tok", credentials: {} });
+    const fake = await runWithModel("anthropic/claude-sonnet-4-6");
+    expect(resolveOAuthApiKeySpy).toHaveBeenCalledWith("anthropic", undefined, expect.any(String));
+    expect(fake.env?.ANTHROPIC_OAUTH_TOKEN).toBe("ant-oauth-tok");
+  });
+
+  it("injects COPILOT_GITHUB_TOKEN for a Copilot OAuth model with a login", async () => {
+    resolveOAuthApiKeySpy.mockResolvedValue({ apiKey: "copilot-tok", credentials: {} });
+    const fake = await runWithModel("github-copilot/gpt-4o");
+    expect(fake.env?.COPILOT_GITHUB_TOKEN).toBe("copilot-tok");
+  });
+
+  it("injects NOTHING for a Codex model (no sandbox env route) and never resolves a token", async () => {
+    const fake = await runWithModel("openai-codex/gpt-5.4");
+    expect(resolveOAuthApiKeySpy).not.toHaveBeenCalled();
+    expect(fake.env?.ANTHROPIC_OAUTH_TOKEN).toBeUndefined();
+    expect(fake.env?.COPILOT_GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it("injects nothing for an Anthropic model with no stored login", async () => {
+    resolveOAuthApiKeySpy.mockResolvedValue(null);
+    const fake = await runWithModel("anthropic/claude-sonnet-4-6");
+    expect(fake.env?.ANTHROPIC_OAUTH_TOKEN).toBeUndefined();
+  });
+
+  it("skips store resolution when an explicit ANTHROPIC_OAUTH_TOKEN is already in the env", async () => {
+    // A hand-set token is respected as an override: we don't spend a refresh
+    // resolving from the store on top of it.
+    process.env.ANTHROPIC_OAUTH_TOKEN = "preset-token";
+    await runWithModel("anthropic/claude-sonnet-4-6");
+    expect(resolveOAuthApiKeySpy).not.toHaveBeenCalled();
+  });
+
+  it("does not resolve OAuth for a plain API-key model", async () => {
+    const fake = await runWithModel("openai/gpt-5.5");
+    expect(resolveOAuthApiKeySpy).not.toHaveBeenCalled();
+    expect(fake.env?.ANTHROPIC_OAUTH_TOKEN).toBeUndefined();
+  });
+});

--- a/tests/engine/agent-executor.oauth.test.ts
+++ b/tests/engine/agent-executor.oauth.test.ts
@@ -10,7 +10,7 @@
  * `resolveOAuthApiKey` so the assertion is about the wiring, not pi-ai's token
  * internals or the network.
  */
-import { mkdtempSync, mkdirSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -31,13 +31,22 @@ function stateDirs() {
   return { stateDir, sessionsDir };
 }
 
-async function runWithModel(model: string) {
+async function runWithModel(
+  model: string,
+  opts: { backend?: "none" | "docker"; writeStore?: boolean } = {},
+) {
   const { stateDir, sessionsDir } = stateDirs();
+  if (opts.writeStore) {
+    writeFileSync(
+      join(stateDir, "auth.json"),
+      JSON.stringify({ "openai-codex": { type: "oauth", access: "a", refresh: "r", expires: 1 } }),
+    );
+  }
   const fake = new FakeSandbox({ returnRunResult: { success: true } as any });
-  await executeAgent("noop", { sandbox: "none", stateDir, sessionsDir, model }, {
+  await executeAgent("noop", { sandbox: opts.backend ?? "docker", stateDir, sessionsDir, model }, {
     sandboxFactory: fake.asFactory(),
   });
-  return fake;
+  return { fake, stateDir };
 }
 
 const savedEnv = { ...process.env };
@@ -51,22 +60,24 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("executor OAuth env injection", () => {
+// Container backends (docker/smol) run the model call in-guest, so OAuth creds
+// must ride in via env tokens. These assert that injection.
+describe("executor OAuth env injection (container backends)", () => {
   it("injects ANTHROPIC_OAUTH_TOKEN for an Anthropic OAuth model with a login", async () => {
     resolveOAuthApiKeySpy.mockResolvedValue({ apiKey: "ant-oauth-tok", credentials: {} });
-    const fake = await runWithModel("anthropic/claude-sonnet-4-6");
+    const { fake } = await runWithModel("anthropic/claude-sonnet-4-6", { backend: "docker" });
     expect(resolveOAuthApiKeySpy).toHaveBeenCalledWith("anthropic", undefined, expect.any(String));
     expect(fake.env?.ANTHROPIC_OAUTH_TOKEN).toBe("ant-oauth-tok");
   });
 
   it("injects COPILOT_GITHUB_TOKEN for a Copilot OAuth model with a login", async () => {
     resolveOAuthApiKeySpy.mockResolvedValue({ apiKey: "copilot-tok", credentials: {} });
-    const fake = await runWithModel("github-copilot/gpt-4o");
+    const { fake } = await runWithModel("github-copilot/gpt-4o", { backend: "docker" });
     expect(fake.env?.COPILOT_GITHUB_TOKEN).toBe("copilot-tok");
   });
 
-  it("injects NOTHING for a Codex model (no sandbox env route) and never resolves a token", async () => {
-    const fake = await runWithModel("openai-codex/gpt-5.4");
+  it("warns (injects nothing) for a Codex model — no in-guest env route", async () => {
+    const { fake } = await runWithModel("openai-codex/gpt-5.4", { backend: "docker" });
     expect(resolveOAuthApiKeySpy).not.toHaveBeenCalled();
     expect(fake.env?.ANTHROPIC_OAUTH_TOKEN).toBeUndefined();
     expect(fake.env?.COPILOT_GITHUB_TOKEN).toBeUndefined();
@@ -74,21 +85,40 @@ describe("executor OAuth env injection", () => {
 
   it("injects nothing for an Anthropic model with no stored login", async () => {
     resolveOAuthApiKeySpy.mockResolvedValue(null);
-    const fake = await runWithModel("anthropic/claude-sonnet-4-6");
+    const { fake } = await runWithModel("anthropic/claude-sonnet-4-6", { backend: "docker" });
     expect(fake.env?.ANTHROPIC_OAUTH_TOKEN).toBeUndefined();
   });
 
   it("skips store resolution when an explicit ANTHROPIC_OAUTH_TOKEN is already in the env", async () => {
-    // A hand-set token is respected as an override: we don't spend a refresh
-    // resolving from the store on top of it.
     process.env.ANTHROPIC_OAUTH_TOKEN = "preset-token";
-    await runWithModel("anthropic/claude-sonnet-4-6");
+    await runWithModel("anthropic/claude-sonnet-4-6", { backend: "docker" });
     expect(resolveOAuthApiKeySpy).not.toHaveBeenCalled();
   });
 
   it("does not resolve OAuth for a plain API-key model", async () => {
-    const fake = await runWithModel("openai/gpt-5.5");
+    const { fake } = await runWithModel("openai/gpt-5.5", { backend: "docker" });
     expect(resolveOAuthApiKeySpy).not.toHaveBeenCalled();
     expect(fake.env?.ANTHROPIC_OAUTH_TOKEN).toBeUndefined();
+  });
+});
+
+// In-process backends (none/gondolin) run the model call host-side, so OAuth is
+// carried by the credential store via agentic-pi's `authFile` — NOT env tokens.
+describe("executor OAuth via authFile (in-process backends)", () => {
+  it("passes authFile to the run and does NOT inject env tokens for Codex", async () => {
+    const { fake, stateDir } = await runWithModel("openai-codex/gpt-5.4", {
+      backend: "none",
+      writeStore: true,
+    });
+    // No env-token injection on the in-process path…
+    expect(resolveOAuthApiKeySpy).not.toHaveBeenCalled();
+    expect(fake.env?.ANTHROPIC_OAUTH_TOKEN).toBeUndefined();
+    // …instead the store path is handed to agentic-pi as authFile.
+    expect(fake.receivedAgentOpts?.authFile).toBe(join(stateDir, "auth.json"));
+  });
+
+  it("omits authFile when no credential store exists", async () => {
+    const { fake } = await runWithModel("anthropic/claude-sonnet-4-6", { backend: "none" });
+    expect(fake.receivedAgentOpts?.authFile).toBeUndefined();
   });
 });

--- a/tests/engine/chat-runner.oauth.test.ts
+++ b/tests/engine/chat-runner.oauth.test.ts
@@ -1,0 +1,110 @@
+/**
+ * ChatRunner OAuth wiring — the three decisions the chat path makes per turn:
+ *   1. OAuth-only model (Codex) with NO stored login → fail the turn with an
+ *      actionable "run: lastlight oauth login …" error, without calling the model.
+ *   2. OAuth model WITH a login → resolve a token and pass it as the per-call
+ *      `apiKey` to the model.
+ *   3. API-key-capable model (Anthropic) with no login → fall through to normal
+ *      env-key auth (no apiKey injected, model IS called).
+ *
+ * pi-ai is mocked so `getModel` returns a stub and `completeSimple` captures the
+ * options it's handed. Only `resolveOAuthApiKey` is stubbed on the oauth module
+ * (everything else there stays real via importActual), so the prefix→provider
+ * mapping and OAUTH_ONLY gating under test are the production ones.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+
+// ── mock pi-ai: stub getModel + capture completeSimple's options ────────────
+const completeSimpleSpy = vi.fn();
+vi.mock("@earendil-works/pi-ai", () => ({
+  getModel: (provider: string, id: string) => ({ provider, model: id, api: "faux", baseUrl: "x" }),
+  completeSimple: (...args: unknown[]) => completeSimpleSpy(...args),
+}));
+
+// ── mock only resolveOAuthApiKey on the oauth module ────────────────────────
+const resolveOAuthApiKeySpy = vi.fn();
+vi.mock("#src/engine/oauth.js", async (importActual) => {
+  const actual = await importActual<typeof import("#src/engine/oauth.js")>();
+  return { ...actual, resolveOAuthApiKey: (...a: unknown[]) => resolveOAuthApiKeySpy(...a) };
+});
+
+const { ChatRunner } = await import("#src/engine/chat/chat-runner.js");
+
+/** Minimal in-memory SessionManager stand-in (the five methods ChatRunner calls). */
+function fakeSessionManager() {
+  const agentIds = new Map<string, string | null>();
+  return {
+    getSession: (id: string) => ({ id, agentSessionId: agentIds.get(id) ?? null }),
+    setAgentSessionId: (id: string, aid: string | null) => agentIds.set(id, aid),
+    getHistory: () => [],
+    addMessage: () => {},
+    touchSession: () => {},
+  } as any;
+}
+
+function okAssistant(text = "hi"): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    stopReason: "stop",
+    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+  } as unknown as AssistantMessage;
+}
+
+function runnerFor(model: string) {
+  return new ChatRunner({ model, systemPrompt: "sys" }, fakeSessionManager());
+}
+
+beforeEach(() => {
+  completeSimpleSpy.mockReset().mockResolvedValue(okAssistant());
+  resolveOAuthApiKeySpy.mockReset();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("ChatRunner OAuth wiring", () => {
+  it("fails with an actionable error when an OAuth-only model has no login", async () => {
+    resolveOAuthApiKeySpy.mockResolvedValue(null); // not logged in
+    const res = await runnerFor("openai-codex/gpt-5.4").turn("sess-1", "hello");
+    expect(res.finish).toBe("error");
+    expect(res.errors[0]).toContain("requires an OAuth login");
+    expect(res.errors[0]).toContain("lastlight oauth login openai-codex");
+    // The model must NOT be called when auth is missing.
+    expect(completeSimpleSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes the resolved OAuth token as the per-call apiKey", async () => {
+    resolveOAuthApiKeySpy.mockResolvedValue({ apiKey: "codex-tok-123", credentials: {} });
+    const res = await runnerFor("openai-codex/gpt-5.4").turn("sess-2", "hello");
+    expect(res.finish).toBe("stop");
+    expect(completeSimpleSpy).toHaveBeenCalledTimes(1);
+    const opts = completeSimpleSpy.mock.calls[0][2] as { apiKey?: string };
+    expect(opts.apiKey).toBe("codex-tok-123");
+  });
+
+  it("falls through to env-key auth for a non-OAuth-only model with no login", async () => {
+    resolveOAuthApiKeySpy.mockResolvedValue(null); // no anthropic OAuth creds
+    const res = await runnerFor("anthropic/claude-sonnet-4-6").turn("sess-3", "hello");
+    // Model IS called (no hard failure), and no apiKey is injected.
+    expect(res.finish).toBe("stop");
+    expect(completeSimpleSpy).toHaveBeenCalledTimes(1);
+    const opts = completeSimpleSpy.mock.calls[0][2] as { apiKey?: string };
+    expect(opts.apiKey).toBeUndefined();
+  });
+
+  it("does not touch OAuth resolution for a plain API-key provider", async () => {
+    const res = await runnerFor("openai/gpt-5.5").turn("sess-4", "hello");
+    expect(res.finish).toBe("stop");
+    expect(resolveOAuthApiKeySpy).not.toHaveBeenCalled();
+    const opts = completeSimpleSpy.mock.calls[0][2] as { apiKey?: string };
+    expect(opts.apiKey).toBeUndefined();
+  });
+
+  it("fails the turn if OAuth refresh throws (expired/revoked grant)", async () => {
+    resolveOAuthApiKeySpy.mockRejectedValue(new Error("Failed to refresh OAuth token for openai-codex"));
+    const res = await runnerFor("openai-codex/gpt-5.4").turn("sess-5", "hello");
+    expect(res.finish).toBe("error");
+    expect(res.errors[0]).toContain("OAuth token refresh failed");
+    expect(completeSimpleSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/engine/oauth.test.ts
+++ b/tests/engine/oauth.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  OAUTH_ONLY_PROVIDERS,
+  hasOAuthCredentials,
+  loadAuthMap,
+  oauthEnvVarForProvider,
+  oauthProviderIdForModel,
+  resolveAuthFile,
+  resolveOAuthApiKey,
+  saveAuthMap,
+} from "../../src/engine/oauth.js";
+import {
+  OAUTH_PROVIDERS,
+  oauthProviderById,
+  oauthProviderByModelPrefix,
+} from "../../src/providers.js";
+
+describe("providers: OAuth registry", () => {
+  it("registers exactly Codex, Anthropic, and Copilot", () => {
+    expect(OAUTH_PROVIDERS.map((p) => p.id).sort()).toEqual([
+      "anthropic",
+      "github-copilot",
+      "openai-codex",
+    ]);
+  });
+
+  it("marks Codex chat-only (no sandbox env route) but the others sandbox-capable", () => {
+    expect(oauthProviderById("openai-codex")?.sandboxEnvVar).toBeNull();
+    expect(oauthProviderById("anthropic")?.sandboxEnvVar).toBe("ANTHROPIC_OAUTH_TOKEN");
+    expect(oauthProviderById("github-copilot")?.sandboxEnvVar).toBe("COPILOT_GITHUB_TOKEN");
+  });
+
+  it("keeps oauth.ts's derived maps consistent with the registry", () => {
+    for (const p of OAUTH_PROVIDERS) {
+      // Every registered model prefix maps back to its own id.
+      expect(oauthProviderIdForModel(`${p.modelPrefix}/whatever`)).toBe(p.id);
+      // The env-var route matches the registry's sandboxEnvVar.
+      expect(oauthEnvVarForProvider(p.id)).toBe(p.sandboxEnvVar ?? undefined);
+      // oauthOnly membership matches the exported set.
+      expect(OAUTH_ONLY_PROVIDERS.has(p.id)).toBe(p.oauthOnly);
+      // The sample model spec is well-formed and starts with the prefix.
+      expect(p.sampleModel.startsWith(`${p.modelPrefix}/`)).toBe(true);
+    }
+  });
+
+  it("resolves providers by model prefix", () => {
+    expect(oauthProviderByModelPrefix("openai-codex")?.id).toBe("openai-codex");
+    expect(oauthProviderByModelPrefix("openai")).toBeUndefined();
+  });
+});
+
+describe("oauth: model → provider mapping", () => {
+  it("maps OAuth model prefixes to provider ids", () => {
+    expect(oauthProviderIdForModel("openai-codex/gpt-5.4")).toBe("openai-codex");
+    expect(oauthProviderIdForModel("anthropic/claude-sonnet-4-6")).toBe("anthropic");
+    expect(oauthProviderIdForModel("github-copilot/gpt-4o")).toBe("github-copilot");
+  });
+
+  it("returns undefined for API-key providers", () => {
+    expect(oauthProviderIdForModel("openai/gpt-5.5")).toBeUndefined();
+    expect(oauthProviderIdForModel("openrouter/google/gemini-2.5-flash")).toBeUndefined();
+    expect(oauthProviderIdForModel("bare-string")).toBeUndefined();
+  });
+});
+
+describe("oauth: sandbox env-var route", () => {
+  it("returns the env var for providers with a sandbox route", () => {
+    expect(oauthEnvVarForProvider("anthropic")).toBe("ANTHROPIC_OAUTH_TOKEN");
+    expect(oauthEnvVarForProvider("github-copilot")).toBe("COPILOT_GITHUB_TOKEN");
+  });
+
+  it("returns undefined for Codex (chat-only, no env route)", () => {
+    expect(oauthEnvVarForProvider("openai-codex")).toBeUndefined();
+  });
+});
+
+describe("oauth: oauth-only set", () => {
+  it("marks Codex + Copilot mandatory, Anthropic optional", () => {
+    expect(OAUTH_ONLY_PROVIDERS.has("openai-codex")).toBe(true);
+    expect(OAUTH_ONLY_PROVIDERS.has("github-copilot")).toBe(true);
+    expect(OAUTH_ONLY_PROVIDERS.has("anthropic")).toBe(false);
+  });
+});
+
+describe("oauth: auth file resolution", () => {
+  const saved = { LASTLIGHT_AUTH_FILE: process.env.LASTLIGHT_AUTH_FILE, STATE_DIR: process.env.STATE_DIR };
+  afterEach(() => {
+    process.env.LASTLIGHT_AUTH_FILE = saved.LASTLIGHT_AUTH_FILE;
+    process.env.STATE_DIR = saved.STATE_DIR;
+  });
+
+  it("prefers an explicit path over everything", () => {
+    process.env.LASTLIGHT_AUTH_FILE = "/env/auth.json";
+    expect(resolveAuthFile("/explicit/a.json", "/state")).toBe("/explicit/a.json");
+  });
+
+  it("honours LASTLIGHT_AUTH_FILE next", () => {
+    process.env.LASTLIGHT_AUTH_FILE = "/env/auth.json";
+    expect(resolveAuthFile(undefined, "/state")).toBe("/env/auth.json");
+  });
+
+  it("falls back to <stateDir>/auth.json then $STATE_DIR", () => {
+    delete process.env.LASTLIGHT_AUTH_FILE;
+    expect(resolveAuthFile(undefined, "/state")).toBe("/state/auth.json");
+    delete process.env.STATE_DIR;
+    process.env.STATE_DIR = "/envstate";
+    expect(resolveAuthFile()).toBe("/envstate/auth.json");
+  });
+});
+
+describe("oauth: credential store", () => {
+  let dir: string;
+  let file: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ll-oauth-"));
+    file = join(dir, "auth.json");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("round-trips a map and writes mode 0600", () => {
+    saveAuthMap({ "openai-codex": { type: "oauth", access: "a", refresh: "r", expires: 1 } }, file);
+    expect(loadAuthMap(file)).toEqual({
+      "openai-codex": { type: "oauth", access: "a", refresh: "r", expires: 1 },
+    });
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+    // Stored form is the auth.json shape pi-ai's own CLI writes.
+    expect(JSON.parse(readFileSync(file, "utf8"))["openai-codex"].type).toBe("oauth");
+  });
+
+  it("hasOAuthCredentials + resolveOAuthApiKey report absence without throwing", async () => {
+    expect(hasOAuthCredentials("openai-codex", file)).toBe(false);
+    await expect(resolveOAuthApiKey("openai-codex", file)).resolves.toBeNull();
+  });
+
+  it("tolerates a missing / malformed store as empty", () => {
+    expect(loadAuthMap(join(dir, "nope.json"))).toEqual({});
+  });
+});


### PR DESCRIPTION
> ### ✅ Update — Codex now works in the **sandbox** too (not just chat)
>
> The original "Codex is chat-only" limitation below is **resolved**. The fix
> landed upstream in **[nearform/agentic-pi#9](https://github.com/nearform/agentic-pi/pull/9)**
> (`authFile` / `--auth-file`): since the model call runs in the agentic-pi
> process — the sandbox executes only *tools* — pointing Pi's `AuthStorage` at a
> host credential store is all a subscription login needs, no token in the VM.
>
> The follow-up commit here (`feat(oauth): Codex in the sandbox via agentic-pi authFile`)
> threads `$STATE_DIR/auth.json` to agentic-pi as `authFile` for the in-process
> backends (`none`/`gondolin`), so **Codex authenticates in sandbox workflow
> phases** there. Container backends (`docker`/`smol`) still carry Anthropic/
> Copilot via env tokens; Codex there awaits mounting the store into the guest.
> Verified end-to-end: a Codex model ran through Last Light's `executeAgent`
> sandbox path (backend `none`) with only the OAuth login — real cost, clean finish.
>
> **Merge order:** requires agentic-pi#9 to ship first; then bump the `agentic-pi`
> dependency here (CI typecheck needs the new `authFile` type).
>
> ---

## What

Adds support for authenticating the model provider with a **subscription login** (OAuth) instead of a static API key, via pi-ai's OAuth providers: **ChatGPT Plus/Pro (Codex)**, **Claude Pro/Max**, and **GitHub Copilot**.

Previously `src/providers.ts` deliberately excluded these ("OAuth-only providers") — there was no login command, credential store, or wiring.

## How

- **`src/engine/oauth.ts`** (new) — shared credential layer: one on-disk store (`$STATE_DIR/auth.json`, same JSON shape pi-ai's own CLI writes; override `LASTLIGHT_AUTH_FILE`), `resolveOAuthApiKey()` (refresh-if-expired + persist rotated creds), and the model-prefix→provider-id / sandbox-env-var maps.
- **`src/providers.ts`** — `OAUTH_PROVIDERS` registry as the single source of truth, alongside the API-key `PROVIDERS`.
- **Chat path** (`chat-runner.ts`) — resolves a token per turn and passes it as the per-call `apiKey`; an OAuth-only model with no login fails the turn with an actionable *"run: lastlight oauth login …"* error.
- **Sandbox path** (`agent-executor.ts`) — injects `ANTHROPIC_OAUTH_TOKEN` / `COPILOT_GITHUB_TOKEN` into the sandbox env.
- **CLI** — `lastlight oauth login|list|status|test|logout` (host-local; `src/cli/oauth-cli.ts`).
- **Setup wizard** — key-less OAuth provider option that points at the login.
- **Docs** — README, CLAUDE.md, `.env.example`.

## Key constraint: two seams, different reach

pi-ai exposes OAuth two ways, and they don't have equal reach:

- **Chat** (in-process pi-ai) passes the token as an `apiKey` → **all three providers work, Codex included.**
- **Sandbox** (agentic-pi) resolves creds from env only. Anthropic/Copilot work via their env tokens, but **Codex has no env-token route (chatgpt.com backend), so it's chat-only** — the executor warns instead of failing opaquely mid-run. No OAuth host is added to the sandbox egress allowlist (chat is in-process; Anthropic OAuth reuses the already-allowed `anthropic.com`).

## Testing

26 tests across the real behaviors (not just helpers):

- `tests/engine/oauth.test.ts` — store round-trip (mode 0600), auth-file resolution precedence, and registry consistency (oauth.ts's derived maps stay in sync with `OAUTH_PROVIDERS`).
- `tests/engine/chat-runner.oauth.test.ts` — the three chat decisions: OAuth-only-no-login → error + model **not** called; login → token passed as `apiKey`; API-key-capable (Anthropic) no-login → fallthrough; refresh-throws → error; plain provider → OAuth untouched.
- `tests/engine/agent-executor.oauth.test.ts` — sandbox env injection via `FakeSandbox`: Anthropic/Copilot → token env vars; Codex → nothing (never resolves); no-login → nothing; preset token → skip resolve.

Full suite: **988 passing / 7 skipped**; `typecheck:test` clean.

Verified manually end-to-end: `lastlight oauth login openai-codex` → a live chat turn served through a ChatGPT Codex subscription with no API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
