### PR TITLE
docs(lastlight-server): make model/provider setup multi-provider

### DIFF
--- a/plugins/lastlight/skills/lastlight-server/SKILL.md
+++ b/plugins/lastlight/skills/lastlight-server/SKILL.md
@@ -46,9 +46,24 @@ Ask for each of these (don't guess). Group the questions; explain what each is f
 - **Managed repos** — one or more `owner/repo` the bot is allowed to act on. The
   bot ignores any repo not listed.
 - **Model** — a `provider/model` string (default `anthropic/claude-sonnet-4-6`),
-  plus the **matching** provider API key. Key→provider mapping:
-  `sk-ant-…` → `ANTHROPIC_API_KEY`, `sk-or-…` → `OPENROUTER_API_KEY`, other
-  `sk-…` → `OPENAI_API_KEY`.
+  plus the **matching** provider's API key. Last Light is multi-provider: the
+  `provider/` prefix picks the provider and the model id follows, e.g.
+  `anthropic/claude-sonnet-4-6`, `openai/gpt-5.5`, `google/gemini-2.5-pro`,
+  `openrouter/anthropic/claude-sonnet-4.5`. Set **only** the one API-key env var
+  that matches the provider you chose. Common ones:
+  - `anthropic/…` → `ANTHROPIC_API_KEY` (`sk-ant-…`)
+  - `openai/…` → `OPENAI_API_KEY` (`sk-…`)
+  - `openrouter/…` → `OPENROUTER_API_KEY` (`sk-or-…`) — aggregator, reaches
+    Anthropic/Google/xAI/… models through one key
+  - `google/…` → `GEMINI_API_KEY`, `mistral/…` → `MISTRAL_API_KEY`,
+    `groq/…` → `GROQ_API_KEY`, `xai/…` → `XAI_API_KEY`, `deepseek/…` →
+    `DEEPSEEK_API_KEY`, and more (Cerebras, Hugging Face, Moonshot, NVIDIA,
+    Fireworks, Together, Z.AI, Kimi, MiniMax).
+
+  The env var name is not always `<PROVIDER>_API_KEY` (e.g. Google uses
+  `GEMINI_API_KEY`, Hugging Face uses `HF_TOKEN`); the full provider → model
+  prefix → env-var map is the registry in `src/providers.ts`, echoed in
+  `references/env-schema.md`.
 
 **Optional**
 - Admin dashboard password (≥8 chars) to protect `/admin`.

--- a/plugins/lastlight/skills/lastlight-server/references/env-schema.md
+++ b/plugins/lastlight/skills/lastlight-server/references/env-schema.md
@@ -31,11 +31,21 @@ WEBHOOK_SECRET=<openssl rand -hex 32>
 DOMAIN=lastlight.example.com
 
 # ── Model + provider API key ─────────────────────────────
+# Multi-provider: the `provider/` prefix selects the provider, e.g.
+#   anthropic/claude-sonnet-4-6 · openai/gpt-5.5 · google/gemini-2.5-pro
+#   openrouter/anthropic/claude-sonnet-4.5
 LASTLIGHT_MODEL=anthropic/claude-sonnet-4-6
-# Set whichever ONE matches LASTLIGHT_MODEL:
+# Set whichever ONE env var matches LASTLIGHT_MODEL's provider:
 ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_API_KEY=sk-...
 # OPENROUTER_API_KEY=sk-or-...
+# GEMINI_API_KEY=AIza...          # google/…
+# MISTRAL_API_KEY=...             # mistral/…
+# GROQ_API_KEY=...                # groq/…
+# XAI_API_KEY=...                 # xai/…
+# DEEPSEEK_API_KEY=...            # deepseek/…
+# …plus Cerebras, Hugging Face (HF_TOKEN), Moonshot, NVIDIA, Fireworks,
+#    Together, Z.AI, Kimi, MiniMax — see src/providers.ts for the full list.
 
 # ── Admin dashboard ──────────────────────────────────────
 ADMIN_SECRET=<openssl rand -hex 32>
@@ -53,8 +63,11 @@ Notes:
 - `GITHUB_APP_PRIVATE_KEY_PATH=./app.pem` is correct as-is — it's resolved
   inside the container, not on the host. Just place the file at
   `instance/secrets/app.pem`.
-- Provider-key detection: `sk-ant-…` is Anthropic; `sk-or-…` is OpenRouter; any
-  other `sk-…` is OpenAI.
+- Provider selection is driven by `LASTLIGHT_MODEL`'s `provider/` prefix, not by
+  the key shape — Last Light forwards every provider's API-key env var into the
+  runtime and each provider authenticates with its own. Set only the env var for
+  the provider your model prefix names. The `sk-ant-…` / `sk-or-…` / `sk-…` key
+  prefixes are just the wizard's convenience hints, not the selection mechanism.
 - **Removing** an env var later requires a container *recreate*
   (`lastlight server start agent`), not just a restart — compose injects
   `env_file` vars at creation time. Adding/changing one only needs


### PR DESCRIPTION
## What

The `lastlight-server` install skill still framed model selection as **Anthropic-first** with a narrow three-way `sk-*` key mapping (`ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY` / `OPENAI_API_KEY`), even though the setup wizard (`src/cli/setup.ts`) already surfaces the **full ~18-provider registry** from `src/providers.ts`.

This rephrases the skill docs to be multi-provider.

## Changes

- **`SKILL.md`** (§2 "Gather inputs" → Model bullet) — leads with "Last Light is multi-provider", gives `provider/model` examples (Anthropic, OpenAI, Google, OpenRouter), and lists the provider → env-var mapping. Notes the env var isn't always `<PROVIDER>_API_KEY` (Google → `GEMINI_API_KEY`, Hugging Face → `HF_TOKEN`) and points at `src/providers.ts` as the source of truth.
- **`references/env-schema.md`** — expands the `.env` model block with commented key lines for the other providers, and rewrites the provider-selection note: selection is driven by `LASTLIGHT_MODEL`'s `provider/` prefix, not by key shape (the `sk-*` prefixes are just wizard hints).

## Notes

- Docs-only; no code or `lastlight/evals` barrel change → no npm release needed.
- Verified every referenced env-var name against the current `src/providers.ts` registry (`GEMINI_API_KEY`, `HF_TOKEN`, `MOONSHOT_API_KEY`, `ZAI_API_KEY`, `KIMI_API_KEY`, etc.).
- The README and `lastlight-guide` skill were already multi-provider aware, so they're left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)