### PR TITLE
feat(config): configurable bot name / @mention handle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,6 +518,16 @@ Required:
 
 - `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY_PATH`, `GITHUB_APP_INSTALLATION_ID`
 - `WEBHOOK_SECRET` — must match the GitHub App webhook secret
+- **Bot identity** (optional; defaults to `last-light`) — `botName` is the
+  GitHub App slug (no `[bot]` suffix) and the single source of truth for the
+  bot's identity. Set it in the overlay `config.yaml` (`botName:
+  nearform-lastlight`) or via the `GITHUB_APP_BOT_NAME` env var. It derives
+  three things: the incoming **`@mention` handle** the router triggers on
+  (`@<botName>` — *only* the configured handle matches, no legacy fallback),
+  the **`botLogin`** used to filter the bot's own comments/reviews
+  (`<botName>[bot]`, still overridable with `BOT_LOGIN`), and the **git commit
+  author** for agent commits (`<botName>[bot]`). Must match the real App slug
+  so `@`-autocomplete and notifications work.
 - One of the provider API-key env vars from `src/providers.ts`
   (Anthropic / OpenAI / OpenRouter / Google / Mistral / Groq / Cerebras /
   xAI / Hugging Face / Moonshot / NVIDIA / Fireworks / Together / DeepSeek /

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,6 +3,14 @@
 # wholesale. Webhooks for repos not listed here are filtered at the connector level.
 managedRepos: []
 
+# The GitHub App slug (no `[bot]` suffix). Single source of truth for the bot's
+# identity: the incoming `@mention` handle (e.g. `@last-light`), the derived
+# `botLogin` (`<botName>[bot]`, self-comment/self-review filter), and the git
+# commit author. Override in your overlay `config.yaml` or via the
+# `GITHUB_APP_BOT_NAME` env var — e.g. set `nearform-lastlight` for the
+# Nearform app so it triggers on `@nearform-lastlight`.
+botName: last-light
+
 models:
   default: anthropic/claude-sonnet-4-6
 

--- a/spec/02-configuration.md
+++ b/spec/02-configuration.md
@@ -23,7 +23,9 @@ warning and fall back — they don't crash boot.
 interface LastLightConfig {
   port: number;
   webhookSecret: string;
-  botLogin: string;
+  botName: string;                        // GitHub App slug (no [bot]); default "last-light".
+                                          // Derives the @mention handle, botLogin, and git author.
+  botLogin: string;                       // "<botName>[bot]" unless BOT_LOGIN overrides
   dbPath: string;
   workflowDir: string;
   stateDir: string;
@@ -76,7 +78,8 @@ missing `GITHUB_APP_ID` is fine for a chat-only deployment.
 | `GITHUB_APP_INSTALLATION_ID` | GitHub integration | — |
 | `GITHUB_APP_PRIVATE_KEY_PATH` | GitHub integration | `./secrets/app.pem` |
 | `WEBHOOK_SECRET` | webhook signature verification | empty (verification **disabled**) |
-| `BOT_LOGIN` | self-event filtering | `last-light[bot]` |
+| `GITHUB_APP_BOT_NAME` | bot slug — `@mention` handle + `botLogin` + git author (also overlay `botName`) | `last-light` |
+| `BOT_LOGIN` | self-event filtering (overrides the `<botName>[bot]` derivation) | `<botName>[bot]` |
 
 The PEM is validated at boot: must exist and parse as PEM (`src/index.ts:42–51`).
 Missing or malformed PEM exits `78`.

--- a/spec/05-router.md
+++ b/spec/05-router.md
@@ -45,6 +45,13 @@ Defined in `src/engine/router.ts:8–40`.
 These run before any LLM call. For every envelope, the first matching
 rule wins.
 
+The `@last-light` handle shown throughout this table is the **default**. The
+mention handle is derived from the configured bot slug (`botName`, default
+`last-light`; set via overlay `config.yaml` or `GITHUB_APP_BOT_NAME`), so a
+deployment with `botName: nearform-lastlight` triggers on `@nearform-lastlight`
+instead. Only the configured handle matches — there is no legacy fallback (see
+[Configuration](/spec/02-configuration)).
+
 | Trigger | Result | Notes |
 |---|---|---|
 | `issue.opened` / `issue.reopened` | `skill: issue-triage` | `reopened=true` for the latter |

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -100,6 +100,15 @@ export interface PublicConfigBundle {
 export interface LastLightConfig {
   port: number;
   webhookSecret: string;
+  /**
+   * The GitHub App slug (no `[bot]` suffix) — e.g. `last-light` or
+   * `nearform-lastlight`. Single source of truth for the bot's identity:
+   * derives the incoming `@mention` handle (router), `botLogin`
+   * (`${botName}[bot]`, self-comment/self-review filter), and the git commit
+   * author. Overridable via overlay `config.yaml` `botName` or the
+   * `GITHUB_APP_BOT_NAME` env var; defaults to `last-light`.
+   */
+  botName: string;
   botLogin: string;
   dbPath: string;
   overlayDir?: string;
@@ -168,6 +177,16 @@ export function getPublicConfig(): PublicConfigBundle {
 
 export function getRoutes(): RouteConfig {
   return currentConfig?.routes || defaultRouteConfig();
+}
+
+/**
+ * The configured bot slug (no `[bot]` suffix), e.g. `last-light` or
+ * `nearform-lastlight`. Returns the `last-light` default when config isn't
+ * loaded yet (unit tests). Drives the router's `@mention` handle plus the
+ * derived `botLogin` and git commit author.
+ */
+export function getBotName(): string {
+  return currentConfig?.botName || "last-light";
 }
 
 const DEFAULT_MODEL = "anthropic/claude-sonnet-4-6";
@@ -361,7 +380,8 @@ export function loadConfig(): LastLightConfig {
   const config: LastLightConfig = {
     port: parseInt(process.env.WEBHOOK_PORT || process.env.PORT || "8644", 10),
     webhookSecret: process.env.WEBHOOK_SECRET || "",
-    botLogin: process.env.BOT_LOGIN || "last-light[bot]",
+    botName: fileCfg.botName,
+    botLogin: process.env.BOT_LOGIN || `${fileCfg.botName}[bot]`,
     stateDir,
     sandboxDir: join(stateDir, "sandboxes"),
     sessionsDir: resolve(process.env.LASTLIGHT_SESSIONS_DIR || join(stateDir, "agent-sessions")),
@@ -405,6 +425,7 @@ function stringEnv(name: string, fallback: string): string {
 
 function normalizeFileConfig(raw: Record<string, unknown>): {
   managedRepos: string[];
+  botName: string;
   routes: RouteConfig;
   disabled: DisabledConfig;
   models: ModelConfig;
@@ -418,6 +439,7 @@ function normalizeFileConfig(raw: Record<string, unknown>): {
   otel: OtelConfig;
 } {
   const managedRepos = stringArray(raw.managedRepos, "managedRepos");
+  const botName = typeof raw.botName === "string" && raw.botName.trim() ? raw.botName.trim() : "last-light";
   const routes = normalizeRoutes(raw.routes);
   const disabledRaw = isPlainObject(raw.disabled) ? raw.disabled : {};
   const modelsRaw = isPlainObject(raw.models) ? raw.models : {};
@@ -446,6 +468,7 @@ function normalizeFileConfig(raw: Record<string, unknown>): {
 
   return {
     managedRepos,
+    botName,
     routes,
     disabled: {
       workflows: optionalStringArray(disabledRaw.workflows, "disabled.workflows"),
@@ -605,6 +628,7 @@ function buildEnvConfigLayer(env: NodeJS.ProcessEnv): Record<string, unknown> {
   setBoolEnv(otel, "strict", env.LASTLIGHT_OTEL_STRICT);
   if (Object.keys(otel).length) layer.otel = otel;
 
+  if (env.GITHUB_APP_BOT_NAME) layer.botName = env.GITHUB_APP_BOT_NAME;
   if (env.BOOTSTRAP_LABEL) layer.bootstrap = { label: env.BOOTSTRAP_LABEL };
   if (env.EXPLORE_DEFAULT_REPO) layer.explore = { defaultRepo: env.EXPLORE_DEFAULT_REPO };
   if (env.REVIEW_POSTS_CHECK !== undefined && env.REVIEW_POSTS_CHECK !== "") {

--- a/src/engine/dispatcher.ts
+++ b/src/engine/dispatcher.ts
@@ -6,6 +6,7 @@ import type { GitHubClient } from "./github/github.js";
 import type { ChatResult } from "./chat/chat.js";
 import { routeEvent, type Route, type RouterDeps } from "./router.js";
 import { runDashboardUrl } from "../notify/model.js";
+import { getRuntimeConfig } from "../config/config.js";
 
 /**
  * Hand a workflow to the runner. Matches `dispatchWorkflow` in index.ts — the
@@ -335,7 +336,7 @@ async function handleWebhookDispatch(
         try {
           // Re-fetch head SHA in case the PR was rebased mid-review.
           const headSha = await github.getPullRequestHeadSha(owner, repo, prNumber);
-          const review = await github.getLatestBotReview(owner, repo, prNumber, headSha);
+          const review = await github.getLatestBotReview(owner, repo, prNumber, headSha, getRuntimeConfig()?.botLogin);
           const conclusion: "success" | "failure" | "neutral" = !result.success
             ? "neutral"
             : review?.state === "APPROVED"

--- a/src/engine/executors/orchestrator.ts
+++ b/src/engine/executors/orchestrator.ts
@@ -2,9 +2,9 @@ import { basename, join } from "path";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { resolveAuthFile } from "../oauth.js";
 import { randomUUID } from "crypto";
-import type { SandboxBackend } from "../../config/config.js";
+import { getBotName, type SandboxBackend } from "../../config/config.js";
 import {
-  AGENT_GIT_IDENTITY_ENV,
+  agentGitIdentityEnv,
   sandboxFor,
   type EgressPolicy,
   type PrePopulateSpec,
@@ -208,7 +208,7 @@ export async function runSandboxedAgent(prompt: string, ctx: SandboxRunContext):
           thinking,
           profile,
           authFile,
-          sandboxEnv: AGENT_GIT_IDENTITY_ENV,
+          sandboxEnv: agentGitIdentityEnv(getBotName()),
           agentCwd: prov.agentCwd,
           skillDirs,
           webSearch: config.webSearch === true,

--- a/src/engine/executors/orchestrator.ts
+++ b/src/engine/executors/orchestrator.ts
@@ -2,7 +2,7 @@ import { basename, join } from "path";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { resolveAuthFile } from "../oauth.js";
 import { randomUUID } from "crypto";
-import { getBotName, type SandboxBackend } from "../../config/config.js";
+import { getBotName, getRuntimeConfig, type SandboxBackend } from "../../config/config.js";
 import {
   agentGitIdentityEnv,
   sandboxFor,
@@ -208,7 +208,7 @@ export async function runSandboxedAgent(prompt: string, ctx: SandboxRunContext):
           thinking,
           profile,
           authFile,
-          sandboxEnv: agentGitIdentityEnv(getBotName()),
+          sandboxEnv: agentGitIdentityEnv(getRuntimeConfig()?.botLogin ?? `${getBotName()}[bot]`),
           agentCwd: prov.agentCwd,
           skillDirs,
           webSearch: config.webSearch === true,

--- a/src/engine/github/git-auth.ts
+++ b/src/engine/github/git-auth.ts
@@ -102,7 +102,8 @@ export async function configureGitAuth(config: {
   appId: string;
   privateKeyPath: string;
   installationId: string;
-  botName?: string;
+  /** Resolved bot login incl. the `[bot]` suffix (e.g. `last-light[bot]`). */
+  botLogin?: string;
   /**
    * Optional repository-name allowlist for the minted installation token.
    * Names are repo names within the installation owner (e.g. ["lastlight"]).
@@ -127,9 +128,9 @@ export async function configureGitAuth(config: {
   const credPath = writeCredentialsFile(token.token);
   execGit(["config", "--global", "credential.helper", `store --file=${credPath}`]);
 
-  const botName = config.botName || "last-light";
-  execGit(["config", "--global", "user.name", `${botName}[bot]`]);
-  execGit(["config", "--global", "user.email", `${botName}[bot]@users.noreply.github.com`]);
+  const botLogin = config.botLogin || "last-light[bot]";
+  execGit(["config", "--global", "user.name", botLogin]);
+  execGit(["config", "--global", "user.email", `${botLogin}@users.noreply.github.com`]);
 
   console.log(`[git-auth] Configured GLOBAL git with GitHub App token (file: ${credPath}, expires: ${token.expiresAt})`);
 

--- a/src/engine/router.ts
+++ b/src/engine/router.ts
@@ -2,7 +2,7 @@ import type { EventEnvelope } from "../connectors/types.js";
 import { classifyComment, classifyCommentAddsInfo, classifyIssueIsQuestion } from "./screen/classifier.js";
 import { screenForInjection, flagPrefix } from "./screen/screen.js";
 import { getManagedRepos, isManagedRepo } from "../managed-repos.js";
-import { getRoutes } from "../config/config.js";
+import { getRoutes, getBotName } from "../config/config.js";
 import type { StateDb } from "../state/db.js";
 
 /**
@@ -51,8 +51,26 @@ function requireManagedRepo(
 /** Author associations that can trigger builds via @mention */
 const MAINTAINER_ROLES = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
-/** Bot mention pattern — case-insensitive */
-const BOT_MENTION = /@last-light\b/i;
+/** Escape a string for safe interpolation into a RegExp. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Bot-mention matchers derived from the configured bot handle (`getBotName()`,
+ * e.g. `last-light` / `nearform-lastlight`). Only the configured handle
+ * matches — there is no legacy `@last-light` fallback (the default handle is
+ * already `last-light`, so existing deployments are unaffected).
+ * `command` builds `@<handle> <cmd>...` matchers for the structured commands.
+ */
+function botMatchers(handle: string) {
+  const h = escapeRegExp(handle);
+  return {
+    /** Bare mention gate — case-insensitive. */
+    mention: new RegExp(`@${h}\\b`, "i"),
+    command: (pattern: string) => new RegExp(`@${h}\\s+${pattern}`, "i"),
+  };
+}
 
 /**
  * Event routing — deterministic for most events, LLM-classified for comments.
@@ -66,6 +84,7 @@ export async function routeEvent(
   const routes = getRoutes();
   const gh = routes.github;
   const slack = routes.slack;
+  const bot = botMatchers(getBotName());
   switch (envelope.type) {
     case "issue.opened": {
       // Pure question issues ("how does X work?", "X vs Y?") want an ANSWER,
@@ -167,7 +186,7 @@ export async function routeEvent(
         deps.db &&
         envelope.issueNumber &&
         !envelope.prNumber &&
-        !BOT_MENTION.test(envelope.body)
+        !bot.mention.test(envelope.body)
       ) {
         const triggerId = `${envelope.repo}#${envelope.issueNumber}`;
         const buildStarted = deps.db.runs.hasRunForTrigger(triggerId, "build");
@@ -209,8 +228,8 @@ export async function routeEvent(
         }
       }
 
-      // Only act on @last-light mentions
-      if (!BOT_MENTION.test(envelope.body)) {
+      // Only act on mentions of the configured bot handle
+      if (!bot.mention.test(envelope.body)) {
         return { action: "ignore", reason: "no bot mention in comment" };
       }
 
@@ -228,8 +247,8 @@ export async function routeEvent(
       }
 
       // Check for approval commands before LLM classification
-      const approveMatch = envelope.body.match(/@last-light\s+approve\b/i);
-      const rejectMatch = envelope.body.match(/@last-light\s+reject\b(.*)/i);
+      const approveMatch = envelope.body.match(bot.command("approve\\b"));
+      const rejectMatch = envelope.body.match(bot.command("reject\\b(.*)"));
       if (approveMatch || rejectMatch) {
         return {
           action: "handler",
@@ -245,7 +264,7 @@ export async function routeEvent(
       }
 
       // Structured match for security-review before LLM classification
-      const securityMatch = envelope.body.match(/@last-light\s+security-review\b/i);
+      const securityMatch = envelope.body.match(bot.command("security-review\\b"));
       if (securityMatch) {
         return {
           action: "handler",
@@ -258,7 +277,7 @@ export async function routeEvent(
       // Everything after the command word is the claim (verify) or the
       // target/steps (qa-test); it flows through as `commentBody`. Both work on
       // issues and PRs. Maintainer-gated above, like security-review.
-      const verifyMatch = envelope.body.match(/@last-light\s+verify\b([\s\S]*)/i);
+      const verifyMatch = envelope.body.match(bot.command("verify\\b([\\s\\S]*)"));
       if (verifyMatch) {
         return {
           action: "handler",
@@ -273,7 +292,7 @@ export async function routeEvent(
           },
         };
       }
-      const qaTestMatch = envelope.body.match(/@last-light\s+qa-test\b([\s\S]*)/i);
+      const qaTestMatch = envelope.body.match(bot.command("qa-test\\b([\\s\\S]*)"));
       if (qaTestMatch) {
         return {
           action: "handler",
@@ -288,11 +307,11 @@ export async function routeEvent(
           },
         };
       }
-      // `@last-light demo [notes]` — record a demo video of the PR/feature.
+      // `@<bot> demo [notes]` — record a demo video of the PR/feature.
       // Anything after the command word flows through as `commentBody` (demo
       // scope/notes). Gated to the docker QA image at the workflow level; on a
       // host without it the demo phase silently skips.
-      const demoMatch = envelope.body.match(/@last-light\s+demo\b([\s\S]*)/i);
+      const demoMatch = envelope.body.match(bot.command("demo\\b([\\s\\S]*)"));
       if (demoMatch) {
         return {
           action: "handler",
@@ -374,7 +393,7 @@ export async function routeEvent(
       // Key on `security-scan` (not just `security`) so we only divert to
       // security-feedback on the per-run SUMMARY issue. Broken-out sub-issues
       // carry `["security", severity]` (no `security-scan`) and must stay on
-      // the normal build/issue-comment path — "@last-light build this fix"
+      // the normal build/issue-comment path — "@<bot> build this fix"
       // on a sub-issue needs the real build cycle, not security-feedback.
       //
       // ALL comment intents on a summary issue funnel to security-feedback

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,7 @@ async function main() {
         appId: config.githubApp.appId,
         privateKeyPath: config.githubApp.privateKeyPath,
         installationId: config.githubApp.installationId,
+        botName: config.botName,
       });
     } catch (err: any) {
       console.warn(`[git-auth] Initial token mint failed (will retry per-execution): ${err.message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,7 @@ async function main() {
         appId: config.githubApp.appId,
         privateKeyPath: config.githubApp.privateKeyPath,
         installationId: config.githubApp.installationId,
-        botName: config.botName,
+        botLogin: config.botLogin,
       });
     } catch (err: any) {
       console.warn(`[git-auth] Initial token mint failed (will retry per-execution): ${err.message}`);

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -172,22 +172,26 @@ export interface SandboxFactoryOpts {
 
 export type SandboxFactory = (backend: SandboxBackend, opts: SandboxFactoryOpts) => Sandbox;
 
-/** Inner-run git identity, shared by every adapter's agent path. */
-const GIT_IDENTITY_ENV: Record<string, string> = {
-  GIT_AUTHOR_NAME: "last-light[bot]",
-  GIT_AUTHOR_EMAIL: "last-light[bot]@users.noreply.github.com",
-  GIT_COMMITTER_NAME: "last-light[bot]",
-  GIT_COMMITTER_EMAIL: "last-light[bot]@users.noreply.github.com",
-  // /workspace is a host-UID bind mount into a different-UID guest; git refuses
-  // to operate without an explicit safe-directory. GIT_CONFIG_* avoids needing
-  // a writeable ~/.gitconfig.
-  GIT_CONFIG_COUNT: "1",
-  GIT_CONFIG_KEY_0: "safe.directory",
-  GIT_CONFIG_VALUE_0: "*",
-};
-
-/** The base (git-identity) sandbox env the orchestrator passes to `runAgent`. */
-export const AGENT_GIT_IDENTITY_ENV: Record<string, string> = GIT_IDENTITY_ENV;
+/**
+ * Inner-run git identity, shared by every adapter's agent path. The author is
+ * derived from the configured bot slug (`botName`, e.g. `last-light` /
+ * `nearform-lastlight`) so agent commits are attributed to the actual App.
+ */
+export function agentGitIdentityEnv(botName: string): Record<string, string> {
+  const login = `${botName}[bot]`;
+  return {
+    GIT_AUTHOR_NAME: login,
+    GIT_AUTHOR_EMAIL: `${login}@users.noreply.github.com`,
+    GIT_COMMITTER_NAME: login,
+    GIT_COMMITTER_EMAIL: `${login}@users.noreply.github.com`,
+    // /workspace is a host-UID bind mount into a different-UID guest; git refuses
+    // to operate without an explicit safe-directory. GIT_CONFIG_* avoids needing
+    // a writeable ~/.gitconfig.
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: "safe.directory",
+    GIT_CONFIG_VALUE_0: "*",
+  };
+}
 
 /**
  * The single factory replacing the `if (backend === …)` ladder. Given a

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -173,12 +173,13 @@ export interface SandboxFactoryOpts {
 export type SandboxFactory = (backend: SandboxBackend, opts: SandboxFactoryOpts) => Sandbox;
 
 /**
- * Inner-run git identity, shared by every adapter's agent path. The author is
- * derived from the configured bot slug (`botName`, e.g. `last-light` /
- * `nearform-lastlight`) so agent commits are attributed to the actual App.
+ * Inner-run git identity, shared by every adapter's agent path. Takes the
+ * resolved bot login (e.g. `last-light[bot]` / `nearform-lastlight[bot]`) so
+ * agent commits are attributed to the actual App — including a `BOT_LOGIN`
+ * override, which the caller resolves before passing it here.
  */
-export function agentGitIdentityEnv(botName: string): Record<string, string> {
-  const login = `${botName}[bot]`;
+export function agentGitIdentityEnv(botLogin: string): Record<string, string> {
+  const login = botLogin;
   return {
     GIT_AUTHOR_NAME: login,
     GIT_AUTHOR_EMAIL: `${login}@users.noreply.github.com`,

--- a/src/workflows/phase-executor.ts
+++ b/src/workflows/phase-executor.ts
@@ -19,6 +19,7 @@ import type { StateDb } from "../state/db.js";
 import type { AgentWorkflowDefinition, PhaseDefinition } from "./schema.js";
 import { phaseSkillNames } from "./schema.js";
 import { loadPromptTemplate, resolveSkillPaths } from "./loader.js";
+import { getRuntimeConfig, getBotName } from "../config/config.js";
 import { renderTemplate, type TemplateContext } from "./templates.js";
 import { evalUntilExpression } from "./loop-eval.js";
 import { parseReviewerVerdict } from "./verdict.js";
@@ -569,7 +570,7 @@ export class PhaseExecutor {
     // resume / re-entry from double-posting).
     if (headSha) {
       try {
-        const existing = await github.getLatestBotReview(owner, repo, prNumber, headSha);
+        const existing = await github.getLatestBotReview(owner, repo, prNumber, headSha, getRuntimeConfig()?.botLogin);
         if (existing) return succeed(`already reviewed head ${headSha.slice(0, 7)} (${existing.state})`);
       } catch {
         /* best-effort — fall through and attempt the post */
@@ -1357,8 +1358,8 @@ export class PhaseExecutor {
           await this.reporter.postNote(
             `**${phaseName} iteration ${iteration}/${MAX_ITER} complete** — approval required to continue.\n\n` +
               `${gateMsg}\n\n` +
-              `**To continue:** comment \`@last-light approve\`\n` +
-              `**To abort:** comment \`@last-light reject [reason]\``,
+              `**To continue:** comment \`@${getBotName()} approve\`\n` +
+              `**To abort:** comment \`@${getBotName()} reject [reason]\``,
           );
         }
         return { results, status: "succeeded", paused: true };

--- a/src/workflows/simple.ts
+++ b/src/workflows/simple.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import type { ExecutorConfig } from "../engine/github/profiles.js";
 import type { StateDb, WorkflowRun } from "../state/db.js";
-import type { ModelConfig, VariantConfig } from "../config/config.js";
+import { getBotName, type ModelConfig, type VariantConfig } from "../config/config.js";
 import { getWorkflow } from "./loader.js";
 import {
   runWorkflow,
@@ -404,6 +404,9 @@ export async function runSimpleWorkflow(
     issueLabels: request.issueLabels || [],
     commentBody: request.commentBody || "",
     sender: request.sender,
+    // The bot's `@mention` handle (e.g. `@last-light`), for approval-gate and
+    // command help strings in workflow YAML — `{{botMention}} approve`.
+    botMention: `@${getBotName()}`,
     branch,
     taskId,
     issueDir,

--- a/src/workflows/triggers.ts
+++ b/src/workflows/triggers.ts
@@ -1,5 +1,5 @@
 import { getCronWorkflows } from "./loader.js";
-import { getRoutes } from "../config/config.js";
+import { getRoutes, getBotName } from "../config/config.js";
 
 export type TriggerInfo =
   | { kind: "cron"; name: string; schedule: string }
@@ -16,17 +16,18 @@ function add(map: Map<string, TriggerInfo[]>, name: string | undefined, info: Tr
 
 function routeTriggers(): Map<string, TriggerInfo[]> {
   const routes = getRoutes();
+  const bot = `@${getBotName()}`;
   const map = new Map<string, TriggerInfo[]>();
   add(map, routes.github.issue_opened, { kind: "github", event: "issue.opened", description: "An issue is opened" });
   add(map, routes.github.issue_reopened, { kind: "github", event: "issue.reopened", description: "An issue is reopened" });
   add(map, routes.github.pr_opened, { kind: "github", event: "pr.opened", description: "A PR is opened" });
   add(map, routes.github.pr_synchronize, { kind: "github", event: "pr.synchronize", description: "A PR is updated" });
   add(map, routes.github.pr_reopened, { kind: "github", event: "pr.reopened", description: "A PR is reopened" });
-  add(map, routes.github.pr_fix, { kind: "mention", description: "`@last-light build …` on a PR comment (maintainers only)" });
-  add(map, routes.github.pr_comment, { kind: "mention", description: "`@last-light <message>` on a PR comment / review" });
-  add(map, routes.github.issue_build, { kind: "mention", description: "`@last-light build …` on an issue comment (maintainers only)" });
-  add(map, routes.github.issue_explore, { kind: "mention", description: "`@last-light explore …` on an issue comment" });
-  add(map, routes.github.issue_comment, { kind: "mention", description: "`@last-light <message>` on an issue comment" });
+  add(map, routes.github.pr_fix, { kind: "mention", description: `\`${bot} build …\` on a PR comment (maintainers only)` });
+  add(map, routes.github.pr_comment, { kind: "mention", description: `\`${bot} <message>\` on a PR comment / review` });
+  add(map, routes.github.issue_build, { kind: "mention", description: `\`${bot} build …\` on an issue comment (maintainers only)` });
+  add(map, routes.github.issue_explore, { kind: "mention", description: `\`${bot} explore …\` on an issue comment` });
+  add(map, routes.github.issue_comment, { kind: "mention", description: `\`${bot} <message>\` on an issue comment` });
   add(map, routes.github.security_feedback, { kind: "internal", description: "Chained from `security-review` when issues are found" });
   add(map, routes.slack.build, { kind: "slack", command: "build", description: "Slack: `build <repo>#<n>`" });
   add(map, routes.slack.triage, { kind: "slack", command: "triage", description: "Slack: `triage <repo>`" });

--- a/tests/engine/router.test.ts
+++ b/tests/engine/router.test.ts
@@ -572,6 +572,58 @@ describe('routeEvent — approval commands in comment.created', () => {
   });
 });
 
+describe('routeEvent — configurable bot handle', () => {
+  // Override the runtime config for this block so the mention handle is a
+  // custom slug rather than the `last-light` default.
+  beforeEach(() => {
+    setRuntimeConfig({
+      managedRepos: ['cliftonc/drizzle-cube'],
+      botName: 'nearform-lastlight',
+    } as unknown as LastLightConfig);
+  });
+
+  it('routes @<configured-handle> approve to approval-response', async () => {
+    const result = await routeEvent(makeEnvelope({
+      type: 'comment.created',
+      body: '@nearform-lastlight approve',
+      authorAssociation: 'OWNER',
+      issueNumber: 10,
+      repo: 'cliftonc/drizzle-cube',
+    }));
+    expect(result.action).toBe('handler');
+    if (result.action === 'handler') {
+      expect(result.handler).toBe('approval-response');
+      expect(result.context.decision).toBe('approved');
+    }
+  });
+
+  it('acts on a bare @<configured-handle> mention (build intent)', async () => {
+    mockClassifyComment.mockResolvedValue({ intent: 'build' });
+    const result = await routeEvent(makeEnvelope({
+      type: 'comment.created',
+      body: '@nearform-lastlight build this fix',
+      authorAssociation: 'OWNER',
+      issueNumber: 11,
+      repo: 'cliftonc/drizzle-cube',
+    }));
+    expect(result.action).toBe('handler');
+  });
+
+  it('ignores the legacy @last-light mention when a different handle is configured', async () => {
+    const result = await routeEvent(makeEnvelope({
+      type: 'comment.created',
+      body: '@last-light approve',
+      authorAssociation: 'OWNER',
+      issueNumber: 10,
+      repo: 'cliftonc/drizzle-cube',
+    }));
+    expect(result.action).toBe('ignore');
+    if (result.action === 'ignore') {
+      expect(result.reason).toBe('no bot mention in comment');
+    }
+  });
+});
+
 // Slack approval routing is now tested in the classifier-driven message
 // events section above (approve/reject intent tests).
 

--- a/workflows/build.yaml
+++ b/workflows/build.yaml
@@ -53,7 +53,7 @@ phases:
       - Plan: `{{issueDir}}/architect-plan.md`
 
       **Review & decide:** {{approvalUrl}}
-      **Or comment:** `@last-light approve` / `@last-light reject [reason]`
+      **Or comment:** `{{botMention}} approve` / `{{botMention}} reject [reason]`
     messages:
       # Single-line messages become the one-line detail on the checklist step,
       # so keep them concise and link the artifact on the branch.
@@ -101,7 +101,7 @@ phases:
           - Verdict: `{{issueDir}}/reviewer-verdict.md`
 
           **Review & decide:** {{approvalUrl}}
-          **Or comment:** `@last-light approve` / `@last-light reject [reason]`
+          **Or comment:** `{{botMention}} approve` / `{{botMention}} reject [reason]`
 
   - name: pr
     label: PR


### PR DESCRIPTION
## Problem

The incoming `@mention` gate was hardcoded to `@last-light` in `router.ts`, so a
GitHub App with a different slug (e.g. `@nearform-lastlight`) had its mentions
**silently ignored** — no overlay/env setting could change it. The env var
`GITHUB_APP_BOT_NAME` referenced in ops notes didn't actually exist in code, and
the `botName` git-author param was never wired, so agent commits were always
`last-light[bot]`.

## Change

Introduce a single `botName` config field (default `last-light`, set via overlay
`config.yaml` or the `GITHUB_APP_BOT_NAME` env var) as the source of truth for
the bot's identity. It derives:

- the **`@mention` handle** the router triggers on — *configured handle only*,
  no legacy fallback (the default stays `last-light`, so existing deployments
  are unaffected).
- **`botLogin`** (`<botName>[bot]`, still overridable with `BOT_LOGIN`) for
  self-comment / self-review filtering and bot-review detection.
- the **git commit author** for agent commits (host + sandbox), fixing the
  previously-unwired `botName`.

Router approve/reject/security-review/verify/qa-test/demo matchers, the
approval-gate help text, workflow trigger descriptions, and `build.yaml`'s gate
message all follow the configured handle (`{{botMention}}` / `getBotName()`).

## Deploy note

The Nearform overlay sets `botName: nearform-lastlight`; after merge + release,
`lastlight server update` on the nearform box picks it up (code change ⇒ image
rebuild).

## Testing

- 3 new router tests: configured handle routes to `approval-response`; a bare
  configured mention routes; the legacy `@last-light` mention is ignored when a
  different handle is configured.
- Full suite green (`993 passed / 7 skipped`); `tsc` + dashboard `tsc -b` clean.

Docs: `CLAUDE.md`, `spec/02-configuration.md`, `spec/05-router.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)