### PR TITLE
feat(classifier): fork the classifier prompt + workflow-driven intents (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,8 +148,15 @@ src/
     screen/             Prompt screening + intent classification.
       screen.ts         Prompt-injection screener. Uses llm.ts with a cheap
                         model (claude-haiku by default).
-      classifier.ts     Tiny LLM call that decides "is this comment asking
-                        me to build something?". Uses llm.ts.
+      classifier.ts     Tiny LLM call that classifies a comment/message into
+                        an intent (build / review / … / chat). Uses llm.ts.
+                        The prompt is COMPOSED at runtime, not hardcoded: a
+                        forkable base (workflows/prompts/classifier.md) + one
+                        `classification:` block per workflow YAML. Adding a
+                        workflow (even in an overlay) adds a routable intent
+                        with no core edit — the router's getWorkflowByIntent
+                        fallback routes it. `lastlight fork classifier` forks
+                        the base prompt. (issue #164)
   workflows/            See src/workflows/CLAUDE.md for the full runner
                         story. Loads YAML definitions, executes phases
                         (linear or DAG), manages resume, approval gates,
@@ -502,6 +509,9 @@ lastlight server status                # compose ps + core/overlay version drift
 lastlight fork                         # list forkable workflows + agent-context (marks forked)
 lastlight fork <workflow>              # workflow YAML + every prompt + skill its phases reference
 lastlight fork agent-context [file]    # all agent-context/*.md (soul/rules/security), or one file
+lastlight fork classifier              # the base intent-classifier prompts (classifier.md +
+                                        # classify-adds-info.md); per-workflow category text
+                                        # travels with `fork <workflow>` already
                                         # [--home dir] [--force to overwrite existing]
 
 # Install the Last Light Claude Code skills into a local Claude Code (HOST-LOCAL;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,13 @@ Codex model is used for a sandbox phase).
 
 The cheap-helper path (`src/engine/llm.ts`, used by screener + classifier)
 bypasses OpenCode and dispatches directly to the same three providers.
-`defaultFastModel()` prefers Anthropic > OpenAI > OpenRouter when multiple
-keys are set — direct provider routes avoid OpenRouter's per-token markup
-when possible.
+`defaultFastModel(taskType)` resolves the model in order: the config `models:`
+map for the task key (`models.classifier` / `models.screener` in `config.yaml`,
+which env `OPENCODE_MODELS` is layered into) → the env `OPENCODE_MODELS` map
+directly → the first configured provider's fast model (Anthropic > OpenAI >
+OpenRouter — direct routes avoid OpenRouter's per-token markup). Only an
+explicit per-task entry counts, never `models.default`, so the helpers stay
+cheap unless deliberately pinned.
 
 Two execution surfaces:
 - **Sandbox** — `opencode run --format json` invoked per workflow phase

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -18,6 +18,13 @@ botName: last-light
 
 models:
   default: anthropic/claude-sonnet-4-6
+  # Per-task overrides keyed by phase or helper name, e.g.:
+  #   architect: anthropic/claude-opus-4-8
+  #   classifier: anthropic/claude-haiku-4-5-20251001   # the intent-routing helper
+  #   screener: anthropic/claude-haiku-4-5-20251001     # the prompt-injection screener
+  # A per-task entry wins over `default`. `classifier`/`screener` are the cheap
+  # one-shot helpers (src/engine/llm.ts); when unset they fall back to the first
+  # configured provider's fast model, NOT `default`.
 
 variants: {}
 

--- a/spec/02-configuration.md
+++ b/spec/02-configuration.md
@@ -396,6 +396,14 @@ Per-task resolvers — `resolveModel(models, taskType)`, `resolveVariant()` —
 sit alongside the schema (`296–297`, `336–340`) and are called from the
 runner and dispatch closure, not from the config loader itself.
 
+The cheap one-shot helpers (`classifier`, `screener` in `src/engine/llm.ts`)
+also honour the `models:` map: `defaultFastModel(taskType)` reads
+`config.models[taskType]` first (so `models.classifier` / `models.screener` in
+`config.yaml` work like any per-task model), then the env `OPENCODE_MODELS`
+map, then the first provider's fast model. Unlike `resolveModel`, it never
+falls back to `models.default` — an unset helper stays on the cheap provider
+default rather than inheriting the (expensive) workflow default.
+
 ## Rebuild notes
 
 - **Layered config, not flattened.** Keep base + per-task-override

--- a/spec/05-router.md
+++ b/spec/05-router.md
@@ -159,8 +159,8 @@ Behaviour:
 
 ## Build-intent classifier
 
-The classifier turns a free-form comment or message into one of fourteen
-discrete intents:
+The classifier turns a free-form comment or message into one discrete intent.
+By default there are fourteen:
 
 ```
 BUILD | EXPLORE | QUESTION | TRIAGE | REVIEW | SECURITY |
@@ -173,8 +173,32 @@ keyword matches above short-circuit before the classifier; natural-language
 requests like "does this actually fix the crash?" reach `verify` via this
 classifier path, and "record a demo of this" reaches `demo`.)
 
-`classifier.ts:39–96` defines the system prompt. The model must reply
-in exactly four lines:
+**The prompt is composed, forkable, and workflow-driven (issue #164).** The
+system prompt is assembled at runtime by `buildClassifierPrompt()`, not
+hardcoded:
+
+- A **forkable base template** — `workflows/prompts/classifier.md`, resolved
+  through the same overlay machinery as any other prompt (overlay wins by name;
+  `lastlight fork classifier` copies it into `instance/`). It holds the framing,
+  the global disambiguation rules, the five harness-owned **control** categories
+  (`APPROVE`/`REJECT`/`STATUS`/`RESET`/`CHAT`), and the `{{categories}}` /
+  `{{examples}}` / `{{intentTokens}}` slots.
+- **Per-workflow categories.** Each workflow YAML contributes its own category
+  via a `classification:` block (`intent` + `description` + optional `examples`);
+  `build.yaml` owns `BUILD`, `pr-review.yaml` owns `REVIEW`, and so on. The
+  classifier enumerates `listAgentWorkflows()`, merges the blocks in canonical
+  order, and derives the token→intent vocabulary (token =
+  `intent.toUpperCase().replace(/-/g,"")`, so `qa-test` → `QATEST`) from the same
+  blocks. The composition is memoised and rebuilt when the asset layers change.
+
+So a deployment can **add a routable intent by adding a workflow** — an overlay
+`incident.yaml` with `classification.intent: incident` teaches the classifier the
+`INCIDENT` category, the parser the token, and the router the route (see
+[data-driven routing](#data-driven-routing-for-new-intents)) with **no core
+edit**. The loader validates at boot that every `classification.intent` is unique
+and doesn't shadow a control intent.
+
+The model must reply in exactly four lines:
 
 ```
 INTENT: BUILD
@@ -205,10 +229,30 @@ Failure modes:
 Called only on (a) GitHub `comment.created` with maintainer @-mention,
 and (b) Slack `message`. Never on deterministic events.
 
+### Data-driven routing for new intents
+
+The router keeps its bespoke, context-dependent branches for the well-known
+intents (`build` → `pr-fix` on a PR vs `github-orchestrator` on an issue;
+`explore` is a no-op on a PR; the `security-scan` diversion). For an intent
+*outside* that well-known set — a new one an overlay workflow introduced — the
+trailing generic default falls back to `getWorkflowByIntent(intent)` (the
+workflow whose `classification.intent` matches), routing to it on both GitHub
+comments and Slack. It routes to that single workflow uniformly across surfaces;
+a deployment needing surface-specific routing for its new intent can still add
+`routes.github` / `routes.slack` overrides. Well-known intents never hit the
+fallback, so their established routing is untouched.
+
+**New issues** (`issue.opened`) route through the same composed classifier:
+`classifyIssueIntent()` runs the main classifier over the issue title + body and
+sends a `QUESTION` intent to the `answer` workflow, everything else to triage
+(the safe default). This replaced a separate hardcoded question-vs-work prompt —
+`answer.yaml` now owns the `QUESTION` category, so the two share one vocabulary.
+
 A second, smaller helper — `classifyCommentAddsInfo` — answers a single
 yes/no question (does a reporter's plain comment add substantive information,
 or is it social noise?) and gates the [reporter-driven re-triage](#reporter-driven-re-triage)
-branch for non-`needs-info` issues. Same cheap-helper path; fail-closed
+branch for non-`needs-info` issues. Its prompt is the forkable
+`workflows/prompts/classify-adds-info.md`. Same cheap-helper path; fail-closed
 (error → no re-triage).
 
 ## `llm.ts` — the cheap-helper path
@@ -282,11 +326,14 @@ dispatching) gets its own branch.
 | Piece | File |
 |---|---|
 | `routeEvent`, `RoutingResult`, `MAINTAINER_ROLES`, `BOT_MENTION` regex | `src/engine/router.ts` |
-| Build-intent classifier | `src/engine/screen/classifier.ts` |
+| Build-intent classifier (compose + parse) | `src/engine/screen/classifier.ts` |
+| Composable base prompt + adds-info prompt | `workflows/prompts/classifier.md`, `workflows/prompts/classify-adds-info.md` |
+| Per-workflow category source | `classification:` block in each `workflows/<name>.yaml` |
+| Intent → workflow fallback | `getWorkflowByIntent()` in `src/workflows/loader.ts` |
 | Injection screener | `src/engine/screen/screen.ts` |
 | Direct provider calls + model auto-detect | `src/engine/llm.ts` |
 | Harness consumer (skill → handler) | `src/index.ts:560–1124` |
-| URL extraction fallback | `extractGithubRefFromText()` in `classifier.ts:182–189` |
+| URL extraction fallback | `extractGithubRefFromText()` in `classifier.ts` |
 
 ## Rebuild notes
 
@@ -311,6 +358,9 @@ dispatching) gets its own branch.
   comment and every Slack message, so cost it. SQLite handles it
   trivially; a re-implementation on a remote DB should cache the active
   set of `triggerId`s in memory.
-- **Treat the classifier prompt as code.** A change to the intent set,
-  the output format, or the fallback rules ripples through every chat
-  surface. Version it like a config file; test it with golden cases.
+- **Treat the classifier prompt as code.** A change to the base template's
+  output format or fallback rules ripples through every chat surface; the intent
+  set itself is now data (one `classification:` block per workflow). Version both
+  like config; test with golden cases (`buildClassifierPrompt()` is pure and
+  snapshot-friendly). Keep the base template and the per-workflow blocks in sync
+  with the token→intent vocabulary they compose into.

--- a/spec/05-router.md
+++ b/spec/05-router.md
@@ -262,12 +262,21 @@ which does direct HTTP POSTs to provider APIs (Anthropic Messages,
 OpenAI Chat Completions, OpenRouter passthrough). No agent SDK, no
 tools, no streaming — single-turn calls only.
 
-Provider auto-detection at `llm.ts:91–105`:
+Fast-model resolution (`defaultFastModel(taskType)` in `llm.ts`), in order:
 
-1. `OPENCODE_MODELS` JSON for the relevant key (`screener`, `classifier`)
-2. `ANTHROPIC_API_KEY` set → `anthropic/claude-haiku-4-5-20251001`
-3. `OPENAI_API_KEY` set → `openai/gpt-5.4-mini`
-4. `OPENROUTER_API_KEY` set → `openrouter/google/gemini-2.5-flash`
+1. The config `models:` map for the task key (`models.classifier`,
+   `models.screener`) — set it in `config.yaml` like any other per-task model.
+   Env `OPENCODE_MODELS` / `LASTLIGHT_MODELS` is layered into this map at
+   config-load, so it's covered here too (env wins over `config.yaml`).
+2. The env `OPENCODE_MODELS` JSON read directly — a fallback for contexts where
+   runtime config isn't loaded (some CLI / test paths).
+3. First configured provider's fast model, in registry order:
+   `ANTHROPIC_API_KEY` → `anthropic/claude-haiku-4-5-20251001`,
+   else `OPENAI_API_KEY` → `openai/gpt-5.4-mini`,
+   else `OPENROUTER_API_KEY` → `openrouter/google/gemini-2.5-flash`.
+
+Only an **explicit** per-task entry counts — never `models.default` — so the
+cheap helpers stay cheap unless a deployment deliberately pins them.
 
 Single retry on 429 / 5xx with a 750 ms back-off; never retries on
 other 4xx (those are real errors).

--- a/spec/06-workflow-engine.md
+++ b/spec/06-workflow-engine.md
@@ -54,9 +54,21 @@ through — webhook dispatch, CLI, cron, admin resume.
   description?: string;
   trigger?: string;      // informational
   variables?: Record<string, string>;
+  classification?: {     // how the intent classifier routes to this workflow (issue #164)
+    intent: string;      //   the intent token this workflow owns (unique; not a control intent)
+    description: string; //   the category paragraph merged into the composed classifier prompt
+    examples?: string[]; //   optional one-line classifier examples
+  };
   phases: PhaseDefinition[];
 }
 ```
+
+The optional `classification` block makes a workflow **self-describing to the
+router**: its `description`/`examples` are composed into the classifier prompt
+(`workflows/prompts/classifier.md`), and its `intent` becomes routable via the
+router's `getWorkflowByIntent` fallback — so adding a workflow (even in an
+overlay) can add a new intent with no core change. See
+[05-router.md → Build-intent classifier](05-router.md#build-intent-classifier).
 
 **Phase level** (`schema.ts:84–182`):
 

--- a/src/cli/fork-cli.ts
+++ b/src/cli/fork-cli.ts
@@ -228,6 +228,7 @@ function forkAll(t: ForkTarget, force: boolean): CopyResult[] {
     for (const r of forkWorkflow(t, def.name, force)) add(r);
   }
   for (const r of forkAgentContext(t, builtinAgentContext(t.coreRoot), force)) add(r);
+  for (const r of forkClassifier(t, force)) add(r);
   return [...byRel.values()].sort((a, b) => a.rel.localeCompare(b.rel));
 }
 
@@ -237,6 +238,26 @@ function forkAgentContext(t: ForkTarget, files: string[], force: boolean): CopyR
     const src = path.join(t.coreRoot, "agent-context", file);
     return copyFile(src, path.join(t.instanceDir, "agent-context", file), `agent-context/${file}`, force);
   });
+}
+
+/**
+ * The base classifier prompt files (issue #164) — the framing/disambiguation
+ * template the intent classifier composes per-workflow categories into, plus
+ * the re-triage novelty gate. Each workflow's own category text lives in its
+ * YAML, so it already travels with `fork <workflow>`; these are the standalone
+ * base prompts a deployment forks to retune the router's classification.
+ */
+const CLASSIFIER_PROMPTS = ["prompts/classifier.md", "prompts/classify-adds-info.md"];
+
+/** Copy the base classifier prompt files into the overlay (skip any absent from core). */
+function forkClassifier(t: ForkTarget, force: boolean): CopyResult[] {
+  const results: CopyResult[] = [];
+  for (const rel of CLASSIFIER_PROMPTS) {
+    const src = path.join(t.coreRoot, "workflows", rel);
+    if (!fs.existsSync(src)) continue;
+    results.push(copyFile(src, path.join(t.instanceDir, "workflows", rel), `workflows/${rel}`, force));
+  }
+  return results;
 }
 
 /** Built-in agent-context filenames (e.g. soul.md, rules.md, security.md). */
@@ -290,6 +311,10 @@ function listForkable(t: ForkTarget): void {
     console.log(chalk.bold("\nForkable agent-context") + chalk.dim("  (lastlight fork agent-context)\n"));
     for (const file of context) console.log(`  ${file}${mark(`agent-context:${file}`)}`);
   }
+  console.log(chalk.bold("\nForkable classifier") + chalk.dim("  (lastlight fork classifier)\n"));
+  for (const rel of CLASSIFIER_PROMPTS) {
+    console.log(`  ${rel}${mark(`prompt:${path.basename(rel)}`)}`);
+  }
   console.log(chalk.dim("\nFork one with: ") + chalk.cyan("lastlight fork <name>"));
   console.log(chalk.dim("Fork everything with: ") + chalk.cyan("lastlight fork all"));
 }
@@ -299,8 +324,9 @@ function listForkable(t: ForkTarget): void {
 /**
  * `lastlight fork [target] [sub]` — dispatch on an explicit target.
  *   - (none)                       → list forkable targets
- *   - "all"                        → every workflow (+ prompts & skills) + context
+ *   - "all"                        → every workflow (+ prompts & skills) + context + classifier
  *   - "agent-context" [file]       → all context files, or one named file
+ *   - "classifier"                 → the base intent-classifier prompt files
  *   - "<workflow>"                 → workflow + its prompts + skills
  * Agent-context is never inferred from a bare filename — it's only reached via
  * the literal `agent-context` target.
@@ -349,6 +375,12 @@ export async function fork(args: string[], opts: ForkOpts): Promise<void> {
     return;
   }
 
+  // classifier — the base intent-classifier prompts (issue #164).
+  if (target === "classifier") {
+    printSummary(t, forkClassifier(t, opts.force ?? false));
+    return;
+  }
+
   // Otherwise treat it as a workflow name.
   try {
     getWorkflow(target);
@@ -358,6 +390,7 @@ export async function fork(args: string[], opts: ForkOpts): Promise<void> {
       chalk.red(`Unknown fork target: ${target}`) +
         chalk.dim(`\n  Workflows: ${names.join(", ")}`) +
         chalk.dim(`\n  Agent-context: "agent-context" (optionally a file, e.g. agent-context soul.md).`) +
+        chalk.dim(`\n  Classifier: "classifier".`) +
         chalk.dim(`\n  Everything: "all".`),
     );
     process.exit(1);

--- a/src/engine/llm.ts
+++ b/src/engine/llm.ts
@@ -23,6 +23,7 @@
  */
 
 import { PROVIDERS, providerByPrefix, type ApiType, type ProviderSpec } from "../providers.js";
+import { getRuntimeConfig } from "../config/config.js";
 
 export type ChatRole = "system" | "user" | "assistant";
 
@@ -95,12 +96,23 @@ export function resolveProvider(model: string): ResolvedProvider {
 
 /**
  * Resolve the model id for a tiny one-shot helper call (classifier / screener).
- * Prefers explicit per-task overrides from OPENCODE_MODELS, then the first
- * configured provider in `PROVIDERS` order (registry order: Anthropic first,
- * then OpenAI, OpenRouter, then the rest — see `src/providers.ts`).
+ * Precedence for a given `taskType`:
+ *   1. an explicit per-task entry in the config `models:` map (`models.classifier`,
+ *      `models.screener`) — which already has env `OPENCODE_MODELS` /
+ *      `LASTLIGHT_MODELS` layered on top at config-load, so this covers both
+ *      config.yaml and the env override in one lookup;
+ *   2. the env `OPENCODE_MODELS` map read directly — a fallback for contexts
+ *      where runtime config isn't loaded (some CLI / test paths);
+ *   3. the first configured provider in `PROVIDERS` order (registry order:
+ *      Anthropic first, then OpenAI, OpenRouter, then the rest — `src/providers.ts`).
+ *
+ * Note: only an EXPLICIT per-task entry counts — never `models.default` — so the
+ * cheap helpers stay cheap unless a deployment deliberately pins them.
  */
 export function defaultFastModel(taskType?: string): string {
   if (taskType) {
+    const configured = getRuntimeConfig()?.models?.[taskType];
+    if (configured) return configured;
     const override = readOpencodeModelOverride(taskType);
     if (override) return override;
   }

--- a/src/engine/router.ts
+++ b/src/engine/router.ts
@@ -1,9 +1,22 @@
 import type { EventEnvelope } from "../connectors/types.js";
-import { classifyComment, classifyCommentAddsInfo, classifyIssueIsQuestion } from "./screen/classifier.js";
+import { classifyComment, classifyCommentAddsInfo, classifyIssueIntent, WELL_KNOWN_INTENTS } from "./screen/classifier.js";
 import { screenForInjection, flagPrefix } from "./screen/screen.js";
 import { getManagedRepos, isManagedRepo } from "../managed-repos.js";
+import { getWorkflowByIntent } from "../workflows/loader.js";
 import { getRoutes, getBotName } from "../config/config.js";
 import type { StateDb } from "../state/db.js";
+
+/**
+ * Resolve a classifier intent the router has no bespoke branch for to the
+ * workflow that claims it via its `classification.intent` (issue #164). Returns
+ * undefined for well-known intents (they keep their explicit, context-dependent
+ * routing) and for unclaimed tokens — so this fires only for a genuinely new
+ * intent an overlay workflow introduced, routing it to that workflow.
+ */
+function fallbackWorkflowForIntent(intent: string): string | undefined {
+  if (WELL_KNOWN_INTENTS.has(intent)) return undefined;
+  return getWorkflowByIntent(intent)?.name;
+}
 
 /**
  * A routing decision — the single term for "what should process this event"
@@ -92,7 +105,7 @@ export async function routeEvent(
       // search + its own model) instead of triage, which would otherwise file
       // a question as an enhancement and write an agent brief. Classified with
       // the same cheap model as comments; WORK is the safe default.
-      const isQuestion = await classifyIssueIsQuestion(
+      const isQuestion = await classifyIssueIntent(
         envelope.title || "",
         envelope.body || "",
       );
@@ -363,12 +376,14 @@ export async function routeEvent(
         //              caps at 2 file reads which isn't enough to answer
         //              "does this PR consider X?" with code-cited evidence)
         // Explore isn't meaningful on PRs since the code already exists.
+        const prNovelWf = fallbackWorkflowForIntent(intent);
         const { handler: prHandler, routeKey: prRouteKey } =
           intent === "build" ? { handler: gh.pr_fix || "pr-fix", routeKey: "github.pr_fix" }
           : intent === "review" ? { handler: gh.pr_review || "pr-review", routeKey: "github.pr_review" }
           : intent === "verify" ? { handler: gh.verify || "verify", routeKey: "github.verify" }
           : intent === "qa-test" ? { handler: gh.qa_test || "qa-test", routeKey: "github.qa_test" }
           : intent === "demo" ? { handler: gh.demo || "demo", routeKey: "github.demo" }
+          : prNovelWf ? { handler: prNovelWf, routeKey: `intent.${intent}` }
           : { handler: gh.pr_comment || "pr-comment", routeKey: "github.pr_comment" };
         return {
           action: "handler",
@@ -415,12 +430,14 @@ export async function routeEvent(
           },
         };
       }
+      const issueNovelWf = fallbackWorkflowForIntent(intent);
       const { handler: issueSkill, routeKey: issueRouteKey } =
         intent === "build" ? { handler: gh.issue_build || "github-orchestrator", routeKey: "github.issue_build" }
         : intent === "explore" ? { handler: gh.issue_explore || "explore", routeKey: "github.issue_explore" }
         : intent === "verify" ? { handler: gh.verify || "verify", routeKey: "github.verify" }
         : intent === "qa-test" ? { handler: gh.qa_test || "qa-test", routeKey: "github.qa_test" }
         : intent === "demo" ? { handler: gh.demo || "demo", routeKey: "github.demo" }
+        : issueNovelWf ? { handler: issueNovelWf, routeKey: `intent.${intent}` }
         : { handler: gh.issue_comment || "issue-comment", routeKey: "github.issue_comment" };
       return {
         action: "handler",
@@ -714,7 +731,31 @@ export async function routeEvent(
           };
         }
 
-        default:
+        default: {
+          // A novel intent an overlay workflow introduced (issue #164) → route
+          // to that workflow. If it named an unmanaged repo, reject on the same
+          // security boundary the built-in repo-scoped intents use.
+          const novelWf = fallbackWorkflowForIntent(intent);
+          if (novelWf) {
+            if (classifiedRepo && !isManagedRepo(classifiedRepo)) {
+              return { action: "reply", message: unmanagedRepoReply(classifiedRepo) };
+            }
+            return {
+              action: "handler",
+              handler: novelWf,
+              context: {
+                _routeKey: `intent.${intent}`,
+                repo: classifiedRepo,
+                issueNumber: classifiedIssue,
+                sender: envelope.sender,
+                commentBody: slackText,
+                source: envelope.source,
+                triggerId: slackTriggerId,
+                channelId,
+                threadId,
+              },
+            };
+          }
           // chat — conversational reply
           return {
             action: "handler",
@@ -726,6 +767,7 @@ export async function routeEvent(
               source: envelope.source,
             },
           };
+        }
       }
     }
 

--- a/src/engine/screen/classifier.ts
+++ b/src/engine/screen/classifier.ts
@@ -1,28 +1,32 @@
 /**
  * LLM-based comment intent classifier.
  *
- * Uses a fast/cheap model (haiku) with no tools to classify whether
- * a GitHub comment is requesting a code change (build/fix), an idea
- * exploration, or a lightweight action (close, label, question, etc.).
+ * Uses a fast/cheap model (haiku) with no tools to classify whether a
+ * GitHub/Slack comment is requesting a code change (build/fix), an idea
+ * exploration, a lightweight action (approve/status/…), etc.
+ *
+ * The main classifier prompt is **composed at runtime**, not hardcoded: a
+ * forkable base template (`workflows/prompts/classifier.md`) supplies the
+ * framing + disambiguation rules + control categories, and each workflow YAML
+ * contributes its own category via a `classification:` block. This lets a
+ * deployment fork the base prompt AND add a new routable intent just by adding
+ * a workflow (see issue #164). The token→intent vocabulary is derived from the
+ * same blocks, so the prompt, the parser, and the router's
+ * `getWorkflowByIntent` fallback all read one source of truth.
  */
 
 import { chat as realChat, defaultFastModel as realDefaultFastModel, type ChatFunction } from "../llm.js";
+import { getAssetVersion, listAgentWorkflows, loadPromptTemplate } from "../../workflows/loader.js";
+import { intentToken, RESERVED_CONTROL_INTENTS } from "../../workflows/schema.js";
 
-export type CommentIntent =
-  | "build"
-  | "explore"
-  | "question"
-  | "triage"
-  | "review"
-  | "security"
-  | "verify"
-  | "qa-test"
-  | "demo"
-  | "approve"
-  | "reject"
-  | "status"
-  | "reset"
-  | "chat";
+/**
+ * A classifier intent. The well-known intents the router has bespoke handling
+ * for are listed in {@link KNOWN_WORKFLOW_INTENT_ORDER} + {@link RESERVED_CONTROL_INTENTS},
+ * but the runtime type is open: a workflow can introduce a new intent (e.g.
+ * `incident`) via its `classification` block, and the router routes it via the
+ * `getWorkflowByIntent` fallback.
+ */
+export type CommentIntent = string;
 
 export interface ClassificationResult {
   intent: CommentIntent;
@@ -48,102 +52,103 @@ export interface ClassifierOptions {
   defaultFastModel?: (taskType?: string) => string;
 }
 
-const CLASSIFIER_PROMPT = `You are a router for messages directed at a GitHub/Slack bot.
-Classify the user's message into exactly one category, and extract any repository or issue references.
+// ── prompt composition ───────────────────────────────────────────────────────
 
-Categories:
-BUILD — The user is ASKING YOU (the bot) to make code changes NOW in a GitHub repo: implement a feature, fix a bug, create/send a PR, resolve an issue with code. BUILD requires a GitHub target — either an explicit repo reference (owner/name or github.com URL) in the message, OR an ISSUE TITLE context line indicating the comment is a reply on an existing issue/PR. If neither is present, classify as CHAT — local filesystem operations ("delete files in ~/foo", "clean up my downloads"), shell-style commands, or vague "build something" with no target are NOT BUILD.
-  BUILD is a REQUEST for NEW work directed at you. A comment that merely REPORTS work the human has ALREADY done is NOT BUILD — it is CHAT. Tells: past-tense ("fixed", "done", "implemented", "added a test", "pushed a fix", "handled it"), a reference to a commit the human made ("addressed in <sha>", "see commit abc123"), thanking you, or explaining/justifying a change they made in response to your review. These are status reports, not requests — classify them CHAT even when the comment is on a PR and even when it @-mentions you. Only classify BUILD when the human asks you to do NEW work (imperative request: "fix X", "now also handle Y", "can you update Z").
-EXPLORE — The user wants help shaping an idea BEFORE writing code: "help me think through X", "brainstorm Y", "spec this out", "explore an idea for Z". A bare "explore" / "explore this" / "let's explore" is also EXPLORE — especially as a reply on an existing issue (ISSUE TITLE present), where the implicit object is the issue's idea. EXPLORE = shape the idea / write a spec; BUILD = write the code now.
-QUESTION — The user is asking a substantive INFORMATIONAL question that warrants research to answer well: "how does X work?", "what's the difference between X and Y?", "how does <repo> compare to <other tool>?", "is it possible to do Z?", "why does X happen?". The deliverable is an ANSWER, not code and not a spec. QUESTION is for real questions that benefit from reading docs/code or searching the web — NOT casual chat, thanks, or one-word replies (those stay CHAT). EXPLORE shapes a NEW idea into a spec; QUESTION answers an EXISTING question about how something works or compares.
-TRIAGE — The user wants to scan/triage issues on a repo: "triage cliftonc/repo", "scan for new issues", "can you triage <repo>?".
-REVIEW — The user wants a code review. Either repo-wide ("review cliftonc/repo", "check PRs", "can you review PRs on <repo>?") OR, when the comment is a reply on a PR (ISSUE TITLE present), a request to review THIS PR: "review this", "can you review this?", "please review", "take a look at this PR", "give this a review". The deliverable is a formal PR review (inline comments on the diff). Prefer REVIEW over CHAT whenever there's a clear "review"/"take a look" request on a PR.
-SECURITY — The user wants a security scan/review of a repo: "security review cliftonc/repo", "scan for vulnerabilities", "check security", "can you do a security review of <repo>?".
-VERIFY — The user wants you to TEST whether a specific claim or behaviour is actually true and report the evidence: "verify that the rate limiter blocks", "does this PR really fix the crash?", "confirm X actually works", "check that Y no longer happens", "prove the --fork flag creates a new session". The deliverable is a CONFIRMED/REFUTED verdict backed by RUNNING the code — not a code change and not a code-quality review. Prefer VERIFY over REVIEW when the user wants proof a behaviour works/is fixed, rather than an assessment of the diff.
-QATEST — The user wants you to drive an app or CLI through a flow and report step-level pass/fail: "qa test the signup flow", "run through login and tell me what breaks", "smoke-test the CLI commands", "exercise the checkout flow". The deliverable is a step-by-step QA report. Prefer QATEST over VERIFY when it's a multi-step flow to exercise rather than a single claim to confirm.
-DEMO — The user wants you to record a DEMO VIDEO of a feature/PR: "demo this", "record a demo of the new dashboard", "make a video showing the dark-mode toggle", "show me a before/after of the fix". The deliverable is a short screen-recorded mp4 of the running web UI, not a pass/fail report and not a verdict. Prefer DEMO over QATEST/VERIFY when the user explicitly asks for a recording, a video, or "show"/"demo" rather than to test or confirm a behaviour.
-APPROVE — The user is approving a pending gate: "approve", "go ahead", "looks good, continue", "yes proceed".
-REJECT — The user is rejecting a pending gate: "reject", "abort", "cancel this", "no don't proceed". Extract any reason given.
-STATUS — The user wants to know what's running: "status", "what's running", "any tasks active?".
-RESET — The user wants to start a fresh session: "new", "reset", "start over", "fresh session".
-CHAT — Anything else: questions, conversation, thanks, general discussion, and status reports of work the human already did ("thanks, fixed in <sha>", "addressed your comments", "done — added tests").
+/**
+ * Canonical order the well-known workflow categories appear in — matches the
+ * historical hardcoded prompt so composition is a no-op diff for the shipped
+ * workflows. Unknown/overlay intents sort after these, alphabetically.
+ */
+const KNOWN_WORKFLOW_INTENT_ORDER = [
+  "build",
+  "explore",
+  "question",
+  "triage",
+  "review",
+  "security",
+  "verify",
+  "qa-test",
+  "demo",
+];
 
-Polite or question phrasings are still clear intent. "Can you do a security review of X?",
-"could you triage <repo>?", "please review PRs on <repo>" are SECURITY, TRIAGE, REVIEW
-respectively — not CHAT. The "prefer CHAT when ambiguous" rule only applies when the
-message has no clear action verb. Presence of "security review", "triage", "review PRs",
-"scan for vulnerabilities", etc. makes the intent unambiguous regardless of politeness.
+function intentOrderIndex(intent: string): number {
+  const i = KNOWN_WORKFLOW_INTENT_ORDER.indexOf(intent);
+  return i === -1 ? KNOWN_WORKFLOW_INTENT_ORDER.length : i;
+}
 
-When ambiguous between EXPLORE and CHAT, prefer CHAT. Only pick EXPLORE when the user is explicitly asking for brainstorming / spec-shaping / design exploration — OR gives a bare "explore"/"explore this" command (see the issue-reply rule below), which is unambiguous, not chat.
-When ambiguous between QUESTION and CHAT, prefer CHAT — only pick QUESTION for a substantive informational question that genuinely benefits from research (reading docs/code or a web search). Casual conversation, greetings, thanks, and trivial one-liners stay CHAT.
-When ambiguous between BUILD and CHAT, prefer CHAT.
-When ambiguous between VERIFY/QATEST and REVIEW/CHAT, prefer the existing category — only pick VERIFY or QATEST when the user explicitly asks you to test, run, confirm, or exercise a behaviour/flow.
-When ambiguous between DEMO and VERIFY/QATEST, prefer the existing category — only pick DEMO when the user explicitly asks for a video, a recording, or to "demo"/"show" the feature.
-When ambiguous between APPROVE/REJECT and CHAT, prefer CHAT — only classify as APPROVE/REJECT when the intent is clearly about a pending workflow gate.
+/**
+ * The intents the router has bespoke, context-dependent handling for (a workflow
+ * intent handled by an explicit router branch, or a harness control intent).
+ * The router's `getWorkflowByIntent` fallback fires ONLY for intents *outside*
+ * this set — i.e. a genuinely new intent an overlay workflow introduced — so the
+ * established routing of the well-known intents (e.g. `explore` is a no-op on a
+ * PR → `pr-comment`) is never disturbed.
+ */
+export const WELL_KNOWN_INTENTS: ReadonlySet<string> = new Set<string>([
+  ...KNOWN_WORKFLOW_INTENT_ORDER,
+  ...RESERVED_CONTROL_INTENTS,
+]);
 
-Repo extraction: always emit REPO as "owner/name" (never a URL). If the message contains
-a github.com URL, convert it: https://github.com/cliftonc/lastlight → cliftonc/lastlight.
-URL paths like /issues/42 or /pull/5 should populate ISSUE as well.
+interface ClassifierState {
+  /** Loader asset version this was assembled at, for cheap staleness checks. */
+  version: number;
+  /** The fully-composed classifier system prompt. */
+  prompt: string;
+  /** UPPER prompt token → intent string (control intents + workflow intents). */
+  tokenToIntent: Map<string, string>;
+}
 
-When the message is a reply on an existing issue/PR, the issue title is provided
-as ISSUE TITLE. Short imperative replies classify by their verb, with the issue
-as the implicit object — the "prefer CHAT when ambiguous" rule does NOT apply to
-a clear command directed at the issue's subject:
-- "lets build this", "build it", "go ahead", "ship it", "do it", "implement
-  this", "make it so" → BUILD (write the code now).
-- "explore", "explore this", "let's explore", "think this through", "spec this
-  out", "brainstorm this" → EXPLORE (shape the idea / write a spec first).
-- "review this", "can you review this", "please review", "take a look",
-  "give this a review" → REVIEW (do a real code review now; on a PR this means
-  review the current PR's diff).
-A bare command word ("explore", "build", "review") on an existing issue/PR is a
-clear command, NOT ambiguous chat.
-This verb rule is for IMPERATIVE requests only. A PR/issue reply that REPORTS
-already-completed work or responds to your review — "thanks, fixed in <sha>",
-"addressed in commit abc123", "done, added a regression test", "this is
-intentional, confirmed with the maintainer" — is a status report, NOT a
-command. Classify it CHAT regardless of the ISSUE TITLE or an @mention. Do not
-let words like "fix"/"build"/"add" inside a past-tense report flip it to BUILD.
+let cachedState: ClassifierState | undefined;
 
-Respond in exactly this format (each on its own line, no extra text):
-INTENT: BUILD|EXPLORE|QUESTION|TRIAGE|REVIEW|SECURITY|VERIFY|QATEST|DEMO|APPROVE|REJECT|STATUS|RESET|CHAT
-REPO: owner/name or NONE
-ISSUE: number or NONE
-REASON: text or NONE
+/** Force a rebuild of the composed prompt (used by tests). */
+export function resetClassifierPromptCache(): void {
+  cachedState = undefined;
+}
 
-Examples:
-"explore adding webhooks to cliftonc/drizby" → INTENT: EXPLORE, REPO: cliftonc/drizby, ISSUE: NONE, REASON: NONE
-"how does cliftonc/lastlight compare to Vercel's Eve framework?" → INTENT: QUESTION, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE
-"what's the difference between a sandbox phase and a chat session in cliftonc/lastlight?" → INTENT: QUESTION, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE
-"thanks, that makes sense!" → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE
-"build cliftonc/drizzle-cube#42" → INTENT: BUILD, REPO: cliftonc/drizzle-cube, ISSUE: 42, REASON: NONE
-"lets build this!" with ISSUE TITLE "Security Review" → INTENT: BUILD, REPO: NONE, ISSUE: NONE, REASON: NONE
-"go ahead" with ISSUE TITLE "Add CSV export" → INTENT: BUILD, REPO: NONE, ISSUE: NONE, REASON: NONE
-"Thanks @last-light — addressed in 49ccadf. Fixed the nested body in the core and added a regression test; point 3 is intentional, confirmed with the maintainer." with ISSUE TITLE "Port fastify/hono/nextjs adapters" → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE
-"done, pushed a fix for the type error in 1a2b3c4" with ISSUE TITLE "Fix build" → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE
-"now also handle the GET /sql case please" with ISSUE TITLE "Port adapters" → INTENT: BUILD, REPO: NONE, ISSUE: NONE, REASON: NONE
-"verify that the --fork flag creates a new session in cliftonc/foo#12" → INTENT: VERIFY, REPO: cliftonc/foo, ISSUE: 12, REASON: NONE
-"does this actually fix the crash?" with ISSUE TITLE "Fix null deref on resize" → INTENT: VERIFY, REPO: NONE, ISSUE: NONE, REASON: NONE
-"can you confirm the rate limiter actually blocks at 100 req/s?" with ISSUE TITLE "Add rate limiter" → INTENT: VERIFY, REPO: NONE, ISSUE: NONE, REASON: NONE
-"qa test the login flow on this PR" with ISSUE TITLE "Add login" → INTENT: QATEST, REPO: NONE, ISSUE: NONE, REASON: NONE
-"run through the signup flow and tell me what breaks" with ISSUE TITLE "Signup v2" → INTENT: QATEST, REPO: NONE, ISSUE: NONE, REASON: NONE
-"record a demo of this" with ISSUE TITLE "Add dark-mode toggle" → INTENT: DEMO, REPO: NONE, ISSUE: NONE, REASON: NONE
-"make a short before/after video of the fix on cliftonc/foo#12" → INTENT: DEMO, REPO: cliftonc/foo, ISSUE: 12, REASON: NONE
-"explore" with ISSUE TITLE "Feature: Allow configuration of otel endpoints" → INTENT: EXPLORE, REPO: NONE, ISSUE: NONE, REASON: NONE
-"explore this" with ISSUE TITLE "Add webhook support" → INTENT: EXPLORE, REPO: NONE, ISSUE: NONE, REASON: NONE
-"approve" → INTENT: APPROVE, REPO: NONE, ISSUE: NONE, REASON: NONE
-"reject, the plan is too complex" → INTENT: REJECT, REPO: NONE, ISSUE: NONE, REASON: the plan is too complex
-"what's running?" → INTENT: STATUS, REPO: NONE, ISSUE: NONE, REASON: NONE
-"run a security review on cliftonc/lastlight" → INTENT: SECURITY, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE
-"can you do a security review of https://github.com/cliftonc/lastlight" → INTENT: SECURITY, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE
-"could you triage https://github.com/foo/bar?" → INTENT: TRIAGE, REPO: foo/bar, ISSUE: NONE, REASON: NONE
-"please review https://github.com/foo/bar/pull/42" → INTENT: REVIEW, REPO: foo/bar, ISSUE: 42, REASON: NONE
-"can you review this?" with ISSUE TITLE "Add HTML sanitizer for messages" → INTENT: REVIEW, REPO: NONE, ISSUE: NONE, REASON: NONE
-"take a look at this PR when you get a chance" with ISSUE TITLE "Port fastify adapter" → INTENT: REVIEW, REPO: NONE, ISSUE: NONE, REASON: NONE
-"scan https://github.com/cliftonc/lastlight for vulnerabilities" → INTENT: SECURITY, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE
-"delete any files in ~/work/lastlight/docs" → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE
-"can you remove the old docs folder for me" (no ISSUE TITLE, no repo) → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE
-"build something cool" (no repo, no ISSUE TITLE) → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE`;
+function assembleClassifier(): ClassifierState {
+  const base = loadPromptTemplate("prompts/classifier.md");
+
+  const blocks = listAgentWorkflows()
+    .map((w) => w.classification)
+    .filter((c): c is NonNullable<typeof c> => !!c)
+    .sort(
+      (a, b) => intentOrderIndex(a.intent) - intentOrderIndex(b.intent) || a.intent.localeCompare(b.intent),
+    );
+
+  const categories = blocks.map((b) => b.description.replace(/\s+$/, "")).join("\n");
+  const examples = blocks.flatMap((b) => b.examples ?? []).join("\n");
+  const intentTokens = [
+    ...blocks.map((b) => intentToken(b.intent)),
+    ...RESERVED_CONTROL_INTENTS.map((i) => intentToken(i)),
+  ].join("|");
+
+  // Function replacers so a `$` in category/example text isn't treated as a
+  // String.replace special pattern.
+  const prompt = base
+    .replace("{{categories}}", () => categories)
+    .replace("{{examples}}", () => examples)
+    .replace("{{intentTokens}}", () => intentTokens);
+
+  const tokenToIntent = new Map<string, string>();
+  for (const i of RESERVED_CONTROL_INTENTS) tokenToIntent.set(intentToken(i), i);
+  for (const b of blocks) tokenToIntent.set(intentToken(b.intent), b.intent);
+
+  return { version: getAssetVersion(), prompt, tokenToIntent };
+}
+
+function classifierState(): ClassifierState {
+  if (!cachedState || cachedState.version !== getAssetVersion()) {
+    cachedState = assembleClassifier();
+  }
+  return cachedState;
+}
+
+/** The composed classifier system prompt (framing + all categories + format). */
+export function buildClassifierPrompt(): string {
+  return classifierState().prompt;
+}
+
+// ── repo/issue extraction ────────────────────────────────────────────────────
 
 /**
  * Extract owner/repo and optional issue/PR number from any github.com URL
@@ -179,74 +184,25 @@ function cleanRepoName(name: string): string {
   return name.replace(/[.,]+$/, "").replace(/\.git$/i, "");
 }
 
-const ISSUE_QUESTION_PROMPT = `You are a router for newly-opened GitHub issues.
-Decide whether the issue is a QUESTION or a WORK item.
-
-QUESTION — the issue asks for information, explanation, comparison, or guidance.
-The reporter wants an ANSWER, not code: "How does X work?", "What's the difference
-between X and Y?", "Is it possible to...?", "Which approach should I use?", "Why
-does X happen?". The deliverable is a written reply.
-
-WORK — the issue requests a code change: a bug report (something is broken and
-should be fixed) or a feature/enhancement request (build or change something).
-The deliverable is a commit or PR.
-
-Decide by the DOMINANT intent. If the issue asks a question AND also requests a
-change ("How do I do X — and could you add it?"), it is WORK: the change is the
-deliverable and triage should handle it. Only pure information requests are QUESTION.
-When genuinely unsure, answer WORK — triage is the safe default.
-
-Respond with exactly one word on its own line: QUESTION or WORK`;
-
 /**
  * Classify whether a newly-opened issue is a pure question (wants an answer)
- * versus a work item (wants a code change). Used by the router to send
- * question issues down the dedicated answer path instead of triage.
- *
- * Falls back to `false` (WORK → triage) on any error — triage is the safe
- * default, and a question that slips through still hits the issue-triage
- * skill's question safety net.
+ * versus a work item (wants a code change). Delegates to the main composed
+ * classifier — `answer.yaml` owns the QUESTION category — and maps the result:
+ * `question` intent → true (route to the answer workflow), anything else →
+ * false (route to triage, the safe default). `classifyComment` swallows its own
+ * errors and returns `chat`, so a transient failure lands on WORK/triage.
  */
-export async function classifyIssueIsQuestion(
+export async function classifyIssueIntent(
   title: string,
   body: string,
   options: ClassifierOptions = {},
 ): Promise<boolean> {
-  try {
-    const chat = options.chat ?? realChat;
-    const defaultFastModel = options.defaultFastModel ?? realDefaultFastModel;
-    const output = await chat(
-      options.model ?? defaultFastModel("classifier"),
-      [
-        { role: "system", content: ISSUE_QUESTION_PROMPT },
-        { role: "user", content: `TITLE: ${title}\n\nBODY: ${body}` },
-      ],
-      { maxTokens: 16 },
-    );
-    return /\bQUESTION\b/i.test(output);
-  } catch (err: any) {
-    console.error(`[classifier] Error classifying issue: ${err.message}`);
-    return false;
-  }
+  const combined = `${title}\n\n${body}`.trim();
+  const { intent } = await classifyComment(combined, { issueTitle: title }, options);
+  return intent === "question";
 }
 
-const ADDS_INFO_PROMPT = `You are deciding whether a new comment on a GitHub issue,
-written by the issue's reporter, should re-open triage of that issue.
-
-ADDS_INFO — the comment adds NEW substantive information that changes the problem
-statement: extra details, reproduction steps, environment specifics, a concrete
-example, clarification of the request, a scope change, or an answer to a question
-triage previously asked. The kind of comment that would make a maintainer re-read
-and re-classify the issue.
-
-NOISE — the comment adds nothing that changes triage: thanks, acknowledgement,
-agreement ("sounds good", "yes please"), a "+1"/me-too, a status update with no
-new specifics, a question directed back at the maintainer, or general chatter.
-
-When genuinely unsure, answer NOISE — re-triage should only fire on a clear
-addition of information.
-
-Respond with exactly one word on its own line: ADDS_INFO or NOISE`;
+const ADDS_INFO_PROMPT_PATH = "prompts/classify-adds-info.md";
 
 /**
  * Decide whether a reporter's comment adds substantive information that should
@@ -271,7 +227,7 @@ export async function classifyCommentAddsInfo(
     const output = await chat(
       options.model ?? defaultFastModel("classifier"),
       [
-        { role: "system", content: ADDS_INFO_PROMPT },
+        { role: "system", content: loadPromptTemplate(ADDS_INFO_PROMPT_PATH) },
         { role: "user", content: userPrompt },
       ],
       { maxTokens: 16 },
@@ -285,7 +241,7 @@ export async function classifyCommentAddsInfo(
 
 /**
  * Classify a GitHub/Slack comment's intent and extract a repo reference.
- * Falls back to intent=action on any error (safe default).
+ * Falls back to intent=chat on any error (safe default).
  */
 export async function classifyComment(
   commentBody: string,
@@ -300,10 +256,11 @@ export async function classifyComment(
     const resolvedOptions = typeof options === "string" ? { model: options } : options;
     const chat = resolvedOptions.chat ?? realChat;
     const defaultFastModel = resolvedOptions.defaultFastModel ?? realDefaultFastModel;
+    const { prompt, tokenToIntent } = classifierState();
     const output = await chat(
       resolvedOptions.model ?? defaultFastModel("classifier"),
       [
-        { role: "system", content: CLASSIFIER_PROMPT },
+        { role: "system", content: prompt },
         { role: "user", content: userPrompt },
       ],
       { maxTokens: 128 },
@@ -311,27 +268,11 @@ export async function classifyComment(
 
     const upper = output.trim().toUpperCase();
 
-    const intentMap: Record<string, CommentIntent> = {
-      BUILD: "build",
-      EXPLORE: "explore",
-      QUESTION: "question",
-      TRIAGE: "triage",
-      REVIEW: "review",
-      SECURITY: "security",
-      VERIFY: "verify",
-      QATEST: "qa-test",
-      DEMO: "demo",
-      APPROVE: "approve",
-      REJECT: "reject",
-      STATUS: "status",
-      RESET: "reset",
-      CHAT: "chat",
-    };
-
-    // Match INTENT line
+    // Match INTENT line, mapping the emitted token back to an intent via the
+    // dynamically-composed vocabulary. Unknown token → chat (safe default).
     const intentMatch = upper.match(/INTENT:\s*(\w+)/);
     const intent: CommentIntent = intentMatch
-      ? (intentMap[intentMatch[1]] ?? "chat")
+      ? (tokenToIntent.get(intentMatch[1]) ?? "chat")
       : "chat";
 
     // Extract repo from "REPO: owner/name" line. If the classifier didn't

--- a/src/workflows/CLAUDE.md
+++ b/src/workflows/CLAUDE.md
@@ -9,7 +9,7 @@ should require **only a YAML file** in `workflows/`, no runner changes.
 
 | File | Role |
 |---|---|
-| `schema.ts` | Zod schema for `AgentWorkflowDefinition`, `PhaseDefinition`, `PhaseLoop`, `GenericLoop`, `CronWorkflowDefinition`. Source of truth for what a YAML file is allowed to contain. |
+| `schema.ts` | Zod schema for `AgentWorkflowDefinition`, `PhaseDefinition`, `PhaseLoop`, `GenericLoop`, `CronWorkflowDefinition`. Source of truth for what a YAML file is allowed to contain. Also home to the optional top-level `classification:` block (`intent`/`description`/`examples`) — how a workflow contributes its category to the composed intent classifier and claims a routable intent (issue #164) — plus `RESERVED_CONTROL_INTENTS` + `intentToken()`. |
 | `loader.ts` | Reads `workflows/*.yaml`, validates against the schema, caches parsed definitions. `getWorkflow(name)` is the only lookup the rest of the code uses. |
 | `templates.ts` | Mustache-ish template engine. Handles `{{branch}}`, `{{issueDir}}`, `{{contextSnapshot}}`, `{{models.architect}}`, `{{phaseOutputs.guardrails.output}}`, list iteration, and `unless_*` clauses. |
 | `simple.ts` | Top-of-stack entry: `runSimpleWorkflow(workflowName, request, …)`. Picks the trigger id, builds the template context, creates or reuses a `workflow_runs` row, then calls `runWorkflow`. |

--- a/src/workflows/loader.ts
+++ b/src/workflows/loader.ts
@@ -5,6 +5,8 @@ import {
   AgentWorkflowSchema,
   CronWorkflowSchema,
   phaseSkillNames,
+  intentToken,
+  RESERVED_CONTROL_INTENTS,
   type AgentWorkflowDefinition,
   type CronWorkflowDefinition,
 } from "./schema.js";
@@ -39,6 +41,14 @@ const cronCache = new Map<string, CronWorkflowDefinition>();
 const agentOrigins = new Map<string, WorkflowOrigin>();
 const cronOrigins = new Map<string, WorkflowOrigin>();
 let cachePopulated = false;
+
+/**
+ * Bumped every time the asset layers change (reconfigure / cache clear). Lets
+ * downstream consumers that derive state from the workflow set — notably the
+ * classifier's composed prompt + intent vocabulary — cheaply detect staleness
+ * without a cross-layer import or a callback registry. Read via `getAssetVersion()`.
+ */
+let assetVersion = 0;
 
 function emptyDisabled(): DisabledConfig {
   return { workflows: [], crons: [], prompts: [], skills: [], agentContext: [] };
@@ -106,6 +116,12 @@ export function clearWorkflowCache(): void {
   agentOrigins.clear();
   cronOrigins.clear();
   cachePopulated = false;
+  assetVersion++;
+}
+
+/** Monotonic counter bumped on every asset-layer reconfigure / cache clear. */
+export function getAssetVersion(): number {
+  return assetVersion;
 }
 
 function loadYamlFile(filePath: string): unknown {
@@ -188,6 +204,20 @@ export function getCronWorkflows(): CronWorkflowDefinition[] {
 export function listAgentWorkflows(): AgentWorkflowDefinition[] {
   populateCache();
   return Array.from(agentCache.values());
+}
+
+/**
+ * The enabled workflow that claims a given classifier intent via its
+ * `classification.intent`, if any. Backs the router's data-driven fallback: an
+ * intent the router's bespoke switch doesn't handle routes to its owning
+ * workflow. Returns undefined for control intents and unclaimed tokens.
+ */
+export function getWorkflowByIntent(intent: string): AgentWorkflowDefinition | undefined {
+  populateCache();
+  for (const def of agentCache.values()) {
+    if (def.classification?.intent === intent) return def;
+  }
+  return undefined;
 }
 
 export function getWorkflowOrigin(name: string): WorkflowOrigin | undefined {
@@ -351,6 +381,50 @@ export function validateAssets(routes?: RouteConfig): void {
   for (const [cronName, def] of cronCache) {
     if (!agentCache.has(def.workflow)) {
       throw new Error(`Cron "${cronName}" targets missing or disabled workflow: ${def.workflow}`);
+    }
+  }
+
+  // Classifier `classification` blocks: each declared intent must be unique
+  // across workflows (two owners would make routing/parsing ambiguous), must
+  // not shadow a reserved control intent (approve/reject/status/reset/chat —
+  // the harness owns those), and its derived prompt token must be collision-free
+  // (e.g. `qa-test` and `qa_test` both → QATEST). A base classifier template
+  // must also exist to compose into. This runs at boot so a bad overlay fails
+  // fast instead of on the first classified event.
+  const controlIntents = new Set<string>(RESERVED_CONTROL_INTENTS);
+  const intentOwner = new Map<string, string>();
+  const tokenOwner = new Map<string, string>();
+  let anyClassification = false;
+  for (const [wfName, def] of agentCache) {
+    const c = def.classification;
+    if (!c) continue;
+    anyClassification = true;
+    if (controlIntents.has(c.intent)) {
+      throw new Error(
+        `Workflow "${wfName}" classification.intent "${c.intent}" is a reserved control intent (${[...controlIntents].join(", ")})`,
+      );
+    }
+    const prevIntent = intentOwner.get(c.intent);
+    if (prevIntent) {
+      throw new Error(
+        `Workflows "${prevIntent}" and "${wfName}" both claim classifier intent "${c.intent}" — an intent must have exactly one owning workflow`,
+      );
+    }
+    intentOwner.set(c.intent, wfName);
+    const token = intentToken(c.intent);
+    const prevToken = tokenOwner.get(token);
+    if (prevToken) {
+      throw new Error(
+        `Workflows "${prevToken}" and "${wfName}" derive the same classifier token "${token}" from different intents — rename one classification.intent`,
+      );
+    }
+    tokenOwner.set(token, wfName);
+  }
+  if (anyClassification) {
+    try {
+      resolvePromptPath("prompts/classifier.md");
+    } catch (err: unknown) {
+      throw new Error(`Classifier base template prompts/classifier.md: ${(err as Error).message}`);
     }
   }
 

--- a/src/workflows/schema.ts
+++ b/src/workflows/schema.ts
@@ -377,6 +377,29 @@ export type OutputRule = z.infer<typeof OutputRuleSchema>;
 // The `kind` field is purely a categorization label used by the dashboard
 // (e.g. to group runs by purpose). The runner ignores it.
 
+/**
+ * Intents owned by the harness itself (workflow gates / session control), not by
+ * any workflow. A workflow's `classification.intent` may not claim one of these.
+ * The classifier keeps their category text + examples in its base prompt template.
+ */
+export const RESERVED_CONTROL_INTENTS = [
+  "approve",
+  "reject",
+  "status",
+  "reset",
+  "chat",
+] as const;
+
+/**
+ * Uppercase prompt token for an intent — the string the classifier emits on its
+ * `INTENT:` line and parses back. `qa-test` → `QATEST`, `incident` → `INCIDENT`.
+ * Kept here (workflows layer) so the loader's validation and the classifier's
+ * prompt/parser derive tokens the same way.
+ */
+export function intentToken(intent: string): string {
+  return intent.toUpperCase().replace(/-/g, "");
+}
+
 export const AgentWorkflowSchema = z.object({
   /** Categorization label — e.g. "build", "triage", "review", "health". Free string. */
   kind: z.string().default("agent"),
@@ -406,6 +429,27 @@ export const AgentWorkflowSchema = z.object({
    */
   final_message: z.string().optional(),
   variables: z.record(z.string(), z.string()).optional(),
+  /**
+   * How the free-text intent classifier should route to this workflow. When
+   * present, this workflow contributes one category to the composed classifier
+   * prompt (`src/engine/screen/classifier.ts`) AND claims the `intent` token:
+   * a comment/message the classifier tags with this intent routes here (via the
+   * router's `getWorkflowByIntent` fallback) unless a bespoke router branch
+   * already handles that intent. The prompt token is derived from `intent`
+   * (`intent.toUpperCase().replace(/-/g, "")` — e.g. `qa-test` → `QATEST`).
+   * Validated in the loader: `intent` must be unique across workflows and must
+   * not collide with a reserved control intent (approve/reject/status/reset/chat).
+   */
+  classification: z
+    .object({
+      /** Intent token this workflow owns (e.g. "build", "qa-test", "incident"). */
+      intent: z.string(),
+      /** The category paragraph, conventionally prefixed with its UPPER token. */
+      description: z.string(),
+      /** Optional one-line classifier examples (verbatim lines for the prompt). */
+      examples: z.array(z.string()).optional(),
+    })
+    .optional(),
   phases: z.array(PhaseDefinitionSchema),
 });
 

--- a/tests/engine/classifier.test.ts
+++ b/tests/engine/classifier.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import { classifyComment, classifyIssueIsQuestion, extractGithubRefFromText } from "#src/engine/screen/classifier.js";
+import {
+  buildClassifierPrompt,
+  classifyComment,
+  classifyIssueIntent,
+  extractGithubRefFromText,
+} from "#src/engine/screen/classifier.js";
 
 describe("extractGithubRefFromText", () => {
   it("returns undefined when no github.com URL is present", () => {
@@ -116,10 +121,32 @@ describe("classifyComment — injected chat", () => {
   });
 });
 
-describe("classifyIssueIsQuestion — injected chat", () => {
+describe("buildClassifierPrompt — composition", () => {
+  it("includes every shipped workflow category + control intents", () => {
+    const prompt = buildClassifierPrompt();
+    // Workflow-owned categories (from each workflow's classification block).
+    for (const token of ["BUILD", "EXPLORE", "QUESTION", "TRIAGE", "REVIEW", "SECURITY", "VERIFY", "QATEST", "DEMO"]) {
+      expect(prompt).toContain(`${token} —`);
+    }
+    // Control categories stay in the base template.
+    for (const token of ["APPROVE", "REJECT", "STATUS", "RESET", "CHAT"]) {
+      expect(prompt).toContain(`${token} —`);
+    }
+    // The format line is composed from the full token set, workflow-first.
+    expect(prompt).toContain(
+      "INTENT: BUILD|EXPLORE|QUESTION|TRIAGE|REVIEW|SECURITY|VERIFY|QATEST|DEMO|APPROVE|REJECT|STATUS|RESET|CHAT",
+    );
+    // No unfilled slots remain.
+    expect(prompt).not.toContain("{{");
+    // A workflow-contributed example made it into the Examples block.
+    expect(prompt).toContain("INTENT: QATEST");
+  });
+});
+
+describe("classifyIssueIntent — injected chat", () => {
   it("returns true for a question issue", async () => {
-    const chat = vi.fn().mockResolvedValue("QUESTION");
-    const r = await classifyIssueIsQuestion(
+    const chat = vi.fn().mockResolvedValue("INTENT: QUESTION\nREPO: NONE\nISSUE: NONE\nREASON: NONE");
+    const r = await classifyIssueIntent(
       "How is lastlight different to Vercel Eve?",
       "Keen on a comparison.",
       { chat, defaultFastModel: () => "openai/test" },
@@ -131,13 +158,13 @@ describe("classifyIssueIsQuestion — injected chat", () => {
         expect.objectContaining({ role: "system" }),
         expect.objectContaining({ role: "user", content: expect.stringContaining("How is lastlight different") }),
       ]),
-      { maxTokens: 16 },
+      { maxTokens: 128 },
     );
   });
 
-  it("returns false for a work item", async () => {
-    const chat = vi.fn().mockResolvedValue("WORK");
-    const r = await classifyIssueIsQuestion("Crash on startup", "App throws on boot.", {
+  it("returns false for a work item (any non-question intent → triage)", async () => {
+    const chat = vi.fn().mockResolvedValue("INTENT: BUILD\nREPO: NONE\nISSUE: NONE\nREASON: NONE");
+    const r = await classifyIssueIntent("Crash on startup", "App throws on boot.", {
       chat,
       defaultFastModel: () => "openai/test",
     });
@@ -147,7 +174,7 @@ describe("classifyIssueIsQuestion — injected chat", () => {
   it("defaults to false (work → triage) when chat rejects", async () => {
     const chat = vi.fn().mockRejectedValue(new Error("network"));
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const r = await classifyIssueIsQuestion("Anything", "body", { chat, defaultFastModel: () => "openai/test" });
+    const r = await classifyIssueIntent("Anything", "body", { chat, defaultFastModel: () => "openai/test" });
     expect(r).toBe(false);
     expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();

--- a/tests/engine/llm.test.ts
+++ b/tests/engine/llm.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { callLlm, chat, defaultFastModel, resolveProvider } from "#src/engine/llm.js";
 import { PROVIDER_ENV_KEYS } from "#src/providers.js";
+import { setRuntimeConfig, resetRuntimeConfigForTests, type LastLightConfig } from "#src/config/config.js";
 
 describe("resolveProvider", () => {
   it("prefers explicit provider prefix", () => {
@@ -41,8 +42,9 @@ describe("defaultFastModel", () => {
   beforeEach(() => {
     for (const key of PROVIDER_ENV_KEYS) delete process.env[key];
     delete process.env.OPENCODE_MODELS;
+    resetRuntimeConfigForTests();
   });
-  afterEach(() => { process.env = { ...ORIGINAL_ENV }; });
+  afterEach(() => { process.env = { ...ORIGINAL_ENV }; resetRuntimeConfigForTests(); });
 
   it("picks an OpenAI model when only OPENAI_API_KEY is set", () => {
     process.env.OPENAI_API_KEY = "k";
@@ -83,6 +85,26 @@ describe("defaultFastModel", () => {
     process.env.OPENAI_API_KEY = "k";
     process.env.OPENCODE_MODELS = "not-json";
     expect(defaultFastModel("classifier")).toMatch(/^openai\//);
+  });
+
+  it("resolves a per-task model from the config models map", () => {
+    process.env.ANTHROPIC_API_KEY = "k";
+    setRuntimeConfig({
+      models: { default: "anthropic/claude-sonnet-4-6", classifier: "anthropic/claude-haiku-4-5-20251001" },
+    } as unknown as LastLightConfig);
+    expect(defaultFastModel("classifier")).toBe("anthropic/claude-haiku-4-5-20251001");
+    // A task without its own entry never inherits models.default — it stays on
+    // the provider fast model.
+    expect(defaultFastModel("screener")).toMatch(/^anthropic\//);
+    expect(defaultFastModel("screener")).not.toBe("anthropic/claude-sonnet-4-6");
+  });
+
+  it("prefers the config models map over provider order", () => {
+    process.env.ANTHROPIC_API_KEY = "k";
+    setRuntimeConfig({
+      models: { default: "anthropic/x", classifier: "openai/pinned-mini" },
+    } as unknown as LastLightConfig);
+    expect(defaultFastModel("classifier")).toBe("openai/pinned-mini");
   });
 });
 

--- a/tests/engine/router.test.ts
+++ b/tests/engine/router.test.ts
@@ -4,9 +4,21 @@ import type { EventEnvelope } from '#src/connectors/types.js';
 // Mock the classifier and screener before importing router
 vi.mock('#src/engine/screen/classifier.js', () => ({
   classifyComment: vi.fn().mockResolvedValue({ intent: 'chat' }),
-  classifyIssueIsQuestion: vi.fn().mockResolvedValue(false),
+  classifyIssueIntent: vi.fn().mockResolvedValue(false),
   classifyCommentAddsInfo: vi.fn().mockResolvedValue(false),
+  // Real well-known set so the router's novel-intent fallback only fires for
+  // intents outside it (issue #164).
+  WELL_KNOWN_INTENTS: new Set([
+    'build', 'explore', 'question', 'triage', 'review', 'security',
+    'verify', 'qa-test', 'demo', 'approve', 'reject', 'status', 'reset', 'chat',
+  ]),
 }));
+// Mock only the loader's getWorkflowByIntent (the router's data-driven fallback
+// lookup); keep everything else real.
+vi.mock('#src/workflows/loader.js', async () => {
+  const actual = await vi.importActual<typeof import('#src/workflows/loader.js')>('#src/workflows/loader.js');
+  return { ...actual, getWorkflowByIntent: vi.fn().mockReturnValue(undefined) };
+});
 vi.mock('#src/engine/screen/screen.js', async () => {
   const actual = await vi.importActual<typeof import('#src/engine/screen/screen.js')>('#src/engine/screen/screen.js');
   return {
@@ -16,13 +28,15 @@ vi.mock('#src/engine/screen/screen.js', async () => {
 });
 
 import { routeEvent, type RouterDeps } from '#src/engine/router.js';
-import { classifyComment, classifyCommentAddsInfo, classifyIssueIsQuestion } from '#src/engine/screen/classifier.js';
+import { classifyComment, classifyCommentAddsInfo, classifyIssueIntent } from '#src/engine/screen/classifier.js';
+import { getWorkflowByIntent } from '#src/workflows/loader.js';
 import { screenForInjection } from '#src/engine/screen/screen.js';
 import { setRuntimeConfig, resetRuntimeConfigForTests, type LastLightConfig } from '#src/config/config.js';
 
 const mockClassifyComment = vi.mocked(classifyComment);
 const mockClassifyAddsInfo = vi.mocked(classifyCommentAddsInfo);
-const mockClassifyIssue = vi.mocked(classifyIssueIsQuestion);
+const mockClassifyIssue = vi.mocked(classifyIssueIntent);
+const mockGetWorkflowByIntent = vi.mocked(getWorkflowByIntent);
 const mockScreen = vi.mocked(screenForInjection);
 
 /** Build RouterDeps with a stubbed workflow-run store. `buildStarted` controls
@@ -42,6 +56,11 @@ beforeEach(() => {
   // Default: new issues are work items (→ triage). Question-routing tests
   // opt in by overriding this per-case.
   mockClassifyIssue.mockResolvedValue(false);
+  // Default: no workflow claims a novel intent (fallback disabled). Overlay
+  // fallback tests opt in per-case. Reset call history too — one case asserts
+  // the fallback was NOT consulted.
+  mockGetWorkflowByIntent.mockReset();
+  mockGetWorkflowByIntent.mockReturnValue(undefined);
   setRuntimeConfig({
     managedRepos: ['cliftonc/drizzle-cube', 'cliftonc/drizby', 'cliftonc/lastlight'],
   } as unknown as LastLightConfig);
@@ -308,6 +327,42 @@ describe('routeEvent — comment.created', () => {
     }
   });
 
+  it('routes a novel overlay intent on an issue to its owning workflow (issue #164)', async () => {
+    mockClassifyComment.mockResolvedValue({ intent: 'incident' });
+    mockGetWorkflowByIntent.mockReturnValue({ name: 'incident' } as any);
+    const result = await routeEvent(makeEnvelope({
+      type: 'comment.created',
+      body: '@last-light declare an incident for this outage',
+      authorAssociation: 'MEMBER',
+      issueNumber: 11,
+    }));
+    expect(result.action).toBe('handler');
+    if (result.action === 'handler') {
+      expect(result.handler).toBe('incident');
+      expect(result.context._routeKey).toBe('intent.incident');
+    }
+    expect(mockGetWorkflowByIntent).toHaveBeenCalledWith('incident');
+  });
+
+  it('does NOT fire the fallback for a well-known intent excluded on this surface', async () => {
+    // `explore` is a no-op on a PR → pr-comment; the fallback must not divert it
+    // even if a workflow claims the intent.
+    mockClassifyComment.mockResolvedValue({ intent: 'explore' });
+    mockGetWorkflowByIntent.mockReturnValue({ name: 'explore' } as any);
+    const result = await routeEvent(makeEnvelope({
+      type: 'comment.created',
+      body: '@last-light explore this',
+      authorAssociation: 'MEMBER',
+      issueNumber: 12,
+      prNumber: 8,
+    }));
+    expect(result.action).toBe('handler');
+    if (result.action === 'handler') {
+      expect(result.handler).toBe('pr-comment');
+    }
+    expect(mockGetWorkflowByIntent).not.toHaveBeenCalled();
+  });
+
   it('passes issue title to classifier on comment events', async () => {
     mockClassifyComment.mockResolvedValue({ intent: 'build' });
     await routeEvent(makeEnvelope({
@@ -400,6 +455,29 @@ describe('routeEvent — message events (classifier-driven)', () => {
   it('routes build intent with unmanaged repo to reply', async () => {
     mockClassifyComment.mockResolvedValue({ intent: 'build', repo: 'unknown/repo' });
     const result = await routeEvent(makeEnvelope({ type: 'message', body: 'build unknown/repo' }));
+    expect(result.action).toBe('reply');
+    if (result.action === 'reply') {
+      expect(result.message).toContain('unknown/repo');
+    }
+  });
+
+  it('routes a novel overlay intent to its owning workflow (issue #164)', async () => {
+    mockClassifyComment.mockResolvedValue({ intent: 'incident', repo: 'cliftonc/lastlight' });
+    mockGetWorkflowByIntent.mockReturnValue({ name: 'incident' } as any);
+    const result = await routeEvent(makeEnvelope({ type: 'message', body: 'declare an incident on cliftonc/lastlight' }));
+    expect(result.action).toBe('handler');
+    if (result.action === 'handler') {
+      expect(result.handler).toBe('incident');
+      expect(result.context._routeKey).toBe('intent.incident');
+      expect(result.context.repo).toBe('cliftonc/lastlight');
+    }
+    expect(mockGetWorkflowByIntent).toHaveBeenCalledWith('incident');
+  });
+
+  it('rejects a novel overlay intent naming an unmanaged repo', async () => {
+    mockClassifyComment.mockResolvedValue({ intent: 'incident', repo: 'unknown/repo' });
+    mockGetWorkflowByIntent.mockReturnValue({ name: 'incident' } as any);
+    const result = await routeEvent(makeEnvelope({ type: 'message', body: 'incident on unknown/repo' }));
     expect(result.action).toBe('reply');
     if (result.action === 'reply') {
       expect(result.message).toContain('unknown/repo');

--- a/tests/fork-cli.test.ts
+++ b/tests/fork-cli.test.ts
@@ -40,6 +40,8 @@ function makeCore(): string {
   for (const p of ["architect", "reviewer", "fix", "re-reviewer"]) {
     writeFileSync(join(core, "workflows", "prompts", `${p}.md`), `# ${p} (core)`);
   }
+  writeFileSync(join(core, "workflows", "prompts", "classifier.md"), "# classifier base (core)");
+  writeFileSync(join(core, "workflows", "prompts", "classify-adds-info.md"), "# adds-info (core)");
   writeFileSync(join(core, "skills", "building", "SKILL.md"), "# building (core)");
   writeFileSync(join(core, "skills", "building", "scripts", "run.sh"), "echo hi");
   writeFileSync(join(core, "skills", "code-review", "SKILL.md"), "# code-review (core)");
@@ -144,6 +146,18 @@ describe("fork-cli", () => {
     // …and every agent-context file.
     expect(existsSync(join(inst, "agent-context", "soul.md"))).toBe(true);
     expect(existsSync(join(inst, "agent-context", "rules.md"))).toBe(true);
+    // …and the base classifier prompts.
+    expect(existsSync(join(inst, "workflows", "prompts", "classifier.md"))).toBe(true);
+    expect(existsSync(join(inst, "workflows", "prompts", "classify-adds-info.md"))).toBe(true);
+  });
+
+  it("forks the base classifier prompts via the `classifier` target", async () => {
+    await fork(["classifier"], { home: core });
+    const prompts = join(core, "instance", "workflows", "prompts");
+    expect(readFileSync(join(prompts, "classifier.md"), "utf8")).toContain("classifier base");
+    expect(existsSync(join(prompts, "classify-adds-info.md"))).toBe(true);
+    // The classifier target must NOT drag in unrelated workflow assets.
+    expect(existsSync(join(core, "instance", "workflows", "build.yaml"))).toBe(false);
   });
 
   it("forks all agent-context files via the explicit target", async () => {

--- a/tests/workflows/loader.test.ts
+++ b/tests/workflows/loader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { setWorkflowDir, clearWorkflowCache, getWorkflow, getCronWorkflows, loadPromptTemplate, resolveSkillPaths } from "#src/workflows/loader.js";
+import { setWorkflowDir, clearWorkflowCache, getWorkflow, getCronWorkflows, loadPromptTemplate, resolveSkillPaths, getWorkflowByIntent, validateAssets } from "#src/workflows/loader.js";
 
 function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), "loader-test-"));
@@ -485,5 +485,68 @@ describe("loader — resolveSkillPaths", () => {
 
   it("throws on path-traversal in skill name", () => {
     expect(() => resolveSkillPaths(["#src/etc/passwd"])).toThrow(/Invalid skill name/);
+  });
+});
+
+describe("loader — classifier classification blocks (issue #164)", () => {
+  let dir: string;
+
+  function writeClassifierTemplate(): void {
+    mkdirSync(join(dir, "prompts"), { recursive: true });
+    writeFileSync(join(dir, "prompts", "classifier.md"), "{{categories}}\n{{examples}}\n{{intentTokens}}");
+  }
+
+  function writeWorkflow(name: string, intent: string): void {
+    writeFileSync(
+      join(dir, `${name}.yaml`),
+      `
+kind: agent
+name: ${name}
+classification:
+  intent: ${intent}
+  description: "${intent.toUpperCase()} — do a ${intent}"
+phases:
+  - name: phase_0
+    type: context
+`.trim(),
+    );
+  }
+
+  beforeEach(() => {
+    dir = makeTempDir();
+    setWorkflowDir(dir);
+    clearWorkflowCache();
+    writeClassifierTemplate();
+  });
+
+  it("getWorkflowByIntent returns the owning workflow", () => {
+    writeWorkflow("incident-flow", "incident");
+    expect(getWorkflowByIntent("incident")?.name).toBe("incident-flow");
+    expect(getWorkflowByIntent("nope")).toBeUndefined();
+  });
+
+  it("validateAssets passes for a single classification owner", () => {
+    writeWorkflow("incident-flow", "incident");
+    expect(() => validateAssets()).not.toThrow();
+  });
+
+  it("validateAssets rejects two workflows claiming the same intent", () => {
+    writeWorkflow("incident-a", "incident");
+    writeWorkflow("incident-b", "incident");
+    expect(() => validateAssets()).toThrow(/both claim classifier intent "incident"/);
+  });
+
+  it("validateAssets rejects a workflow claiming a reserved control intent", () => {
+    writeWorkflow("chatty", "chat");
+    expect(() => validateAssets()).toThrow(/reserved control intent/);
+  });
+
+  it("validateAssets rejects a missing base classifier template", () => {
+    // Remove the template written by beforeEach by pointing at a fresh dir.
+    dir = makeTempDir();
+    setWorkflowDir(dir);
+    clearWorkflowCache();
+    writeWorkflow("incident-flow", "incident");
+    expect(() => validateAssets()).toThrow(/classifier\.md/);
   });
 });

--- a/workflows/answer.yaml
+++ b/workflows/answer.yaml
@@ -1,5 +1,12 @@
 kind: answer
 name: answer
+classification:
+  intent: question
+  description: |
+    QUESTION — The user is asking a substantive INFORMATIONAL question that warrants research to answer well: "how does X work?", "what's the difference between X and Y?", "how does <repo> compare to <other tool>?", "is it possible to do Z?", "why does X happen?". The deliverable is an ANSWER, not code and not a spec. QUESTION is for real questions that benefit from reading docs/code or searching the web — NOT casual chat, thanks, or one-word replies (those stay CHAT). EXPLORE shapes a NEW idea into a spec; QUESTION answers an EXISTING question about how something works or compares.
+  examples:
+    - '"how does cliftonc/lastlight compare to Vercel''s Eve framework?" → INTENT: QUESTION, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE'
+    - '"what''s the difference between a sandbox phase and a chat session in cliftonc/lastlight?" → INTENT: QUESTION, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE'
 description: |
   Answer a question issue directly. Used when a newly-opened issue asks for
   information, an explanation, or a comparison rather than a code change — the

--- a/workflows/build.yaml
+++ b/workflows/build.yaml
@@ -1,5 +1,20 @@
 kind: build
 name: build
+classification:
+  intent: build
+  description: |
+    BUILD — The user is ASKING YOU (the bot) to make code changes NOW in a GitHub repo: implement a feature, fix a bug, create/send a PR, resolve an issue with code. BUILD requires a GitHub target — either an explicit repo reference (owner/name or github.com URL) in the message, OR an ISSUE TITLE context line indicating the comment is a reply on an existing issue/PR. If neither is present, classify as CHAT — local filesystem operations ("delete files in ~/foo", "clean up my downloads"), shell-style commands, or vague "build something" with no target are NOT BUILD.
+      BUILD is a REQUEST for NEW work directed at you. A comment that merely REPORTS work the human has ALREADY done is NOT BUILD — it is CHAT. Tells: past-tense ("fixed", "done", "implemented", "added a test", "pushed a fix", "handled it"), a reference to a commit the human made ("addressed in <sha>", "see commit abc123"), thanking you, or explaining/justifying a change they made in response to your review. These are status reports, not requests — classify them CHAT even when the comment is on a PR and even when it @-mentions you. Only classify BUILD when the human asks you to do NEW work (imperative request: "fix X", "now also handle Y", "can you update Z").
+  examples:
+    - '"build cliftonc/drizzle-cube#42" → INTENT: BUILD, REPO: cliftonc/drizzle-cube, ISSUE: 42, REASON: NONE'
+    - '"lets build this!" with ISSUE TITLE "Security Review" → INTENT: BUILD, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"go ahead" with ISSUE TITLE "Add CSV export" → INTENT: BUILD, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"now also handle the GET /sql case please" with ISSUE TITLE "Port adapters" → INTENT: BUILD, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"Thanks @last-light — addressed in 49ccadf. Fixed the nested body in the core and added a regression test; point 3 is intentional, confirmed with the maintainer." with ISSUE TITLE "Port fastify/hono/nextjs adapters" → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"done, pushed a fix for the type error in 1a2b3c4" with ISSUE TITLE "Fix build" → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"delete any files in ~/work/lastlight/docs" → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"can you remove the old docs folder for me" (no ISSUE TITLE, no repo) → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"build something cool" (no repo, no ISSUE TITLE) → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE'
 description: "Architect -> Executor -> Reviewer build cycle"
 trigger: build
 # Render progress as a single in-place task-list comment/message that updates

--- a/workflows/demo.yaml
+++ b/workflows/demo.yaml
@@ -1,5 +1,12 @@
 kind: demo
 name: demo
+classification:
+  intent: demo
+  description: |
+    DEMO — The user wants you to record a DEMO VIDEO of a feature/PR: "demo this", "record a demo of the new dashboard", "make a video showing the dark-mode toggle", "show me a before/after of the fix". The deliverable is a short screen-recorded mp4 of the running web UI, not a pass/fail report and not a verdict. Prefer DEMO over QATEST/VERIFY when the user explicitly asks for a recording, a video, or "show"/"demo" rather than to test or confirm a behaviour.
+  examples:
+    - '"record a demo of this" with ISSUE TITLE "Add dark-mode toggle" → INTENT: DEMO, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"make a short before/after video of the fix on cliftonc/foo#12" → INTENT: DEMO, REPO: cliftonc/foo, ISSUE: 12, REASON: NONE'
 description: |
   Record a short demo VIDEO of a PR or feature and post it. Drives the repo's
   web UI in a real headless browser, screen-records the session, and composites

--- a/workflows/explore.yaml
+++ b/workflows/explore.yaml
@@ -1,5 +1,13 @@
 kind: explore
 name: explore
+classification:
+  intent: explore
+  description: |
+    EXPLORE — The user wants help shaping an idea BEFORE writing code: "help me think through X", "brainstorm Y", "spec this out", "explore an idea for Z". A bare "explore" / "explore this" / "let's explore" is also EXPLORE — especially as a reply on an existing issue (ISSUE TITLE present), where the implicit object is the issue's idea. EXPLORE = shape the idea / write a spec; BUILD = write the code now.
+  examples:
+    - '"explore adding webhooks to cliftonc/drizby" → INTENT: EXPLORE, REPO: cliftonc/drizby, ISSUE: NONE, REASON: NONE'
+    - '"explore" with ISSUE TITLE "Feature: Allow configuration of otel endpoints" → INTENT: EXPLORE, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"explore this" with ISSUE TITLE "Add webhook support" → INTENT: EXPLORE, REPO: NONE, ISSUE: NONE, REASON: NONE'
 description: |
   Socratic idea-shaping loop: read the existing issue/thread for context, ask
   clarifying questions in a reply-gated loop until the shape is clear, then

--- a/workflows/issue-triage.yaml
+++ b/workflows/issue-triage.yaml
@@ -1,5 +1,11 @@
 kind: triage
 name: issue-triage
+classification:
+  intent: triage
+  description: |
+    TRIAGE — The user wants to scan/triage issues on a repo: "triage cliftonc/repo", "scan for new issues", "can you triage <repo>?".
+  examples:
+    - '"could you triage https://github.com/foo/bar?" → INTENT: TRIAGE, REPO: foo/bar, ISSUE: NONE, REASON: NONE'
 description: |
   Triage a GitHub issue: read it, classify it, label it, and act on stale or
   incomplete reports. Single agent invocation, no PR creation.

--- a/workflows/pr-review.yaml
+++ b/workflows/pr-review.yaml
@@ -1,5 +1,13 @@
 kind: review
 name: pr-review
+classification:
+  intent: review
+  description: |
+    REVIEW — The user wants a code review. Either repo-wide ("review cliftonc/repo", "check PRs", "can you review PRs on <repo>?") OR, when the comment is a reply on a PR (ISSUE TITLE present), a request to review THIS PR: "review this", "can you review this?", "please review", "take a look at this PR", "give this a review". The deliverable is a formal PR review (inline comments on the diff). Prefer REVIEW over CHAT whenever there's a clear "review"/"take a look" request on a PR.
+  examples:
+    - '"please review https://github.com/foo/bar/pull/42" → INTENT: REVIEW, REPO: foo/bar, ISSUE: 42, REASON: NONE'
+    - '"can you review this?" with ISSUE TITLE "Add HTML sanitizer for messages" → INTENT: REVIEW, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"take a look at this PR when you get a chance" with ISSUE TITLE "Port fastify adapter" → INTENT: REVIEW, REPO: NONE, ISSUE: NONE, REASON: NONE'
 description: |
   Review a single GitHub pull request: read the diff, check for issues, and
   post structured feedback. Does not run a full build cycle and does not

--- a/workflows/prompts/classifier.md
+++ b/workflows/prompts/classifier.md
@@ -1,0 +1,60 @@
+You are a router for messages directed at a GitHub/Slack bot.
+Classify the user's message into exactly one category, and extract any repository or issue references.
+
+Categories:
+{{categories}}
+APPROVE — The user is approving a pending gate: "approve", "go ahead", "looks good, continue", "yes proceed".
+REJECT — The user is rejecting a pending gate: "reject", "abort", "cancel this", "no don't proceed". Extract any reason given.
+STATUS — The user wants to know what's running: "status", "what's running", "any tasks active?".
+RESET — The user wants to start a fresh session: "new", "reset", "start over", "fresh session".
+CHAT — Anything else: questions, conversation, thanks, general discussion, and status reports of work the human already did ("thanks, fixed in <sha>", "addressed your comments", "done — added tests").
+
+Polite or question phrasings are still clear intent. "Can you do a security review of X?",
+"could you triage <repo>?", "please review PRs on <repo>" are SECURITY, TRIAGE, REVIEW
+respectively — not CHAT. The "prefer CHAT when ambiguous" rule only applies when the
+message has no clear action verb. Presence of "security review", "triage", "review PRs",
+"scan for vulnerabilities", etc. makes the intent unambiguous regardless of politeness.
+
+When ambiguous between EXPLORE and CHAT, prefer CHAT. Only pick EXPLORE when the user is explicitly asking for brainstorming / spec-shaping / design exploration — OR gives a bare "explore"/"explore this" command (see the issue-reply rule below), which is unambiguous, not chat.
+When ambiguous between QUESTION and CHAT, prefer CHAT — only pick QUESTION for a substantive informational question that genuinely benefits from research (reading docs/code or a web search). Casual conversation, greetings, thanks, and trivial one-liners stay CHAT.
+When ambiguous between BUILD and CHAT, prefer CHAT.
+When ambiguous between VERIFY/QATEST and REVIEW/CHAT, prefer the existing category — only pick VERIFY or QATEST when the user explicitly asks you to test, run, confirm, or exercise a behaviour/flow.
+When ambiguous between DEMO and VERIFY/QATEST, prefer the existing category — only pick DEMO when the user explicitly asks for a video, a recording, or to "demo"/"show" the feature.
+When ambiguous between APPROVE/REJECT and CHAT, prefer CHAT — only classify as APPROVE/REJECT when the intent is clearly about a pending workflow gate.
+
+Repo extraction: always emit REPO as "owner/name" (never a URL). If the message contains
+a github.com URL, convert it: https://github.com/cliftonc/lastlight → cliftonc/lastlight.
+URL paths like /issues/42 or /pull/5 should populate ISSUE as well.
+
+When the message is a reply on an existing issue/PR, the issue title is provided
+as ISSUE TITLE. Short imperative replies classify by their verb, with the issue
+as the implicit object — the "prefer CHAT when ambiguous" rule does NOT apply to
+a clear command directed at the issue's subject:
+- "lets build this", "build it", "go ahead", "ship it", "do it", "implement
+  this", "make it so" → BUILD (write the code now).
+- "explore", "explore this", "let's explore", "think this through", "spec this
+  out", "brainstorm this" → EXPLORE (shape the idea / write a spec first).
+- "review this", "can you review this", "please review", "take a look",
+  "give this a review" → REVIEW (do a real code review now; on a PR this means
+  review the current PR's diff).
+A bare command word ("explore", "build", "review") on an existing issue/PR is a
+clear command, NOT ambiguous chat.
+This verb rule is for IMPERATIVE requests only. A PR/issue reply that REPORTS
+already-completed work or responds to your review — "thanks, fixed in <sha>",
+"addressed in commit abc123", "done, added a regression test", "this is
+intentional, confirmed with the maintainer" — is a status report, NOT a
+command. Classify it CHAT regardless of the ISSUE TITLE or an @mention. Do not
+let words like "fix"/"build"/"add" inside a past-tense report flip it to BUILD.
+
+Respond in exactly this format (each on its own line, no extra text):
+INTENT: {{intentTokens}}
+REPO: owner/name or NONE
+ISSUE: number or NONE
+REASON: text or NONE
+
+Examples:
+{{examples}}
+"thanks, that makes sense!" → INTENT: CHAT, REPO: NONE, ISSUE: NONE, REASON: NONE
+"approve" → INTENT: APPROVE, REPO: NONE, ISSUE: NONE, REASON: NONE
+"reject, the plan is too complex" → INTENT: REJECT, REPO: NONE, ISSUE: NONE, REASON: the plan is too complex
+"what's running?" → INTENT: STATUS, REPO: NONE, ISSUE: NONE, REASON: NONE

--- a/workflows/prompts/classify-adds-info.md
+++ b/workflows/prompts/classify-adds-info.md
@@ -1,0 +1,17 @@
+You are deciding whether a new comment on a GitHub issue,
+written by the issue's reporter, should re-open triage of that issue.
+
+ADDS_INFO — the comment adds NEW substantive information that changes the problem
+statement: extra details, reproduction steps, environment specifics, a concrete
+example, clarification of the request, a scope change, or an answer to a question
+triage previously asked. The kind of comment that would make a maintainer re-read
+and re-classify the issue.
+
+NOISE — the comment adds nothing that changes triage: thanks, acknowledgement,
+agreement ("sounds good", "yes please"), a "+1"/me-too, a status update with no
+new specifics, a question directed back at the maintainer, or general chatter.
+
+When genuinely unsure, answer NOISE — re-triage should only fire on a clear
+addition of information.
+
+Respond with exactly one word on its own line: ADDS_INFO or NOISE

--- a/workflows/qa-test.yaml
+++ b/workflows/qa-test.yaml
@@ -1,5 +1,12 @@
 kind: qa-test
 name: qa-test
+classification:
+  intent: qa-test
+  description: |
+    QATEST — The user wants you to drive an app or CLI through a flow and report step-level pass/fail: "qa test the signup flow", "run through login and tell me what breaks", "smoke-test the CLI commands", "exercise the checkout flow". The deliverable is a step-by-step QA report. Prefer QATEST over VERIFY when it's a multi-step flow to exercise rather than a single claim to confirm.
+  examples:
+    - '"qa test the login flow on this PR" with ISSUE TITLE "Add login" → INTENT: QATEST, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"run through the signup flow and tell me what breaks" with ISSUE TITLE "Signup v2" → INTENT: QATEST, REPO: NONE, ISSUE: NONE, REASON: NONE'
 description: |
   Run an automated QA flow against a repo's CLI or locally-served app and report
   step-level pass/fail with evidence. It installs and runs the code in the

--- a/workflows/security-review.yaml
+++ b/workflows/security-review.yaml
@@ -1,5 +1,13 @@
 kind: health
 name: security-review
+classification:
+  intent: security
+  description: |
+    SECURITY — The user wants a security scan/review of a repo: "security review cliftonc/repo", "scan for vulnerabilities", "check security", "can you do a security review of <repo>?".
+  examples:
+    - '"run a security review on cliftonc/lastlight" → INTENT: SECURITY, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE'
+    - '"can you do a security review of https://github.com/cliftonc/lastlight" → INTENT: SECURITY, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE'
+    - '"scan https://github.com/cliftonc/lastlight for vulnerabilities" → INTENT: SECURITY, REPO: cliftonc/lastlight, ISSUE: NONE, REASON: NONE'
 description: |
   Scan the target repository for security issues using open-source tools
   (npm audit, semgrep, gitleaks) plus AI code review. Files ONE summary

--- a/workflows/verify.yaml
+++ b/workflows/verify.yaml
@@ -1,5 +1,13 @@
 kind: verify
 name: verify
+classification:
+  intent: verify
+  description: |
+    VERIFY — The user wants you to TEST whether a specific claim or behaviour is actually true and report the evidence: "verify that the rate limiter blocks", "does this PR really fix the crash?", "confirm X actually works", "check that Y no longer happens", "prove the --fork flag creates a new session". The deliverable is a CONFIRMED/REFUTED verdict backed by RUNNING the code — not a code change and not a code-quality review. Prefer VERIFY over REVIEW when the user wants proof a behaviour works/is fixed, rather than an assessment of the diff.
+  examples:
+    - '"verify that the --fork flag creates a new session in cliftonc/foo#12" → INTENT: VERIFY, REPO: cliftonc/foo, ISSUE: 12, REASON: NONE'
+    - '"does this actually fix the crash?" with ISSUE TITLE "Fix null deref on resize" → INTENT: VERIFY, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    - '"can you confirm the rate limiter actually blocks at 100 req/s?" with ISSUE TITLE "Add rate limiter" → INTENT: VERIFY, REPO: NONE, ISSUE: NONE, REASON: NONE'
 description: |
   Verify a behaviour claim against a repo or PR and report whether the evidence
   confirms or refutes it. It installs and runs the code in the sandbox, captures


### PR DESCRIPTION
Closes #164.

## Problem
The intent classifier — which routes all free-text input (GitHub comments, Slack messages) to a workflow — was a single hardcoded ~95-line `CLASSIFIER_PROMPT` string in `src/engine/screen/classifier.ts`. It baked together framing, 14 category descriptions, and disambiguation rules, so it was **not forkable** per-deployment and **did not scale** as workflows were added (every new workflow meant hand-editing the one string).

## What this does
The classifier prompt is now **composed at runtime**, not hardcoded:

- **Forkable base template** — `workflows/prompts/classifier.md`, resolved through the existing overlay/`resolvePromptPath` machinery (overlay wins by name). Holds the framing, global disambiguation rules, the 5 harness-owned control categories (`APPROVE`/`REJECT`/`STATUS`/`RESET`/`CHAT`), and the `{{categories}}`/`{{examples}}`/`{{intentTokens}}` slots.
- **Per-workflow categories** — each of the 9 intent-owning workflows carries its own `classification:` block (`intent` + `description` + `examples`) in its YAML. `build.yaml` owns `BUILD`, `pr-review.yaml` owns `REVIEW`, etc.

### An overlay workflow "just works"
The token→intent parser vocabulary **and** an intent→workflow `getWorkflowByIntent` router fallback are derived from the same `classification:` blocks. So adding a workflow (even in an overlay) — e.g. `instance/workflows/incident.yaml` with `classification.intent: incident` — teaches the classifier the `INCIDENT` category, the parser the token, and the router the route, **with no core edit**.

The router's existing per-intent branches are untouched (they encode context-dependent logic like `build`→`pr-fix` on a PR); only the trailing generic default falls back to `getWorkflowByIntent`, and only for intents *outside* the well-known set — so `explore`-on-a-PR etc. keep their exact behavior.

**Limitation (documented):** a brand-new intent routes to its single owning workflow uniformly across GitHub issue/PR/Slack; surface-specific routing still needs `routes.*` overrides.

### Consolidation
- `ISSUE_QUESTION_PROMPT` retired — new issues route through the main classifier's `QUESTION` intent (`answer.yaml` owns it) via `classifyIssueIntent`.
- The re-triage gate is now the forkable `workflows/prompts/classify-adds-info.md`.
- `lastlight fork classifier` forks the base prompts (per-workflow category text already travels with `fork <workflow>`).
- Loader `validateAssets` rejects duplicate / reserved-control / token-colliding `classification.intent` at boot; composition is memoized against a loader asset-version counter (no cross-layer import).

## Verification
- Full suite: **1061 passed, 7 skipped**; `tsc --noEmit` clean.
- **Prompt parity** confirmed — the composed output is structurally byte-identical to the original 14-category prompt.
- **End-to-end `incident` acceptance check** run against a real overlay (no mocks): category composes in, token line includes `INCIDENT`, `getWorkflowByIntent` resolves, `classifyComment` parses it.
- New tests: classifier composition + `classifyIssueIntent`; loader validation + `getWorkflowByIntent`; router novel-intent fallback (GitHub + Slack, incl. unmanaged-repo rejection + a "well-known excluded" negative case); fork-cli `classifier` target.

## Docs
- This repo: `spec/05-router.md`, `spec/06-workflow-engine.md`, `CLAUDE.md`, `src/workflows/CLAUDE.md`.
- Separate `lastlight-www` repo: `docs/cli.astro` gets `lastlight fork classifier` (committed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)