### PR TITLE
feat(skills): bulk github_ensure_labels for canonical label bootstrap (#151)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@sinclair/typebox": "^0.34.49",
         "@slack/bolt": "^4.6.0",
         "@slack/web-api": "^7.16.0",
-        "agentic-pi": "^0.2.14",
+        "agentic-pi": "^0.2.15",
         "arctic": "^3.7.0",
         "better-sqlite3": "^11.0.0",
         "chalk": "^5.6.2",
@@ -7935,9 +7935,9 @@
       }
     },
     "node_modules/agentic-pi": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/agentic-pi/-/agentic-pi-0.2.14.tgz",
-      "integrity": "sha512-I1lAS30cYOOLMvb1T5lmXJ75ljGKgXjnP1JhkwVnF0Vf+Ij/3ObayLGGAyXYeJEwl6tBUcg371tzImGiJdjOMw==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/agentic-pi/-/agentic-pi-0.2.15.tgz",
+      "integrity": "sha512-8rTVL64dOEVx82azRL6o6cG2A+UZ9739zpcFY+vYwjs9Jw811KaGyZA4v31ysinUiHMaipBhde0ZDdEaz/tfHQ==",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/gondolin": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@sinclair/typebox": "^0.34.49",
     "@slack/bolt": "^4.6.0",
     "@slack/web-api": "^7.16.0",
-    "agentic-pi": "^0.2.14",
+    "agentic-pi": "^0.2.15",
     "arctic": "^3.7.0",
     "better-sqlite3": "^11.0.0",
     "chalk": "^5.6.2",

--- a/skills/issue-answer/SKILL.md
+++ b/skills/issue-answer/SKILL.md
@@ -67,10 +67,11 @@ maintainer to `@last-light build` (or `explore`) it — let triage own work item
      For broad/open-ended questions (e.g. "what's missing vs tool X"), gather a
      representative sample and answer from it — explicitly noting it's a
      sample, not an exhaustive audit — rather than enumerating everything.
-3. **Label (GitHub issue only).** Apply `question` with `github_add_labels`
-   (create it first with `github_create_label`, color `d876e3`; ignore a 422
-   "already exists"). If label creation/adding is denied, skip it — the answer
-   is the deliverable. For a Slack-initiated question there is no issue to label.
+3. **Label (GitHub issue only).** Ensure `question` exists idempotently with
+   `github_ensure_labels` (`[{name: "question", color: "d876e3"}]` — one call,
+   no 422 to worry about), then apply it with `github_add_labels`. If ensuring
+   or adding the label is denied, skip it — the answer is the deliverable. For a
+   Slack-initiated question there is no issue to label.
 4. **Write the answer as your final message** (the harness delivers it — see
    above; do not post it yourself):
    - Direct and structured. Lead with the answer; use short sections or a

--- a/skills/issue-comment/SKILL.md
+++ b/skills/issue-comment/SKILL.md
@@ -23,7 +23,9 @@ outgoing comment.** Never make code changes, create branches, or push.
 2. **Do the bounded action:**
    - Close / reopen → `github_update_issue`
    - Label → `github_add_labels` / `github_remove_label` (use the canonical
-     triage roles from `docs/agents/triage-labels.md` where relevant)
+     triage roles from `docs/agents/triage-labels.md` where relevant; if you're
+     applying a canonical label that may not exist yet, ensure it first with one
+     idempotent `github_ensure_labels` call so it lands with the right color)
    - Duplicate check → search similar issues, link the original in one comment
    - Answer a direct question → ≤5 sentences, ≤2 file reads. Don't survey the
      codebase or compile a report.

--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -29,8 +29,10 @@ downstream build agent, which has full source access.
 
 ## 0. Ensure the labels exist
 
-Before applying any label, create the canonical set idempotently with
-`github_create_label` (ignore 422 "already exists"):
+Before applying any label, create the canonical set in a **single** idempotent
+`github_ensure_labels` call — pass every row below as one `labels` array
+(`{name, color}`). It lists once and creates only the missing ones, so it never
+errors on labels that already exist:
 
 | Label | Color | Role |
 |-------|-------|------|
@@ -44,7 +46,7 @@ Before applying any label, create the canonical set idempotently with
 | `duplicate` | `cfd3d7` | dedupe |
 | `question` | `d876e3` | question |
 
-If label creation is denied (the token lacks the permission), fall back to using
+If the call is denied (the token lacks the permission), fall back to using
 only the labels that already exist on the repo and skip the rest. Done when the
 labels you need are present or you've confirmed you can't create them.
 

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -68,7 +68,9 @@ recording "no relevant changes since prior scan" and return.
 
 ### 2. Ensure labels exist
 
-`github_create_label` for each (idempotent — ignore 422):
+One idempotent `github_ensure_labels` call — pass every row below as a single
+`labels` array of `{name, color}` (it creates only the missing ones, never
+errors on existing labels):
 
 | Label | Color | Purpose |
 |-------|-------|---------|

--- a/workflows/prompts/answer.md
+++ b/workflows/prompts/answer.md
@@ -58,7 +58,8 @@ double-post. The only GitHub write you make is the label:
 
 {{#if issueNumber}}
 - Apply the `question` label to issue #{{issueNumber}} with `github_add_labels`
-  (create it first with `github_create_label`, color `d876e3`; ignore a 422).
+  (ensure it exists first with one `github_ensure_labels` call —
+  `[{name: "question", color: "d876e3"}]`; it's idempotent, no 422 to handle).
   Leave the issue open.
 {{/if}}
 {{#if !issueNumber}}


### PR DESCRIPTION
Closes #151.

## What

Adopt agentic-pi's new idempotent, check-first, bulk `github_ensure_labels(owner, repo, labels)` tool (nearform/agentic-pi#11, shipped in **0.2.15**) across the label-touching skills, replacing the old "call `github_create_label` per label, ignore the 422 `already_exists`" pattern.

A triage run against a repo whose labels already exist now makes **one** `github_ensure_labels` call instead of N failing 422 creates — no more 422 noise in the session log.

## Changes

- `skills/issue-triage/SKILL.md` §0 — one `github_ensure_labels` call for the canonical set; dropped the "ignore 422" caveat.
- `skills/issue-answer/SKILL.md` §3 + `workflows/prompts/answer.md` — ensure `question` (`d876e3`) idempotently, then add it.
- `skills/security-review/SKILL.md` §2 — one `github_ensure_labels` call for the security label set.
- `skills/issue-comment/SKILL.md` — ensure a canonical label exists (right color) before applying it.
- Bump `agentic-pi` `^0.2.14` → `^0.2.15`. The sandbox image pins agentic-pi's version + integrity straight from `package-lock.json` (`sandbox.Dockerfile`), so a rebuild automatically picks up the new tool — no manual Dockerfile bump.

## Verification

- `npm run build` (tsc) passes against 0.2.15.
- `github_ensure_labels(owner, repo, labels: [{name, color?, description?}])` signature confirmed in `node_modules/agentic-pi/dist/extensions/github/tools.js`.
- agentic-pi integration tests pass (`agent-executor`, `pi-events`).

## Rollout

Ships with the normal release / `server update` flow. **Requires a sandbox image rebuild** (`docker compose build sandbox`, done by `lastlight server update`) so the deployed sandbox exposes `github_ensure_labels`. Per the npm-release policy this touches skills/prompts consumed via the evals barrel, so it warrants a version bump + release.

## Docs

No `spec/`/www change: the spec catalogue documents each skill's *purpose* (unchanged — they still "label"), not which `github_*` tool bootstraps labels. `spec/` has no `create_label`/`ensure_labels` reference. (docs-sync run; internal tool-idiom swap only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)