### PR TITLE
fix(build): recreate a build's workspace from the default branch on re-run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,6 +652,12 @@ Sandbox workspace provisioning (issue #107):
   phase; a different run reusing the dir → `git fetch` + `reset --hard` +
   `git clean -fdx -e node_modules` (deps stay warm). See the workflows
   guide's "taskId scoping" section.
+- **Per-issue build recreate (issue #153)** — `build` workspaces are keyed by
+  (repo, issue) too, but a different-run marker → **delete the leftover
+  checkout and re-clone from the default branch** (`recreateFromBase`), so a
+  re-triggered incomplete build starts again off current `main` and never
+  inherits a stale feature branch. A same-run resume still preserves the
+  checkout. Policy sets: `src/workflows/target-policy.ts`.
 
 OpenTelemetry (optional):
 

--- a/src/engine/agent-executor.ts
+++ b/src/engine/agent-executor.ts
@@ -202,6 +202,7 @@ async function prepareRun(
           token: mintedToken,
           runId: access.runId,
           shallow: access.shallow,
+          recreateFromBase: access.recreateFromBase,
         }
       : undefined;
 

--- a/src/engine/github/profiles.ts
+++ b/src/engine/github/profiles.ts
@@ -251,11 +251,11 @@ export interface GitSandboxAccess {
    * task's workspace before the sandbox container starts. The agent then
    * sees the workspace already checked out — no `clone_repo` call needed
    * inside the session. Used by read-only workflows (pr-review, pr-fix)
-   * that operate on an existing branch rather than creating one.
-   *
-   * Build-style workflows that create a new lastlight/* branch from main
-   * leave this unset — they start empty and let the agent set up the
-   * branch fresh.
+   * that operate on an existing branch, and by branch-synthesizing
+   * workflows (`build`, `verify`, `qa-test`, `demo` — see
+   * `PREPOPULATE_SYNTH_WORKFLOWS`) whose `lastlight/N-slug` branch doesn't
+   * exist on the remote yet: the missing-branch fallback in
+   * `prePopulateWorkspace` clones the default branch and creates it locally.
    */
   prePopulateBranch?: string;
   /**
@@ -275,6 +275,16 @@ export interface GitSandboxAccess {
    * have headroom.
    */
   shallow?: boolean;
+  /**
+   * Recreate the workspace from the **default branch** on a fresh run instead
+   * of reusing/refreshing an existing feature-branch checkout. Set for the
+   * `PER_TARGET_RECREATE_WORKFLOWS` (build): a re-triggered build discards any
+   * leftover from an earlier incomplete run and starts again off current
+   * `main`, and its feature branch is always cut from the latest default —
+   * never inheriting a stale pushed branch (issue #153). A same-run resume
+   * (approval gate) still preserves the checkout via the run marker.
+   */
+  recreateFromBase?: boolean;
 }
 
 export const GITHUB_PERMISSION_PROFILES: Record<GitAccessProfile, GitHubTokenPermissions> = {

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { isAbsolute, join, relative, resolve, sep } from "path";
 import { DockerSandbox, type WorkspaceMount } from "./docker.js";
 import { SANDBOX_IMAGE, isSandboxAvailable } from "./images.js";
@@ -228,22 +228,29 @@ type PrePopulate = {
   token: string;
   runId?: string;
   shallow?: boolean;
+  recreateFromBase?: boolean;
 };
 
 /**
  * Clone the repo into `<workDir>/<repo>` at the given branch.
  *
- * Three cases:
+ * Cases:
  * - **Fresh dir** (no `.git`): clone. `--depth 1 --single-branch` for
- *   read-only workflows (`pre.shallow`), `--depth 50` otherwise.
+ *   read-only workflows (`pre.shallow`), `--depth 50` otherwise. For
+ *   `recreateFromBase` the branch is cut from the default branch directly
+ *   (never `clone --branch <feature>`).
  * - **Same run revisiting the workspace** (`.git` exists, run marker matches
  *   `pre.runId`): preserve — this is a later phase of the same run reading
  *   what an earlier phase wrote (architect's `plan.md`, the reviewer's
  *   checkout). No git ops.
- * - **A fresh run reusing an old per-PR workspace** (`.git` exists, marker
- *   differs/absent): fetch + hard-reset to the remote branch + `git clean`
- *   that **keeps `node_modules`** so the next `npm install` is incremental.
- *   This is the re-review fast path from issue #107.
+ * - **A fresh run reusing an old per-target workspace** (`.git` exists, marker
+ *   differs/absent):
+ *   - default (pr-review / pr-fix): fetch + hard-reset to the remote branch +
+ *     `git clean` that **keeps `node_modules`** so the next `npm install` is
+ *     incremental (the re-review fast path from issue #107).
+ *   - `recreateFromBase` (build): delete the stale checkout and re-clone from
+ *     the default branch — a re-triggered incomplete build starts again off
+ *     current `main` (issue #153).
  */
 export { prePopulateWorkspace as __prePopulateWorkspaceForTest };
 
@@ -266,8 +273,10 @@ export function prePopulateWorkspace(
   // the workspace root.
   const repoDir = join(workDir, pre.repo);
   const markerPath = join(workDir, RUN_MARKER);
+  const scrub = (s: unknown): string =>
+    typeof s === "string" ? s.replaceAll(pre.token, "[REDACTED-TOKEN]") : "";
   // Repo dir might already exist — from a later phase of the same run, or a
-  // *different* run reusing a stable per-PR workspace (issue #107).
+  // *different* run reusing a stable per-target workspace (issue #107).
   if (existsSync(join(repoDir, ".git"))) {
     const lastRun = readMarker(markerPath);
     // Same run (or a caller that doesn't track runs): preserve the workspace
@@ -278,15 +287,39 @@ export function prePopulateWorkspace(
       );
       return;
     }
-    // Different run reusing this PR's workspace — refresh in place.
-    refreshExistingClone(repoDir, markerPath, pre);
-    return;
+    if (pre.recreateFromBase) {
+      // build (#153): a prior incomplete run left a checkout on a possibly
+      // stale feature branch. Discard it and re-clone from the default branch
+      // (below) so the re-triggered build starts again off current `main`.
+      try {
+        rmSync(repoDir, { recursive: true, force: true });
+        console.log(
+          `[sandbox] Recreating ${repoDir} from the default branch ` +
+          `(discarded stale workspace from run ${lastRun ?? "unknown"}).`,
+        );
+      } catch (err: any) {
+        console.warn(
+          `[sandbox] Failed to remove stale workspace ${repoDir} ` +
+          `(${scrub(err?.message)}); attempting a fresh clone anyway.`,
+        );
+      }
+      // fall through to the recreate-from-base clone below.
+    } else {
+      // Different run reusing this PR's workspace — refresh in place.
+      refreshExistingClone(repoDir, markerPath, pre);
+      return;
+    }
   }
-  const scrub = (s: unknown): string =>
-    typeof s === "string" ? s.replaceAll(pre.token, "[REDACTED-TOKEN]") : "";
   const start = Date.now();
   const depth = pre.shallow ? "1" : "50";
   const shallowArgs = pre.shallow ? ["--single-branch"] : [];
+  // Recreate-from-base workflows (build) always cut their branch from the
+  // default branch — never `clone --branch <feature>`, which would resurrect a
+  // stale *pushed* feature branch from an earlier incomplete run (#153).
+  if (pre.recreateFromBase) {
+    cloneDefaultAndCreateBranch(repoDir, url, depth, shallowArgs, pre, markerPath, start, scrub);
+    return;
+  }
   try {
     execFileSync(
       "git",
@@ -306,34 +339,9 @@ export function prePopulateWorkspace(
       // Build-style workflows create a brand-new branch (e.g. `lastlight/N-slug`)
       // and push it later. The remote doesn't have it yet at pre-clone time —
       // clone the default branch, then create the target branch locally so
-      // the agent enters a workspace already on the right branch with the
-      // right upstream URL configured.
-      try {
-        execFileSync(
-          "git",
-          ["clone", "--depth", depth, ...shallowArgs, url, repoDir],
-          { stdio: "pipe", timeout: 120_000 },
-        );
-        execFileSync(
-          "git",
-          ["-C", repoDir, "checkout", "-b", pre.branch],
-          { stdio: "pipe", timeout: 30_000 },
-        );
-        writeMarker(markerPath, pre.runId);
-        const ms = Date.now() - start;
-        console.log(
-          `[sandbox] Pre-cloned ${pre.owner}/${pre.repo} (default branch) into ${repoDir} ` +
-          `and created local branch ${pre.branch} (${ms}ms)`,
-        );
-        return;
-      } catch (err2: any) {
-        const secondError = scrub(err2?.message) || scrub(err2?.stderr?.toString?.()) || "unknown error";
-        console.warn(
-          `[sandbox] Pre-clone fallback of ${pre.owner}/${pre.repo} failed (${secondError}). ` +
-          `Agent will need to clone via MCP.`,
-        );
-        return;
-      }
+      // the agent enters a workspace already on the right branch.
+      cloneDefaultAndCreateBranch(repoDir, url, depth, shallowArgs, pre, markerPath, start, scrub);
+      return;
     }
     // Don't kill the run on a failed pre-clone — fall through to an empty
     // workspace and let the agent clone via the MCP path as a backup.
@@ -343,6 +351,51 @@ export function prePopulateWorkspace(
     // The token is scrubbed above before anything reaches the logs.
     console.warn(
       `[sandbox] Pre-clone of ${pre.owner}/${pre.repo}@${pre.branch} failed (${firstError}). ` +
+      `Agent will need to clone via MCP.`,
+    );
+  }
+}
+
+/**
+ * Clone the repo's default branch into `repoDir` and create `pre.branch`
+ * locally off it (`checkout -B`), then stamp the run marker. Shared by two
+ * paths: the feature branch not existing on the remote yet (build-style first
+ * run) and a recreate-from-base workflow deliberately re-cutting its branch
+ * from the default (issue #153). Best-effort — on failure it logs a
+ * token-scrubbed warning and leaves an empty workspace for the agent's MCP
+ * clone fallback.
+ */
+function cloneDefaultAndCreateBranch(
+  repoDir: string,
+  url: string,
+  depth: string,
+  shallowArgs: string[],
+  pre: PrePopulate,
+  markerPath: string,
+  start: number,
+  scrub: (s: unknown) => string,
+): void {
+  try {
+    execFileSync(
+      "git",
+      ["clone", "--depth", depth, ...shallowArgs, url, repoDir],
+      { stdio: "pipe", timeout: 120_000 },
+    );
+    execFileSync(
+      "git",
+      ["-C", repoDir, "checkout", "-B", pre.branch],
+      { stdio: "pipe", timeout: 30_000 },
+    );
+    writeMarker(markerPath, pre.runId);
+    const ms = Date.now() - start;
+    console.log(
+      `[sandbox] Pre-cloned ${pre.owner}/${pre.repo} (default branch) into ${repoDir} ` +
+      `and created local branch ${pre.branch} (${ms}ms)`,
+    );
+  } catch (err: any) {
+    const reason = scrub(err?.message) || scrub(err?.stderr?.toString?.()) || "unknown error";
+    console.warn(
+      `[sandbox] Default-branch clone of ${pre.owner}/${pre.repo} failed (${reason}). ` +
       `Agent will need to clone via MCP.`,
     );
   }

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -104,6 +104,15 @@ export interface PrePopulateSpec {
   token: string;
   runId?: string;
   shallow?: boolean;
+  /**
+   * Recreate the checkout from the default branch on a fresh (different-run)
+   * provision instead of refreshing the existing feature branch: delete any
+   * leftover checkout and clone the default branch, then create `branch`
+   * locally off it. Set for `build` so a re-triggered incomplete build starts
+   * again from current `main` (issue #153). A same-run provision still
+   * preserves the workspace.
+   */
+  recreateFromBase?: boolean;
 }
 
 /** What {@link Sandbox.provision} hands back to the orchestrator. */

--- a/src/workflows/CLAUDE.md
+++ b/src/workflows/CLAUDE.md
@@ -397,12 +397,25 @@ suffix — their taskId is `${repo}-${prNumber}-${workflowName}`, keyed by
 sandbox dir, so `prePopulateWorkspace` does `git fetch` + `reset --hard` +
 `git clean -fdx -e node_modules` instead of a fresh 1.3G clone + full
 install, and N dirs/PR collapse to 1 (cutting the #106 churn at its
-source). `build` is excluded — it creates a new branch per run and must not
-reuse. Concurrency is held off by the dispatcher's
-`isRunning(skill, triggerId)` guard plus `runs.getByTrigger` reuse; the
-cross-run vs same-run distinction is made by a `<workDir>/.lastlight-run`
-marker stamped with the owning run id (same id → preserve the checkout for
-the next phase; different id → refresh). See `src/sandbox/index.ts`.
+source).
+
+**Per-target recreate (issue #153).** `PER_TARGET_RECREATE_WORKFLOWS`
+(`build`) *also* drops the run-id suffix (taskId `${repo}-${issueNumber}-build`)
+so a re-triggered build lands in the **same** sandbox dir — but on a
+*different*-run marker it **deletes the leftover checkout and re-clones from the
+default branch** instead of refreshing the (stale) feature branch. An incomplete
+build is therefore disposable: re-running it starts again off current `main`,
+and its `lastlight/N-slug` branch is always cut from the latest default, never a
+stale pushed branch. This is driven by `recreateFromBase` on `GitSandboxAccess`
+/ `PrePopulateSpec` (set in `gitSandboxAccessForWorkflow`).
+
+Concurrency is held off by the dispatcher's `isRunning(skill, triggerId)` guard
+plus `runs.getByTrigger` reuse; the cross-run vs same-run distinction is made by
+a `<workDir>/.lastlight-run` marker stamped with the owning run id (same id →
+preserve the checkout for the next phase — the architect's `plan.md` survives;
+different id → refresh for pr-review/pr-fix, recreate-from-base for build). The
+workspace-provisioning policy sets live in `src/workflows/target-policy.ts`; the
+clone logic is in `src/sandbox/index.ts`.
 
 ## Templates
 

--- a/src/workflows/resume.ts
+++ b/src/workflows/resume.ts
@@ -4,6 +4,7 @@ import type { GitHubClient } from "../engine/github/github.js";
 import type { ModelConfig, VariantConfig } from "../config/config.js";
 import { runWorkflow, type ApprovalGateConfig, type RunnerCallbacks } from "./runner.js";
 import { getWorkflow } from "./loader.js";
+import { workflowScopedTaskId } from "./simple.js";
 import { slugify, type TemplateContext } from "./templates.js";
 import {
   ProgressNotifier,
@@ -59,18 +60,6 @@ export function parseSlackTriggerId(
   const [teamId, channelId, threadTs] = parts;
   if (!teamId || !channelId || !threadTs) return null;
   return { teamId, channelId, threadTs };
-}
-
-function workflowScopedTaskId(
-  repo: string,
-  issueNumber: number | undefined,
-  workflowName: string,
-  workflowRunId: string,
-): string {
-  const suffix = workflowRunId.slice(0, 8);
-  return issueNumber !== undefined
-    ? `${repo}-${issueNumber}-${workflowName}-${suffix}`
-    : `${repo}-${workflowName}-${suffix}`;
 }
 
 /**

--- a/src/workflows/runner.ts
+++ b/src/workflows/runner.ts
@@ -11,6 +11,7 @@ import type { AgentWorkflowDefinition } from "./schema.js";
 import { loadPromptTemplate } from "./loader.js";
 import { renderTemplate, type TemplateContext } from "./templates.js";
 import { buildDag, getReadyNodes, getNodesToSkip, isComplete } from "./dag.js";
+import { PER_TARGET_RECREATE_WORKFLOWS } from "./target-policy.js";
 import { qaImageAvailable, SANDBOX_IMAGE_QA } from "../sandbox/images.js";
 import {
   PhaseExecutor,
@@ -120,6 +121,9 @@ export function gitSandboxAccessForWorkflow(
     // the code-pushing profiles (build / pr-fix / security-feedback) keep the
     // deeper clone for rebase/amend headroom.
     shallow: profile !== "repo-write",
+    // `build` recreates its workspace from the default branch on a fresh run
+    // (issue #153) rather than refreshing a possibly-stale feature branch.
+    recreateFromBase: PER_TARGET_RECREATE_WORKFLOWS.has(workflowName),
   };
 }
 

--- a/src/workflows/simple.ts
+++ b/src/workflows/simple.ts
@@ -15,6 +15,12 @@ import { slugify } from "./templates.js";
 import { wrapUntrusted } from "../engine/screen/screen.js";
 import { buildProgressModel, runDashboardUrl } from "../notify/model.js";
 import { buildAssetIssueKey } from "../state/build-assets.js";
+import {
+  PER_TARGET_REUSE_WORKFLOWS,
+  PER_TARGET_RECREATE_WORKFLOWS,
+  PREPOPULATE_SYNTH_WORKFLOWS,
+  PR_HEADREF_PREPOPULATE_WORKFLOWS,
+} from "./target-policy.js";
 
 /**
  * Lightweight invocation request for any agent workflow. The runner handles
@@ -63,61 +69,16 @@ export interface SimpleWorkflowRequest {
   prePopulateBranch?: string;
 }
 
-/**
- * Workflows whose workspace is keyed by **(repo, PR)** rather than per-run.
- * For these the taskId drops the run-id suffix so re-reviews of the same PR
- * (push → `synchronize`, cron PR-review fanout) reuse one sandbox dir — a
- * warm `node_modules` + an incremental `git fetch` instead of a fresh
- * 1.3G clone + full install each time, and N dirs/PR collapse to 1 (issue
- * #107, cutting the #106 churn at its source). Concurrency is held off by
- * the dispatcher's `isRunning(skill, triggerId)` guard plus
- * `runs.getByTrigger` reuse — two runs never share the dir live; the
- * cross-run refresh in `prePopulateWorkspace` resets it cleanly between them.
- * `build` is excluded — it creates a new branch per run and must not reuse.
- */
-export const PER_TARGET_REUSE_WORKFLOWS = new Set(["pr-review", "pr-fix"]);
-
-/**
- * Workflows that synthesize their own `lastlight/N-slug` branch (which doesn't
- * exist on the remote at dispatch time) yet should still pre-populate the
- * sandbox: the agent's cwd becomes the repo root (no `git clone`/`cd`), and —
- * for the read-only `verify`/`qa-test` runs — server-mode artifacts the agent
- * writes to `.lastlight/<key>/` (e.g. browser-QA screenshots) land where
- * `serverArtifacts()` harvests them instead of being orphaned a level up.
- * `build` was the original member; verify/qa-test were added for the harvest
- * fix, and `demo` for the same reason (its `demo.mp4` is written under
- * `.lastlight/<key>/` and harvested into the Artifacts store). For a fresh
- * (issue-scoped) dispatch the dispatcher leaves `prePopulateBranch` unset and
- * the missing-branch fallback in `prePopulateWorkspace` clones the default
- * branch — correct for `build`/`demo`, which *create* the synth branch off the
- * default. But when the *same* workflow runs against an existing PR, the synth
- * `lastlight/<prNumber>-<title-slug>` name won't match the PR's real head ref
- * (named after the originating issue), so the fallback would clone the default
- * branch and test/demo code that lacks the PR — see
- * `PR_HEADREF_PREPOPULATE_WORKFLOWS`.
- */
-export const PREPOPULATE_SYNTH_WORKFLOWS = new Set(["build", "verify", "qa-test", "demo"]);
-
-/**
- * The subset of PR-scoped read workflows the dispatcher pins to the PR's *real*
- * head ref (via `getPullRequest(...).head.ref`) before pre-populating, instead
- * of letting them fall back to the synthesized `lastlight/N-<title-slug>` name.
- * Each of these is meaningful only against an existing PR, and the synth name
- * never matches the PR's actual branch (which is named after the originating
- * issue, e.g. `lastlight/14-…` for a PR #15). Without this pinning:
- *   - `qa-test` / `verify` QA the *base* branch and report the PR's feature
- *     missing — a false-negative result.
- *   - `demo`'s "after" collapses onto the default branch, matching "before".
- * `pr-fix` is handled separately (it plumbs `branch` through context for the
- * architect/executor to push to). See the resolution block in
- * `dispatchWorkflow` (src/index.ts).
- */
-export const PR_HEADREF_PREPOPULATE_WORKFLOWS = new Set([
-  "pr-review",
-  "demo",
-  "qa-test",
-  "verify",
-]);
+// Per-target workspace provisioning policy lives in `./target-policy.js` (a
+// leaf module the runner can share without an import cycle). Imported at the
+// top for local use; re-exported here for existing callers (e.g. src/index.ts
+// imports PR_HEADREF_PREPOPULATE_WORKFLOWS).
+export {
+  PER_TARGET_REUSE_WORKFLOWS,
+  PER_TARGET_RECREATE_WORKFLOWS,
+  PREPOPULATE_SYNTH_WORKFLOWS,
+  PR_HEADREF_PREPOPULATE_WORKFLOWS,
+};
 
 export function workflowScopedTaskId(
   repo: string,
@@ -125,8 +86,14 @@ export function workflowScopedTaskId(
   workflowName: string,
   workflowId: string,
 ): string {
-  // Reusable per-PR workspaces are keyed by (repo, PR) only — no run suffix.
-  if (number !== undefined && PER_TARGET_REUSE_WORKFLOWS.has(workflowName)) {
+  // Reusable / recreatable per-target workspaces are keyed by (repo, issue)
+  // only — no run suffix — so a re-run lands on the same dir (reused for
+  // pr-review/pr-fix, recreated-from-base for build; see the two sets above).
+  if (
+    number !== undefined &&
+    (PER_TARGET_REUSE_WORKFLOWS.has(workflowName) ||
+      PER_TARGET_RECREATE_WORKFLOWS.has(workflowName))
+  ) {
     return `${repo}-${number}-${workflowName}`;
   }
   const suffix = workflowId.slice(0, 8);

--- a/src/workflows/target-policy.ts
+++ b/src/workflows/target-policy.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-target sandbox-workspace provisioning policy — which workflows key their
+ * workspace by (repo, issue/PR) and how a re-run treats an existing checkout.
+ *
+ * This is a leaf module (no imports of the runner or the simple entrypoint) so
+ * both `simple.ts` (taskId keying) and `runner.ts` (`gitSandboxAccessForWorkflow`)
+ * can read the same source of truth without an import cycle. `simple.ts`
+ * re-exports these for existing callers (e.g. `src/index.ts`).
+ */
+
+/**
+ * Workflows whose workspace is keyed by **(repo, PR)** rather than per-run.
+ * For these the taskId drops the run-id suffix so re-reviews of the same PR
+ * (push → `synchronize`, cron PR-review fanout) reuse one sandbox dir — a
+ * warm `node_modules` + an incremental `git fetch` instead of a fresh
+ * 1.3G clone + full install each time, and N dirs/PR collapse to 1 (issue
+ * #107, cutting the #106 churn at its source). Concurrency is held off by
+ * the dispatcher's `isRunning(skill, triggerId)` guard plus
+ * `runs.getByTrigger` reuse — two runs never share the dir live; the
+ * cross-run refresh in `prePopulateWorkspace` resets it cleanly between them.
+ * `build` is handled by `PER_TARGET_RECREATE_WORKFLOWS` instead — it must not
+ * *refresh* a stale checkout (that would reset onto the old feature branch);
+ * it recreates the workspace from the default branch.
+ */
+export const PER_TARGET_REUSE_WORKFLOWS = new Set(["pr-review", "pr-fix"]);
+
+/**
+ * Workflows whose per-target workspace is **recreated from the default branch**
+ * on a fresh run rather than refreshed onto an existing feature branch. Like
+ * `PER_TARGET_REUSE_WORKFLOWS`, these key the taskId by (repo, issue) only (no
+ * run-id suffix) so a re-run lands on the same dir — but a *different*-run
+ * marker triggers a delete + fresh clone off the default branch, not a
+ * `git fetch`/reset of the (stale) feature branch. This makes an incomplete
+ * `build` disposable: re-triggering it starts again from current `main`
+ * (issue #153). A genuine *resume* of the same run (approval gate) still
+ * preserves the workspace via the same-run marker — the architect's `plan.md`
+ * survives. Concurrency is held off by the dispatcher's
+ * `isRunning(skill, triggerId)` guard, so the delete only ever hits a leftover
+ * from a finished/abandoned run.
+ */
+export const PER_TARGET_RECREATE_WORKFLOWS = new Set(["build"]);
+
+/**
+ * Workflows that synthesize their own `lastlight/N-slug` branch (which doesn't
+ * exist on the remote at dispatch time) yet should still pre-populate the
+ * sandbox: the agent's cwd becomes the repo root (no `git clone`/`cd`), and —
+ * for the read-only `verify`/`qa-test` runs — server-mode artifacts the agent
+ * writes to `.lastlight/<key>/` (e.g. browser-QA screenshots) land where
+ * `serverArtifacts()` harvests them instead of being orphaned a level up.
+ * `build` was the original member; verify/qa-test were added for the harvest
+ * fix, and `demo` for the same reason (its `demo.mp4` is written under
+ * `.lastlight/<key>/` and harvested into the Artifacts store). For a fresh
+ * (issue-scoped) dispatch the dispatcher leaves `prePopulateBranch` unset and
+ * the missing-branch fallback in `prePopulateWorkspace` clones the default
+ * branch — correct for `build`/`demo`, which *create* the synth branch off the
+ * default. But when the *same* workflow runs against an existing PR, the synth
+ * `lastlight/<prNumber>-<title-slug>` name won't match the PR's real head ref
+ * (named after the originating issue), so the fallback would clone the default
+ * branch and test/demo code that lacks the PR — see
+ * `PR_HEADREF_PREPOPULATE_WORKFLOWS`.
+ */
+export const PREPOPULATE_SYNTH_WORKFLOWS = new Set(["build", "verify", "qa-test", "demo"]);
+
+/**
+ * The subset of PR-scoped read workflows the dispatcher pins to the PR's *real*
+ * head ref (via `getPullRequest(...).head.ref`) before pre-populating, instead
+ * of letting them fall back to the synthesized `lastlight/N-<title-slug>` name.
+ * Each of these is meaningful only against an existing PR, and the synth name
+ * never matches the PR's actual branch (which is named after the originating
+ * issue, e.g. `lastlight/14-…` for a PR #15). Without this pinning:
+ *   - `qa-test` / `verify` QA the *base* branch and report the PR's feature
+ *     missing — a false-negative result.
+ *   - `demo`'s "after" collapses onto the default branch, matching "before".
+ * `pr-fix` is handled separately (it plumbs `branch` through context for the
+ * architect/executor to push to). See the resolution block in
+ * `dispatchWorkflow` (src/index.ts).
+ */
+export const PR_HEADREF_PREPOPULATE_WORKFLOWS = new Set([
+  "pr-review",
+  "demo",
+  "qa-test",
+  "verify",
+]);

--- a/tests/sandbox/index.test.ts
+++ b/tests/sandbox/index.test.ts
@@ -181,3 +181,71 @@ describe("prePopulateWorkspace clone depth + per-PR reuse (issue #107)", () => {
     expect(readFileSync(join(workDir, ".lastlight-run"), "utf-8")).toBe("old-run");
   });
 });
+
+describe("prePopulateWorkspace recreate-from-base (build, issue #153)", () => {
+  let workDir: string;
+  const REPO = "lastlight";
+  const FEATURE = "lastlight/149-foo";
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "ll-recreate-"));
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockExec.mockReturnValue(Buffer.from(""));
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockExec.mockReset();
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function seedExistingClone(marker?: string): void {
+    mkdirSync(join(workDir, REPO, ".git"), { recursive: true });
+    if (marker !== undefined) writeFileSync(join(workDir, ".lastlight-run"), marker);
+  }
+
+  it("deletes a stale checkout from a DIFFERENT run and re-clones from the default branch", () => {
+    seedExistingClone("old-run");
+    prePopulateWorkspace(workDir, {
+      owner: "cliftonc", repo: REPO, branch: FEATURE, token: TOKEN,
+      runId: "new-run", shallow: false, recreateFromBase: true,
+    });
+    // The stale checkout was removed (clone is mocked, so it isn't recreated).
+    expect(existsSync(join(workDir, REPO, ".git"))).toBe(false);
+    // Never refreshes the stale feature branch (no fetch/reset/clean).
+    expect(calledArgs().some((a) => a.includes("fetch"))).toBe(false);
+    // Clones the DEFAULT branch (no `--branch <feature>`), then cuts the
+    // feature branch locally off it.
+    const clone = calledArgs().find((a) => a[0] === "clone")!;
+    expect(clone).not.toContain("--branch");
+    const checkout = calledArgs().find((a) => a.includes("checkout"))!;
+    expect(checkout).toEqual(["-C", join(workDir, REPO), "checkout", "-B", FEATURE]);
+    // Marker advanced to the new run.
+    expect(readFileSync(join(workDir, ".lastlight-run"), "utf-8")).toBe("new-run");
+  });
+
+  it("cuts the branch from the default branch on a fresh clone (never clone --branch)", () => {
+    prePopulateWorkspace(workDir, {
+      owner: "cliftonc", repo: REPO, branch: FEATURE, token: TOKEN,
+      runId: "run-1", shallow: false, recreateFromBase: true,
+    });
+    // A stale *pushed* feature branch must never be resurrected via clone --branch.
+    const clones = calledArgs().filter((a) => a[0] === "clone");
+    expect(clones).toHaveLength(1);
+    expect(clones[0]).not.toContain("--branch");
+    const checkout = calledArgs().find((a) => a.includes("checkout"))!;
+    expect(checkout[checkout.indexOf("checkout") + 1]).toBe("-B");
+    expect(readFileSync(join(workDir, ".lastlight-run"), "utf-8")).toBe("run-1");
+  });
+
+  it("preserves the workspace on a SAME-run revisit even with recreateFromBase", () => {
+    seedExistingClone("run-1");
+    prePopulateWorkspace(workDir, {
+      owner: "cliftonc", repo: REPO, branch: FEATURE, token: TOKEN,
+      runId: "run-1", recreateFromBase: true,
+    });
+    // Same run → no git ops, no delete (the architect's plan.md must survive).
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(existsSync(join(workDir, REPO, ".git"))).toBe(true);
+  });
+});

--- a/tests/workflows/runner.test.ts
+++ b/tests/workflows/runner.test.ts
@@ -1429,3 +1429,16 @@ describe("gitSandboxAccessForWorkflow — App PEM never enters the sandbox", () 
     },
   );
 });
+
+describe("gitSandboxAccessForWorkflow — recreate-from-base (issue #153)", () => {
+  it("sets recreateFromBase for build", () => {
+    expect(gitSandboxAccessForWorkflow("build", "owner", "repo").recreateFromBase).toBe(true);
+  });
+
+  it.each(["pr-review", "pr-fix", "issue-triage", "verify", "qa-test"])(
+    "leaves recreateFromBase falsy for %s (reuse/refresh or in-session clone)",
+    (wf) => {
+      expect(gitSandboxAccessForWorkflow(wf, "owner", "repo").recreateFromBase).toBeFalsy();
+    },
+  );
+});

--- a/tests/workflows/simple.test.ts
+++ b/tests/workflows/simple.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { workflowScopedTaskId, resolveRunBranch, PER_TARGET_REUSE_WORKFLOWS, PREPOPULATE_SYNTH_WORKFLOWS, PR_HEADREF_PREPOPULATE_WORKFLOWS } from "#src/workflows/simple.js";
+import { workflowScopedTaskId, resolveRunBranch, PER_TARGET_REUSE_WORKFLOWS, PER_TARGET_RECREATE_WORKFLOWS, PREPOPULATE_SYNTH_WORKFLOWS, PR_HEADREF_PREPOPULATE_WORKFLOWS } from "#src/workflows/simple.js";
 
 const RUN = "abcdef12-3456-7890-abcd-ef1234567890";
 
@@ -14,9 +14,15 @@ describe("workflowScopedTaskId", () => {
     }
   });
 
-  it("keeps the run suffix for build so each run gets a fresh workspace", () => {
-    const id = workflowScopedTaskId("drizzle-cube", 918, "build", RUN);
-    expect(id).toBe("drizzle-cube-918-build-abcdef12");
+  it("keys build (recreate-from-base) by (repo, issue) with no run suffix so a re-run lands on the same dir", () => {
+    for (const wf of PER_TARGET_RECREATE_WORKFLOWS) {
+      const a = workflowScopedTaskId("drizzle-cube", 918, wf, RUN);
+      const b = workflowScopedTaskId("drizzle-cube", 918, wf, "different-run-id");
+      expect(a).toBe(`drizzle-cube-918-${wf}`);
+      // A re-triggered build resolves to the same dir → the stale checkout is
+      // found and recreated from the default branch (issue #153).
+      expect(a).toBe(b);
+    }
   });
 
   it("keeps the run suffix for repo-scoped (no number) workflows", () => {


### PR DESCRIPTION
Closes #153.

## Problem

A re-triggered `build` could operate on a **stale checkout**. The harness never
brought a build's feature branch up to date with the default branch, and never
cleaned up a workspace left behind by an earlier incomplete run:

- `prePopulateWorkspace` only ever *refreshed the feature branch* on reuse
  (`git fetch`/reset of `pre.branch`) — never the base — and the fresh-clone
  path used `clone --branch <feature>`, which would resurrect a stale **pushed**
  feature branch.
- `build`'s per-run taskId suffix meant every run got a new dir; old workspaces
  orphaned on disk forever.

Concurrency was already handled — `isRunning("build", issueNumber)`
(`dispatcher.ts`) silently skips a second concurrent build for the same issue.

## Change — treat an incomplete build as disposable

New **recreate-from-base** workspace mode for `build` (peer of the per-PR reuse
mode), reusing the existing `.lastlight-run` marker that distinguishes
"same run" from "different run":

- **Key build by `(repo, issue)`** (`PER_TARGET_RECREATE_WORKFLOWS`) so a re-run
  lands on the **same** dir and the stale leftover is found. The four
  workspace-policy sets moved into a leaf module `src/workflows/target-policy.ts`
  so `runner.ts` can share them without a `simple ↔ runner` import cycle;
  `simple.ts` re-exports for existing callers, and `resume.ts` now uses the
  canonical `workflowScopedTaskId`.
- **Plumb `recreateFromBase`** (`GitSandboxAccess` → `PrePopulateSpec`). When set,
  `prePopulateWorkspace`:
  - different-run leftover → **delete the checkout** and clone the **default
    branch**, then `checkout -B <feature>` (extracted into a shared
    `cloneDefaultAndCreateBranch` helper, also used by the existing
    missing-branch fallback);
  - fresh clone → clone the default branch directly, **never** `clone --branch`,
    so a stale pushed branch is never inherited;
  - **same-run** revisit → preserve the checkout (the architect's `plan.md`
    survives an approval-gate resume).

So a re-triggered incomplete build starts again off current `main`; a genuine
resume of the same run is untouched.

### Rejected: silent `git merge origin/<default>`
Conflict resolution needs agent judgment, not a `git` call in the plumbing.
Recreate-from-base avoids conflicts by discarding the incomplete build.

## Notes / trade-offs
- Deterministic keying means two same-issue builds that both slip past
  `isRunning` in the tiny window before the first `executions` row is written
  would share a dir — a narrow, pre-existing race; the dispatcher guard is the
  real protection.
- A recreated workspace loses warm `node_modules` (full delete); bounded by the
  shared package **download** cache (`/cache`, docker backend).
- **Out of scope (follow-up):** discarding/force-pushing a build feature branch
  that was already *pushed* to the remote before failing. This PR fixes the
  local workspace only.

## Tests
- `tests/sandbox/index.test.ts` — delete-and-recreate on a different run; fresh
  clone never uses `clone --branch`; same-run preserve.
- `tests/workflows/simple.test.ts` — build's taskId drops the run suffix.
- `tests/workflows/runner.test.ts` — `gitSandboxAccessForWorkflow` sets
  `recreateFromBase` for build, falsy for reuse/in-session-clone workflows.

Full suite: **1016 passed / 7 skipped**; `npm run build` + `npm run typecheck:test` clean.

## Deploy
Harness code → reaches prod via `lastlight server update` (image rebuild). No npm
release needed (CLI and the `lastlight/evals` barrel are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)