### PR TITLE
feat(identity): user identity records + actor logging (#205)

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -75,6 +75,9 @@ WEBHOOK_SECRET=your-webhook-secret
 # SLACK_OAUTH_CLIENT_SECRET=
 # SLACK_OAUTH_REDIRECT_URI=http://localhost:8644/admin/api/oauth/slack/callback
 # SLACK_ALLOWED_WORKSPACE=your-team-id-or-domain   # Restrict to one workspace
+# Bot scope users:read.email (setup step, issue #205): grant it + re-consent the
+# Slack app so a Slack-initiated run/approval matches the acting user to their
+# GitHub identity by email. Without it, matching degrades to the Slack username.
 
 # ── GitHub OAuth (optional — enables "Login with GitHub" on dashboard) ──
 # Uses the existing GitHub App's OAuth capability. Client ID is shown on the

--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -662,8 +662,16 @@ Slack (optional):
 - `SLACK_ALLOWED_USERS` — comma-separated user ids allowlist
 - `SLACK_OAUTH_CLIENT_ID`, `SLACK_OAUTH_CLIENT_SECRET`,
   `SLACK_OAUTH_REDIRECT_URI` — enables "Login with Slack" on the dashboard
-  (OIDC via arctic, uses `openid.connect.userInfo`)
+  (OIDC via arctic, uses `openid.connect.userInfo`; requests the `email` scope
+  so a Slack login matches a `users` row by email — issue #205)
 - `SLACK_ALLOWED_WORKSPACE` — restrict OAuth login to one team_id / domain
+- **Slack bot scope `users:read.email`** (setup step, issue #205) — required
+  for **Slack → user matching**: with it, `web.users.info` returns the user's
+  `profile.email` so a Slack-initiated run/approval attributes to the same
+  person as their GitHub login (matched by email, `slack_user_id` linked lazily).
+  Without it the address is omitted and matching silently degrades to the Slack
+  username fallback — never blocking the run. Re-consent the Slack app after
+  adding the scope.
 - `CHAT_BATCH_DEBOUNCE_MS` — settle window (ms, default 700; 0 disables) the
   `MessageBatcher` waits to coalesce a bursty thread before routing, so a rapid
   multi-message burst is classified once and answered as one ordered turn

--- a/apps/server/dashboard/src/api.ts
+++ b/apps/server/dashboard/src/api.ts
@@ -127,9 +127,24 @@ export interface WorkflowRun {
   startedAt: string;
   updatedAt: string;
   finishedAt?: string;
+  /** Who ORIGINALLY triggered the run — a GitHub login / Slack handle / cli / cron (issue #205). */
+  triggeredBy?: string;
+  /** Coarse actor category for {@link triggeredBy}. */
+  triggerActorType?: "github" | "slack" | "cli" | "cron" | "admin" | "system";
   /** Roll-up totals across the run's executions — present on the runs list. */
   totalCostUsd?: number;
   totalTokens?: number;
+}
+
+/**
+ * The `users`-table identity for a run's actor (issue #205), returned alongside
+ * the single-run detail endpoint. Null for cron/system/password actors or a
+ * login with no matching row — the UI then falls back to the raw login string.
+ */
+export interface TriggeredByUser {
+  login?: string;
+  name?: string | null;
+  avatarUrl?: string | null;
 }
 
 /**
@@ -633,7 +648,10 @@ export const api = {
     );
   },
   workflowNames: () => req<{ names: string[] }>("/workflow-names"),
-  workflowRun: (id: string) => req<{ workflowRun: WorkflowRun }>(`/workflow-runs/${id}`),
+  workflowRun: (id: string) =>
+    req<{ workflowRun: WorkflowRun; triggeredByUser: TriggeredByUser | null }>(
+      `/workflow-runs/${id}`,
+    ),
   workflowRunExecutions: (id: string) =>
     req<{ executions: WorkflowRunExecution[] }>(`/workflow-runs/${id}/executions`),
   // All approvals (pending + resolved) for one run — powers the pipeline's

--- a/apps/server/dashboard/src/components/ActorChip.tsx
+++ b/apps/server/dashboard/src/components/ActorChip.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import {
+  UserCircleIcon,
+  ChatBubbleLeftRightIcon,
+  CommandLineIcon,
+  ClockIcon,
+  ShieldCheckIcon,
+  CpuChipIcon,
+} from "@heroicons/react/24/outline";
+import { GhLink } from "./GhLink";
+import type { WorkflowRun, TriggeredByUser } from "../api";
+
+type ActorType = NonNullable<WorkflowRun["triggerActorType"]>;
+
+/** Per-actor-type fallback icon (used when there's no avatar), + a tooltip label. */
+const ACTOR_META: Record<ActorType, { Icon: typeof UserCircleIcon; label: string }> = {
+  github: { Icon: UserCircleIcon, label: "GitHub" },
+  slack: { Icon: ChatBubbleLeftRightIcon, label: "Slack" },
+  cli: { Icon: CommandLineIcon, label: "CLI / API" },
+  cron: { Icon: ClockIcon, label: "Cron" },
+  admin: { Icon: ShieldCheckIcon, label: "Admin" },
+  system: { Icon: CpuChipIcon, label: "System" },
+};
+
+export interface ActorChipProps {
+  /** The raw actor handle (`workflow_runs.triggered_by`). */
+  login?: string;
+  /** Coarse actor category — drives the fallback icon + tooltip. */
+  actorType?: ActorType;
+  /** `users`-table enrichment (avatar + real name), when resolved. */
+  user?: TriggeredByUser | null;
+  /** `sm` (default) for list rows, `md` for the detail panel. */
+  size?: "sm" | "md";
+  className?: string;
+}
+
+/**
+ * Renders "who triggered this" (issue #205) as an icon/avatar + name chip. Uses
+ * the `users`-table avatar + real name when available, else the actor handle,
+ * else the actor-type label; falls back to a per-type icon when there's no
+ * avatar. GitHub actors link out to their profile.
+ */
+export function ActorChip({ login, actorType, user, size = "sm", className }: ActorChipProps) {
+  const [imgFailed, setImgFailed] = useState(false);
+
+  // Nothing to show at all — omit the chip entirely.
+  const display = user?.name || user?.login || login;
+  if (!display && !actorType) return null;
+
+  const meta = actorType ? ACTOR_META[actorType] : undefined;
+  const Icon = meta?.Icon ?? UserCircleIcon;
+  const dim = size === "md" ? "w-5 h-5" : "w-4 h-4";
+  const textCls = size === "md" ? "text-xs" : "text-2xs";
+  const avatarUrl = user?.avatarUrl && !imgFailed ? user.avatarUrl : null;
+
+  const glyph = avatarUrl ? (
+    <img
+      src={avatarUrl}
+      alt=""
+      className={`${dim} rounded-full shrink-0 object-cover`}
+      onError={() => setImgFailed(true)}
+    />
+  ) : (
+    <Icon className={`${dim} shrink-0 text-base-content/50`} />
+  );
+
+  const label = display ?? meta?.label ?? "";
+  const title = `Triggered by ${label}${meta ? ` (${meta.label})` : ""}`;
+
+  // GitHub actors with a login link out to their profile; everything else is
+  // plain text (Slack ids / cli / cron aren't GitHub-resolvable).
+  const body =
+    actorType === "github" && login ? (
+      <GhLink
+        href={`https://github.com/${encodeURIComponent(login)}`}
+        className={`${textCls} font-mono hover:underline truncate`}
+        title={title}
+      >
+        {label}
+      </GhLink>
+    ) : (
+      <span className={`${textCls} font-mono text-base-content/70 truncate`} title={title}>
+        {label}
+      </span>
+    );
+
+  return (
+    <span className={`inline-flex items-center gap-1 min-w-0 ${className ?? ""}`} title={title}>
+      {glyph}
+      {body}
+    </span>
+  );
+}

--- a/apps/server/dashboard/src/components/HomePage.tsx
+++ b/apps/server/dashboard/src/components/HomePage.tsx
@@ -17,6 +17,7 @@ import { useStatsSeries } from "../hooks/useDailyStats";
 import { useTheme } from "../hooks/useTheme";
 import { repoUrl, issueUrl, runRepoPath } from "../lib/githubLinks";
 import { GhLink } from "./GhLink";
+import { ActorChip } from "./ActorChip";
 import clsx from "clsx";
 
 type StatRange = "today" | "7d" | "30d";
@@ -425,6 +426,13 @@ function LiveActivitySection({
                   {run.workflowName}
                 </span>
                 <RunTarget run={run} />
+                {run.triggeredBy && (
+                  <ActorChip
+                    login={run.triggeredBy}
+                    actorType={run.triggerActorType}
+                    className="shrink-0 max-w-[8rem]"
+                  />
+                )}
                 <span className="text-base-content/50 shrink-0">{run.currentPhase}</span>
                 <span className="text-base-content/40 shrink-0">{timeAgo(run.startedAt)}</span>
               </div>
@@ -481,6 +489,13 @@ function RecentWorkflowsSection({
                     {run.workflowName}
                   </span>
                   <RunTarget run={run} />
+                  {run.triggeredBy && (
+                    <ActorChip
+                      login={run.triggeredBy}
+                      actorType={run.triggerActorType}
+                      className="shrink-0 max-w-[8rem]"
+                    />
+                  )}
                   {run.totalTokens ? (
                     <span className="text-base-content/40 font-mono shrink-0 tabular-nums" title="tokens">
                       {formatTokens(run.totalTokens)} tok

--- a/apps/server/dashboard/src/components/WorkflowList.tsx
+++ b/apps/server/dashboard/src/components/WorkflowList.tsx
@@ -8,6 +8,7 @@ import {
   MinusCircleIcon,
   ClockIcon,
   ArrowPathIcon,
+  QuestionMarkCircleIcon,
 } from "@heroicons/react/24/solid";
 import {
   api,
@@ -50,7 +51,8 @@ function elapsed(run: WorkflowRun): string {
 
 /** Status → solid icon + colour. Used both in the dense list rows and the
  *  detail-panel header (the text chip was too heavy). Title carries the word. */
-const STATUS_ICON: Record<WorkflowRun["status"], { Icon: typeof CheckCircleIcon; cls: string }> = {
+type StatusIconMeta = { Icon: typeof CheckCircleIcon; cls: string };
+const STATUS_ICON: Record<WorkflowRun["status"], StatusIconMeta> = {
   queued: { Icon: ClockIcon, cls: "text-base-content/50" },
   running: { Icon: ArrowPathIcon, cls: "text-info animate-spin" },
   paused: { Icon: PauseCircleIcon, cls: "text-warning" },
@@ -58,9 +60,13 @@ const STATUS_ICON: Record<WorkflowRun["status"], { Icon: typeof CheckCircleIcon;
   failed: { Icon: XCircleIcon, cls: "text-error" },
   cancelled: { Icon: MinusCircleIcon, cls: "text-base-content/40" },
 };
+// Neutral fallback so an unrecognised runtime status (e.g. a new server-side
+// status shipped before the dashboard) degrades gracefully instead of crashing
+// the list with a destructure-of-undefined TypeError.
+const STATUS_ICON_FALLBACK: StatusIconMeta = { Icon: QuestionMarkCircleIcon, cls: "text-base-content/40" };
 
 function StatusIcon({ status, className }: { status: WorkflowRun["status"]; className?: string }) {
-  const { Icon, cls } = STATUS_ICON[status];
+  const { Icon, cls } = STATUS_ICON[status] ?? STATUS_ICON_FALLBACK;
   return <Icon className={clsx("shrink-0", cls, className ?? "w-4 h-4")} title={status} />;
 }
 

--- a/apps/server/dashboard/src/components/WorkflowList.tsx
+++ b/apps/server/dashboard/src/components/WorkflowList.tsx
@@ -7,7 +7,9 @@ import {
   type WorkflowApproval,
   type WorkflowDefinition,
   type WorkflowRunExecution,
+  type TriggeredByUser,
 } from "../api";
+import { ActorChip } from "./ActorChip";
 import { WorkflowPipeline } from "./WorkflowPipeline";
 import { ApprovalBanner } from "./ApprovalBanner";
 import { PhaseDetailPanel } from "./PhaseDetailPanel";
@@ -52,6 +54,8 @@ function StatusBadge({ status }: { status: WorkflowRun["status"] }) {
 
 interface DetailPanelProps {
   run: WorkflowRun;
+  /** Resolved `users`-table identity for the run's actor (avatar/name), issue #205. */
+  triggeredByUser?: TriggeredByUser | null;
   approvals: WorkflowApproval[];
   onCancel: (id: string) => void;
   onRetry: (id: string) => void;
@@ -203,7 +207,7 @@ function ResizablePipeline({
 
 // ── Detail panel ────────────────────────────────────────────────────────
 
-function DetailPanel({ run, approvals, onCancel, onRetry, onApprovalResponded, onOpenDefinition }: DetailPanelProps) {
+function DetailPanel({ run, triggeredByUser, approvals, onCancel, onRetry, onApprovalResponded, onOpenDefinition }: DetailPanelProps) {
   const canCancel = run.status === "running" || run.status === "paused";
   const canRetry = run.status === "failed";
 
@@ -406,7 +410,18 @@ function DetailPanel({ run, approvals, onCancel, onRetry, onApprovalResponded, o
         )}
       </div>
 
-      <div className="text-2xs text-base-content/40 font-mono flex gap-4 shrink-0">
+      <div className="text-2xs text-base-content/40 font-mono flex gap-4 items-center flex-wrap shrink-0">
+        {run.triggeredBy && (
+          <span className="inline-flex items-center gap-1">
+            <span className="opacity-60">triggered by</span>
+            <ActorChip
+              login={run.triggeredBy}
+              actorType={run.triggerActorType}
+              user={triggeredByUser}
+              size="md"
+            />
+          </span>
+        )}
         <span>started {timeAgo(run.startedAt)} ago</span>
         <span>elapsed {elapsed(run)}</span>
         {run.finishedAt && <span>finished {timeAgo(run.finishedAt)} ago</span>}
@@ -589,19 +604,29 @@ export function WorkflowList({ timeRange, query, repo, onOpenDefinition }: Workf
   // wins for the live-updating fields (status / phaseHistory refresh on poll);
   // we only splice the immutable `context` in from the detail fetch below.
   const [detailRun, setDetailRun] = useState<WorkflowRun | null>(null);
+  // The run actor's `users`-table identity (avatar + real name), issue #205.
+  // Comes only from the detail fetch (the list payload has just the login).
+  const [triggeredByUser, setTriggeredByUser] = useState<TriggeredByUser | null>(null);
   useEffect(() => {
     if (!selectedId) {
       setDetailRun(null);
+      setTriggeredByUser(null);
       return;
     }
     let cancelled = false;
     api
       .workflowRun(selectedId)
       .then((res) => {
-        if (!cancelled) setDetailRun(res.workflowRun);
+        if (!cancelled) {
+          setDetailRun(res.workflowRun);
+          setTriggeredByUser(res.triggeredByUser);
+        }
       })
       .catch(() => {
-        if (!cancelled) setDetailRun(null);
+        if (!cancelled) {
+          setDetailRun(null);
+          setTriggeredByUser(null);
+        }
       });
     return () => {
       cancelled = true;
@@ -723,6 +748,13 @@ export function WorkflowList({ timeRange, query, repo, onOpenDefinition }: Workf
                       {hasApprovals && (
                         <span className="badge badge-warning badge-xs">approval</span>
                       )}
+                      {run.triggeredBy && (
+                        <ActorChip
+                          login={run.triggeredBy}
+                          actorType={run.triggerActorType}
+                          className="max-w-[8rem]"
+                        />
+                      )}
                       <span className="ml-auto text-base-content/40 font-mono">
                         {timeAgo(run.startedAt)} ago
                       </span>
@@ -804,6 +836,7 @@ export function WorkflowList({ timeRange, query, repo, onOpenDefinition }: Workf
         {selectedRun ? (
           <DetailPanel
             run={selectedRun}
+            triggeredByUser={detailForSelected ? triggeredByUser : null}
             approvals={approvals}
             onCancel={handleCancel}
             onRetry={handleRetry}

--- a/apps/server/dashboard/src/components/WorkflowList.tsx
+++ b/apps/server/dashboard/src/components/WorkflowList.tsx
@@ -2,6 +2,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
 import { DocumentMagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import {
+  CheckCircleIcon,
+  XCircleIcon,
+  PauseCircleIcon,
+  MinusCircleIcon,
+  ClockIcon,
+  ArrowPathIcon,
+} from "@heroicons/react/24/solid";
+import {
   api,
   type WorkflowRun,
   type WorkflowApproval,
@@ -40,16 +48,20 @@ function elapsed(run: WorkflowRun): string {
   return `${m}m${s}s`;
 }
 
-function StatusBadge({ status }: { status: WorkflowRun["status"] }) {
-  const cls = clsx("badge badge-xs font-mono", {
-    "badge-neutral": status === "queued",
-    "badge-info": status === "running",
-    "badge-warning": status === "paused",
-    "badge-success": status === "succeeded",
-    "badge-error": status === "failed",
-    "badge-ghost": status === "cancelled",
-  });
-  return <span className={cls}>{status}</span>;
+/** Status → solid icon + colour. Used both in the dense list rows and the
+ *  detail-panel header (the text chip was too heavy). Title carries the word. */
+const STATUS_ICON: Record<WorkflowRun["status"], { Icon: typeof CheckCircleIcon; cls: string }> = {
+  queued: { Icon: ClockIcon, cls: "text-base-content/50" },
+  running: { Icon: ArrowPathIcon, cls: "text-info animate-spin" },
+  paused: { Icon: PauseCircleIcon, cls: "text-warning" },
+  succeeded: { Icon: CheckCircleIcon, cls: "text-success" },
+  failed: { Icon: XCircleIcon, cls: "text-error" },
+  cancelled: { Icon: MinusCircleIcon, cls: "text-base-content/40" },
+};
+
+function StatusIcon({ status, className }: { status: WorkflowRun["status"]; className?: string }) {
+  const { Icon, cls } = STATUS_ICON[status];
+  return <Icon className={clsx("shrink-0", cls, className ?? "w-4 h-4")} title={status} />;
 }
 
 interface DetailPanelProps {
@@ -366,7 +378,7 @@ function DetailPanel({ run, triggeredByUser, approvals, onCancel, onRetry, onApp
             <DocumentMagnifyingGlassIcon className="w-4 h-4" />
           </button>
         )}
-        <StatusBadge status={run.status} />
+        <StatusIcon status={run.status} className="w-5 h-5" />
         {run.repo &&
           (() => {
             const href = repoUrl(runRepoPath(run));
@@ -391,6 +403,22 @@ function DetailPanel({ run, triggeredByUser, approvals, onCancel, onRetry, onApp
               <span className={cls}>#{run.issueNumber}</span>
             );
           })()}
+        {run.triggeredBy && (
+          <span className="inline-flex items-center gap-1.5 text-xs text-base-content/50">
+            <span className="opacity-70">by</span>
+            <ActorChip
+              login={run.triggeredBy}
+              actorType={run.triggerActorType}
+              user={triggeredByUser}
+              size="md"
+            />
+          </span>
+        )}
+        <span className="text-2xs text-base-content/40 font-mono flex gap-3 items-center">
+          <span>started {timeAgo(run.startedAt)} ago</span>
+          <span>elapsed {elapsed(run)}</span>
+          {run.finishedAt && <span>finished {timeAgo(run.finishedAt)} ago</span>}
+        </span>
         {canCancel && (
           <button
             className="btn btn-xs btn-error btn-outline ml-auto"
@@ -408,23 +436,6 @@ function DetailPanel({ run, triggeredByUser, approvals, onCancel, onRetry, onApp
             Retry
           </button>
         )}
-      </div>
-
-      <div className="text-2xs text-base-content/40 font-mono flex gap-4 items-center flex-wrap shrink-0">
-        {run.triggeredBy && (
-          <span className="inline-flex items-center gap-1">
-            <span className="opacity-60">triggered by</span>
-            <ActorChip
-              login={run.triggeredBy}
-              actorType={run.triggerActorType}
-              user={triggeredByUser}
-              size="md"
-            />
-          </span>
-        )}
-        <span>started {timeAgo(run.startedAt)} ago</span>
-        <span>elapsed {elapsed(run)}</span>
-        {run.finishedAt && <span>finished {timeAgo(run.finishedAt)} ago</span>}
       </div>
 
       <ApprovalBanner approvals={pendingApprovals} onResponded={handleApprovalResponded} />
@@ -718,8 +729,6 @@ export function WorkflowList({ timeRange, query, repo, onOpenDefinition }: Workf
           <ul className="flex-1">
             {visibleRuns.map((run) => {
               const active = run.id === selectedId;
-              const canCancel = run.status === "running" || run.status === "paused";
-              const canRetry = run.status === "failed";
               const hasApprovals = approvals.some((a) => a.workflowRunId === run.id);
               return (
                 <li key={run.id} className="border-b border-base-300/40">
@@ -737,79 +746,61 @@ export function WorkflowList({ timeRange, query, repo, onOpenDefinition }: Workf
                       }
                     }}
                     className={clsx(
-                      "w-full flex flex-col items-start gap-0.5 py-2 px-3 text-left transition-colors cursor-pointer",
+                      "w-full flex flex-col items-start gap-0.5 py-1.5 px-3 text-left transition-colors cursor-pointer border-l-2 -ml-px pl-[10px]",
                       active
-                        ? "bg-primary/15 border-l-2 border-l-primary -ml-px pl-[10px]"
-                        : "hover:bg-base-300/40 border-l-2 border-l-transparent -ml-px pl-[10px]",
+                        ? "bg-primary/15 border-l-primary"
+                        : clsx("border-l-transparent", {
+                            // Faint red tint on unselected FAILED rows so they
+                            // stand out at a glance; everything else is neutral.
+                            "bg-error/10 hover:bg-error/20": run.status === "failed",
+                            "hover:bg-base-300/40": run.status !== "failed",
+                          }),
                     )}
                   >
                     <div className="flex items-center gap-2 w-full text-2xs">
-                      <StatusBadge status={run.status} />
+                      <span className="text-xs font-medium truncate text-base-content/90 min-w-0">
+                        {run.workflowName}
+                      </span>
                       {hasApprovals && (
-                        <span className="badge badge-warning badge-xs">approval</span>
+                        <span className="badge badge-warning badge-xs shrink-0">approval</span>
                       )}
-                      {run.triggeredBy && (
-                        <ActorChip
-                          login={run.triggeredBy}
-                          actorType={run.triggerActorType}
-                          className="max-w-[8rem]"
-                        />
-                      )}
-                      <span className="ml-auto text-base-content/40 font-mono">
+                      <span className="ml-auto text-base-content/40 font-mono shrink-0">
                         {timeAgo(run.startedAt)} ago
                       </span>
+                      <StatusIcon status={run.status} />
                     </div>
-                    <div className="text-sm truncate w-full text-base-content/90">
-                      {run.workflowName}
-                    </div>
-                    <div className="flex gap-2 text-2xs text-base-content/40 w-full font-mono">
+                    <div className="flex items-center gap-2 text-2xs text-base-content/40 w-full font-mono">
                       {run.repo &&
                         (() => {
                           const href = repoUrl(runRepoPath(run));
                           return href ? (
-                            <GhLink href={href} className="truncate" title={`Open ${run.repo} on GitHub`}>
+                            <GhLink href={href} className="truncate shrink-0" title={`Open ${run.repo} on GitHub`}>
                               {run.repo}
                             </GhLink>
                           ) : (
-                            <span className="truncate">{run.repo}</span>
+                            <span className="truncate shrink-0">{run.repo}</span>
                           );
                         })()}
                       {run.issueNumber &&
                         (() => {
                           const href = issueUrl(runRepoPath(run), run.issueNumber, run.workflowName);
                           return href ? (
-                            <GhLink href={href} title={`Open #${run.issueNumber} on GitHub`}>
+                            <GhLink href={href} className="shrink-0" title={`Open #${run.issueNumber} on GitHub`}>
                               #{run.issueNumber}
                             </GhLink>
                           ) : (
-                            <span>#{run.issueNumber}</span>
+                            <span className="shrink-0">#{run.issueNumber}</span>
                           );
                         })()}
-                      <span className="ml-auto">{run.currentPhase}</span>
+                      {run.triggeredBy && (
+                        <ActorChip
+                          login={run.triggeredBy}
+                          actorType={run.triggerActorType}
+                          className="min-w-0"
+                        />
+                      )}
+                      <span className="ml-auto shrink-0">{run.currentPhase}</span>
                     </div>
-                    {canCancel && (
-                      <button
-                        className="btn btn-2xs btn-error btn-outline mt-1 h-5 min-h-0 text-2xs"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleCancel(run.id);
-                        }}
-                      >
-                        cancel
-                      </button>
-                    )}
-                    {canRetry && (
-                      <button
-                        className="btn btn-2xs btn-warning btn-outline mt-1 h-5 min-h-0 text-2xs"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleRetry(run.id);
-                        }}
-                        title="Re-run from the phase that failed, keeping the same context"
-                      >
-                        retry
-                      </button>
-                    )}
                   </div>
                 </li>
               );

--- a/apps/server/spec/10-state.md
+++ b/apps/server/spec/10-state.md
@@ -56,7 +56,9 @@ CREATE TABLE IF NOT EXISTS executions (
   api_duration_ms INTEGER,
   stop_reason TEXT,
   workflow_run_id TEXT,                 -- → workflow_runs.id
-  output_text TEXT                      -- large final assistant text for loop iterations
+  output_text TEXT,                     -- large final assistant text for loop iterations
+  triggered_by TEXT,                    -- actor login/handle (joins users.login)
+  trigger_actor_type TEXT               -- github | slack | cli | cron | admin | system
 );
 
 CREATE INDEX idx_executions_trigger      ON executions(trigger_type, trigger_id);
@@ -91,7 +93,9 @@ CREATE TABLE IF NOT EXISTS workflow_runs (
   restart_count INTEGER NOT NULL DEFAULT 0,
   started_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
-  finished_at TEXT
+  finished_at TEXT,
+  triggered_by TEXT,                           -- ORIGINAL trigger's actor (joins users.login)
+  trigger_actor_type TEXT                       -- github | slack | cli | cron | admin | system
 );
 
 CREATE INDEX idx_workflow_runs_trigger      ON workflow_runs(trigger_id, status);
@@ -200,6 +204,48 @@ CREATE TABLE IF NOT EXISTS workflow_overrides (
 ```
 
 Workflow-level kill switch. Absence of a row = enabled by default.
+
+### `users`
+
+First-class user identity, populated on every dashboard login (GitHub +
+Slack OAuth). An **additive enrichment** table: every actor column elsewhere
+(`workflow_runs.triggered_by`, `executions.triggered_by`,
+`workflow_approvals.responded_by`, `cron_overrides.updated_by`) stays free-text
+`login`, and this row is resolved by LEFT-JOIN on `login`. `github_id` /
+`slack_user_id` are the stable upsert keys; `email` is captured as the future
+outbound-email hook (nothing sends yet) and is **indexed but NOT unique**
+(shared corporate mailboxes + many null Slack-only rows would collide a UNIQUE
+constraint).
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,                    -- randomUUID
+  github_id INTEGER UNIQUE,               -- stable numeric id (upsert key); null for Slack-only rows
+  login TEXT UNIQUE,                      -- GitHub login = the soft join key used everywhere
+  name TEXT,
+  email TEXT,                             -- future email hook; indexed, NOT unique
+  avatar_url TEXT,
+  slack_user_id TEXT UNIQUE,              -- U… id, linked lazily on Slack match
+  is_blocked INTEGER NOT NULL DEFAULT 0,
+  email_is_placeholder INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  last_login_at TEXT
+);
+CREATE INDEX idx_users_login ON users(login);
+CREATE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_users_slack ON users(slack_user_id);
+```
+
+The GitHub OAuth callback upserts on `github_id` (falling back to
+`GET /user/emails` for the primary+verified address when the profile hides it);
+the Slack OAuth callback and the Slack connector match a user's email to an
+existing row and link `slack_user_id` onto it (else create a Slack-only row).
+The verified GitHub `login` then rides the session HMAC token so actor-hardcoded
+routes attribute an action to a real person. **Actor semantics:** a run's
+`triggered_by` is the ORIGINAL trigger; retry / cancel / approve actors land on
+the append-only `executions` ledger (and `workflow_approvals.responded_by`),
+never overwriting the run's origin value. See `src/state/user-store.ts`.
 
 ### `messaging_sessions` + `messaging_messages`
 
@@ -358,6 +404,7 @@ session recreation after timeouts.
 | `WorkflowRunStore` — `workflow_runs` + atomic lifecycle ops | `src/state/workflow-run-store.ts` |
 | `ExecutionStore` — `executions` table + ops | `src/state/execution-store.ts` |
 | `ApprovalStore` — `workflow_approvals` | `src/state/approval-store.ts` |
+| `UserStore` — `users` identity + Slack/email matching | `src/state/user-store.ts` |
 | JSONL writer + envelope translation | `src/engine/event-shim.ts` |
 | Sandbox session reader (dashboard) | `src/admin/SessionReader.ts` |
 | Chat session reader (dashboard, DB-backed) | `src/admin/ChatSessionReader.ts` |

--- a/apps/server/src/admin/auth.ts
+++ b/apps/server/src/admin/auth.ts
@@ -11,9 +11,19 @@ const TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
  */
 export const REFRESH_GRACE_SECONDS = 60 * 60 * 24 * 7; // 7 days
 
-export function createToken(secret: string, method?: "password" | "slack" | "github"): string {
-  const payload: { exp: number; method?: string } = { exp: Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS };
+export function createToken(
+  secret: string,
+  method?: "password" | "slack" | "github",
+  login?: string,
+): string {
+  const payload: { exp: number; method?: string; login?: string } = {
+    exp: Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS,
+  };
   if (method) payload.method = method;
+  // The verified identity (issue #205) rides the token so actor-hardcoded
+  // routes can attribute an action to a real person. Additive and
+  // signature-compatible — existing 2-arg callers mint tokens without it.
+  if (login) payload.login = login;
   const payloadB64 = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const sig = crypto.createHmac("sha256", secret).update(payloadB64).digest("base64url");
   return `${payloadB64}.${sig}`;
@@ -59,6 +69,9 @@ export function verifyTokenForRefresh(token: string, secret: string): boolean {
 export interface TokenPayload {
   exp: number;
   method?: "password" | "slack" | "github";
+  /** Verified identity carried across refresh (issue #205) — GitHub login, or
+   *  a Slack-matched login. Absent for password / unmatched-Slack sessions. */
+  login?: string;
 }
 
 /**
@@ -78,6 +91,7 @@ export function decodeToken(token: string): TokenPayload | null {
       exp: payload.exp,
       method:
         method === "password" || method === "slack" || method === "github" ? method : undefined,
+      login: typeof payload.login === "string" ? payload.login : undefined,
     };
   } catch {
     return null;
@@ -136,6 +150,21 @@ export function authMiddleware(enabled: boolean, secret: string) {
     if (!token || !verifyToken(token, secret)) {
       return c.json({ error: "unauthorized" }, 401);
     }
+    // Surface the verified identity to downstream routes (issue #205). The
+    // single seam every actor-hardcoded route reads via {@link actorFromContext}.
+    c.set("actorLogin", decodeToken(token)?.login);
     return next();
   };
+}
+
+/**
+ * The authenticated actor's GitHub login for the current request, or undefined
+ * when auth is disabled / the session carries no login (password or
+ * unmatched-Slack). `authMiddleware` sets `actorLogin` after verifying the
+ * token; this is the single read seam every actor-hardcoded admin route uses to
+ * attribute an action (retry / cancel / approve / CLI build) to a real person,
+ * falling back to `cli`/`admin` when it returns undefined (issue #205).
+ */
+export function actorFromContext(c: Context): string | undefined {
+  return c.get("actorLogin") as string | undefined;
 }

--- a/apps/server/src/admin/routes.ts
+++ b/apps/server/src/admin/routes.ts
@@ -1077,7 +1077,21 @@ export function createAdminRoutes(
     const id = c.req.param("id");
     const run = db.runs.getRun(id);
     if (!run) return c.json({ error: "workflow run not found" }, 404);
-    return c.json({ workflowRun: run });
+    // Enrich the actor with the `users` identity (issue #205) so the run
+    // detail panel can show a real name + avatar, not just the raw login.
+    // Best-effort: absent (password/cron/system actors, or a login with no
+    // row) → the panel falls back to the login string + actor-type badge.
+    const triggeredByUser = run.triggeredBy ? db.users.findByLogin(run.triggeredBy) : null;
+    return c.json({
+      workflowRun: run,
+      triggeredByUser: triggeredByUser
+        ? {
+            login: triggeredByUser.login,
+            name: triggeredByUser.name,
+            avatarUrl: triggeredByUser.avatarUrl,
+          }
+        : null,
+    });
   });
 
   // List the executions belonging to a workflow run, ordered by start time.

--- a/apps/server/src/admin/routes.ts
+++ b/apps/server/src/admin/routes.ts
@@ -17,7 +17,7 @@ import {
   getContainerLogs,
   streamContainerLogs,
 } from "./docker.js";
-import { authMiddleware, createToken, verifyTokenForRefresh, decodeToken } from "./auth.js";
+import { authMiddleware, createToken, verifyTokenForRefresh, decodeToken, actorFromContext } from "./auth.js";
 import { Cron } from "croner";
 import type { CronScheduler } from "../cron/scheduler.js";
 import { enumerateOverlayAssets } from "lastlight-shared/overlay-assets";
@@ -558,7 +558,8 @@ export function createAdminRoutes(
     if (!current || !verifyTokenForRefresh(current, config.adminSecret)) {
       return c.json({ error: "unauthorized" }, 401);
     }
-    return c.json({ token: createToken(config.adminSecret, decodeToken(current)?.method) });
+    const decoded = decodeToken(current);
+    return c.json({ token: createToken(config.adminSecret, decoded?.method, decoded?.login) });
   });
 
   // Slack OAuth routes (only active when Slack OAuth env vars are configured)
@@ -578,7 +579,10 @@ export function createAdminRoutes(
       path: "/",
       maxAge: 600, // 10 minutes
     });
-    const url = slack.createAuthorizationURL(state, ["openid", "profile"]);
+    // `email` is requested (issue #205) so the OIDC userInfo carries the
+    // address we match Slack logins to a `users` row on (and store as the
+    // future email hook).
+    const url = slack.createAuthorizationURL(state, ["openid", "profile", "email"]);
     return c.redirect(url.toString());
   });
 
@@ -616,6 +620,8 @@ export function createAdminRoutes(
         ok?: boolean;
         error?: string;
         sub?: string;
+        name?: string;
+        email?: string;
         "https://slack.com/team_id"?: string;
         "https://slack.com/team_domain"?: string;
         "https://slack.com/user_id"?: string;
@@ -641,7 +647,28 @@ export function createAdminRoutes(
         }
       }
 
-      const token = createToken(config.adminSecret, "slack");
+      // Capture / match a first-class user identity (issue #205): match the
+      // Slack email to an existing (GitHub) `users` row and link the Slack id
+      // onto it, else create a Slack-only row. When matched, the person's
+      // GitHub login rides the token so a Slack dashboard session attributes to
+      // the same user. Best-effort — never block a valid login on it.
+      let matchedLogin: string | undefined;
+      const slackUserId = userInfo["https://slack.com/user_id"];
+      if (slackUserId) {
+        try {
+          const user = db.users.upsertSlackUser({
+            slackUserId,
+            name: userInfo.name ?? null,
+            email: userInfo.email ?? null,
+          });
+          matchedLogin = user.login;
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn(`[oauth] failed to persist Slack user ${slackUserId}: ${msg}`);
+        }
+      }
+
+      const token = createToken(config.adminSecret, "slack", matchedLogin);
       // Redirect to dashboard with token in URL; App.tsx strips it immediately.
       // Trailing slash matters: Vite serves the SPA with base "/admin/" so a
       // bare "/admin" 404s in dev. Production static serving accepts both.
@@ -712,7 +739,13 @@ export function createAdminRoutes(
           Accept: "application/vnd.github+json",
         },
       });
-      const userInfo = (await res.json()) as { login?: string };
+      const userInfo = (await res.json()) as {
+        id?: number;
+        login?: string;
+        name?: string | null;
+        email?: string | null;
+        avatar_url?: string | null;
+      };
 
       let memberStatus: number | undefined;
       if (userInfo.login && !githubAllowAnyUser) {
@@ -745,7 +778,54 @@ export function createAdminRoutes(
         return fail("github_org");
       }
 
-      const token = createToken(config.adminSecret, "github");
+      // Capture a first-class user identity (issue #205). A public GitHub
+      // profile often hides the email on GET /user, so fall back to the
+      // authenticated /user/emails list and pick the primary+verified one —
+      // this is the future outbound-email hook (nothing sends yet). Persisting
+      // is orthogonal to the org gate above, so it runs even for
+      // githubAllowAnyUser logins.
+      let email = userInfo.email ?? null;
+      if (!email) {
+        try {
+          const emailsRes = await fetch("https://api.github.com/user/emails", {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              "User-Agent": "lastlight-admin",
+              Accept: "application/vnd.github+json",
+            },
+          });
+          if (emailsRes.ok) {
+            const emails = (await emailsRes.json()) as Array<{
+              email?: string;
+              primary?: boolean;
+              verified?: boolean;
+            }>;
+            email = emails.find((e) => e.primary && e.verified)?.email ?? null;
+          }
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn(`[oauth] GitHub /user/emails lookup failed for ${login}: ${msg}`);
+        }
+      }
+      if (typeof userInfo.id === "number") {
+        try {
+          db.users.getOrCreateUserByGithub({
+            githubId: userInfo.id,
+            login,
+            name: userInfo.name ?? null,
+            email,
+            avatarUrl: userInfo.avatar_url ?? null,
+          });
+        } catch (err: unknown) {
+          // Identity capture is best-effort — never block a valid login on it.
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn(`[oauth] failed to persist user ${login}: ${msg}`);
+        }
+      }
+
+      // Carry the verified login in the token so actor-hardcoded routes
+      // attribute to this person.
+      const token = createToken(config.adminSecret, "github", login);
       return c.redirect(`/admin/?token=${encodeURIComponent(token)}`);
     } catch (err: unknown) {
       console.error("GitHub OAuth exchange failed:", err);
@@ -1053,6 +1133,10 @@ export function createAdminRoutes(
     if (run.status !== "running" && run.status !== "paused" && run.status !== "queued") {
       return c.json({ error: `cannot cancel a run with status '${run.status}'` }, 400);
     }
+    // Actor logging (issue #205): the canceller lands on the append-only
+    // executions ledger (via the finish error below), never overwriting the
+    // run's original `triggered_by`.
+    const actor = actorFromContext(c) ?? "admin";
     db.runs.cancelRun(id);
     // Flipping the DB row alone only stops the runner before the NEXT phase.
     // Kill any sandbox container currently executing a phase of this run so
@@ -1085,7 +1169,7 @@ export function createAdminRoutes(
         // raced before dedup closed.
         for (const e of db.executions.runningExecutions()) {
           if (e.workflowRunId === id) {
-            db.executions.recordFinish(e.id, { success: false, error: "cancelled via admin dashboard" });
+            db.executions.recordFinish(e.id, { success: false, error: `cancelled via admin dashboard by ${actor}` });
           }
         }
       } catch (err) {
@@ -1113,7 +1197,7 @@ export function createAdminRoutes(
     }
     // Fire-and-forget: restartRun (inside the callback) flips status→running
     // atomically, so a second immediate retry click 400s on the status guard.
-    config.retryWorkflow(run, "admin").catch((err) =>
+    config.retryWorkflow(run, actorFromContext(c) ?? "admin").catch((err) =>
       console.error(`[admin] retry ${id} failed:`, err));
     return c.json({ retrying: id });
   });
@@ -1590,9 +1674,12 @@ export function createAdminRoutes(
     const approval = db.approvals.getById(id);
     if (!approval) return c.json({ error: "approval not found" }, 404);
     if (approval.status !== "pending") return c.json({ error: `already ${approval.status}` }, 400);
+    // Actor logging (issue #205): attribute the approval to the authenticated
+    // user, falling back to `admin` for password/anonymous sessions.
+    const actor = actorFromContext(c) ?? "admin";
     if (body.decision === "rejected") {
       // One transaction: respond 'rejected' + fail the run.
-      db.runs.resolveGateAndFail(id, "admin", body.reason);
+      db.runs.resolveGateAndFail(id, actor, body.reason);
     } else {
       // Record the approval, then let resumeWorkflow flip the run back to
       // `running` — but only as part of an actual dispatch. resumeWorkflow
@@ -1607,13 +1694,13 @@ export function createAdminRoutes(
       // respond() is a compare-and-set on the still-pending row, so a racing
       // responder (the status check above is a TOCTOU read) changes 0 rows.
       // Only the winner resumes — the loser must not dispatch a second time.
-      const changed = db.approvals.respond(id, "approved", "admin", body.reason);
+      const changed = db.approvals.respond(id, "approved", actor, body.reason);
       if (changed !== 1) {
         return c.json({ error: "already resolved" }, 409);
       }
       const workflowRun = db.runs.getRun(approval.workflowRunId);
       if (workflowRun && config.resumeWorkflow) {
-        config.resumeWorkflow(workflowRun, "admin").catch((err) => {
+        config.resumeWorkflow(workflowRun, actor).catch((err) => {
           console.error(`[admin] Failed to resume workflow ${workflowRun.id}:`, err);
         });
       }
@@ -1774,8 +1861,11 @@ export function createAdminRoutes(
     if (!config.triggerCron) {
       return c.json({ error: "cron trigger not configured" }, 503);
     }
-    // Same context shape the scheduler + toggle handler build.
-    const context = { repos: getManagedRepos(), ...def.context };
+    // Same context shape the scheduler + toggle handler build, plus the
+    // acting user (issue #205) so a manually-fired cron attributes to the
+    // person who clicked "Run now" rather than the anonymous scheduler.
+    // `dispatchWorkflow` destructures `sender` for free.
+    const context = { repos: getManagedRepos(), sender: actorFromContext(c), ...def.context };
     config.triggerCron(def.workflow, context).catch((err) => {
       console.error(`[admin] cron trigger ${name} failed:`, err);
     });

--- a/apps/server/src/connectors/slack/connector.ts
+++ b/apps/server/src/connectors/slack/connector.ts
@@ -6,6 +6,7 @@ import { MessagingConnector } from "../messaging/base.js";
 import type { SessionManager } from "../messaging/session-manager.js";
 import type { MessagingConfig } from "../messaging/types.js";
 import type { EventEnvelope } from "../types.js";
+import type { UserStore } from "../../state/user-store.js";
 import { hasMarkdownImage, markdownToSlackBlocks, markdownToSlackMrkdwn } from "./mrkdwn.js";
 
 /**
@@ -52,6 +53,13 @@ export interface SlackConnectorConfig extends MessagingConfig {
    * present in webhook mode.
    */
   honoApp?: Hono;
+  /**
+   * User identity store (issue #205). When present, a Slack user is matched to
+   * a `users` row by email so a Slack-initiated run/approval attributes to the
+   * same person as their GitHub login. Optional — matching silently degrades to
+   * the Slack username without it (or without the `users:read.email` scope).
+   */
+  users?: UserStore;
 }
 
 /**
@@ -522,7 +530,17 @@ export class SlackConnector extends MessagingConnector {
     });
   }
 
-  /** Resolve a Slack user ID to a username (cached) */
+  /**
+   * Resolve a Slack user ID to an actor handle (cached).
+   *
+   * When a {@link UserStore} is wired (issue #205), this prefers the person's
+   * GitHub **login** so a Slack-initiated run/approval attributes to the same
+   * user as their dashboard login: fast-path on `slack_user_id`, else match the
+   * Slack profile email to a `users` row and link the Slack id onto it. It
+   * degrades to today's Slack username when there's no store, no
+   * `users:read.email` scope (email omitted), or no match — never blocking the
+   * run.
+   */
   private async resolveUsername(userId: string): Promise<string> {
     const cached = this.userCache.get(userId);
     if (cached) return cached;
@@ -530,11 +548,43 @@ export class SlackConnector extends MessagingConnector {
     try {
       const result = await this.web.users.info({ user: userId });
       const username = result.user?.name || result.user?.real_name || userId;
-      this.userCache.set(userId, username);
-      return username;
+      const resolved = this.matchActorLogin(userId, result) ?? username;
+      this.userCache.set(userId, resolved);
+      return resolved;
     } catch {
       return userId;
     }
+  }
+
+  /**
+   * Match a Slack user to a `users` row and return their GitHub login, or null
+   * to fall back to the Slack username. Best-effort: any store error is
+   * swallowed so identity matching can never fail a message.
+   */
+  private matchActorLogin(
+    userId: string,
+    info: Awaited<ReturnType<WebClient["users"]["info"]>>,
+  ): string | null {
+    const users = this.slackConfig.users;
+    if (!users) return null;
+    try {
+      // Fast path: already linked to a GitHub identity.
+      const linked = users.findBySlackUserId(userId);
+      if (linked?.login) return linked.login;
+
+      // `email` requires the `users:read.email` bot scope; absent otherwise.
+      const email = info.user?.profile?.email;
+      if (!email) return null;
+      const byEmail = users.findByEmail(email);
+      if (byEmail) {
+        if (byEmail.slackUserId !== userId) users.linkSlackUser(byEmail.id, userId);
+        return byEmail.login ?? null;
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[slack] user identity match failed for ${userId}: ${msg}`);
+    }
+    return null;
   }
 }
 

--- a/apps/server/src/engine/dispatcher.ts
+++ b/apps/server/src/engine/dispatcher.ts
@@ -525,6 +525,9 @@ async function handleBuild(
     repo: repoStr,
     issueNumber,
     startedAt: new Date().toISOString(),
+    // Actor logging (issue #205): who fired this build.
+    triggeredBy: (context.sender as string) || undefined,
+    triggerActorType: envelope.type === "message" ? "slack" : "github",
   });
 
   if (envelope.type === "message") {
@@ -881,6 +884,10 @@ export async function runChatTurn(
     triggerId: sessionId,
     skill: "chat",
     startedAt: new Date().toISOString(),
+    // Actor logging (issue #205): the chat sender (a Slack login/handle,
+    // resolved to a GitHub login when the user matched a `users` row).
+    triggeredBy: sender,
+    triggerActorType: "slack",
   });
 
   try {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -12,7 +12,7 @@ import { configureWorkflowAssets, validateAssets, getWorkflow } from "./workflow
 import { ChatRunner } from "./engine/chat/chat-runner.js";
 import { buildReadSkillTool, loadChatSkillCatalogue } from "./engine/chat/chat-skills.js";
 import { configureGitAuth } from "./engine/github/git-auth.js";
-import { StateDb, type TriggerActorType } from "./state/db.js";
+import { StateDb, isTriggerActorType, type TriggerActorType } from "./state/db.js";
 import { CronScheduler, type WorkflowRunner } from "./cron/scheduler.js";
 import { getJobs } from "./cron/jobs.js";
 import { dispatchCronWorkflow, fanOutContexts } from "./cron/fanout.js";
@@ -330,7 +330,10 @@ async function main() {
       (typeof ctxTriggeredBy === "string" && ctxTriggeredBy) ||
       (typeof sender === "string" ? sender : undefined);
     const triggerActorType: TriggerActorType =
-      (typeof ctxTriggerActorType === "string" ? (ctxTriggerActorType as TriggerActorType) : undefined) ??
+      // Membership-checked, not a bare cast: `ctxTriggerActorType` is untrusted
+      // `unknown` from the spread context, so an unrecognised value falls
+      // through to the derived default rather than being persisted verbatim.
+      (isTriggerActorType(ctxTriggerActorType) ? ctxTriggerActorType : undefined) ??
       (slackTriggerId || ctxSource === "slack"
         ? "slack"
         : _triggerType === "cron"

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -12,7 +12,7 @@ import { configureWorkflowAssets, validateAssets, getWorkflow } from "./workflow
 import { ChatRunner } from "./engine/chat/chat-runner.js";
 import { buildReadSkillTool, loadChatSkillCatalogue } from "./engine/chat/chat-skills.js";
 import { configureGitAuth } from "./engine/github/git-auth.js";
-import { StateDb } from "./state/db.js";
+import { StateDb, type TriggerActorType } from "./state/db.js";
 import { CronScheduler, type WorkflowRunner } from "./cron/scheduler.js";
 import { getJobs } from "./cron/jobs.js";
 import { dispatchCronWorkflow, fanOutContexts } from "./cron/fanout.js";
@@ -26,7 +26,7 @@ import { mountAdmin } from "./admin/index.js";
 import { cleanupOrphanedSandboxes } from "./sandbox/index.js";
 import { writeEgressFirewallConfigs, writeOtelCollectorConfig } from "./sandbox/egress-firewall-config.js";
 import { initTelemetry, shutdownTelemetry } from "./telemetry/index.js";
-import { authMiddleware, authIsEnabled } from "./admin/auth.js";
+import { authMiddleware, authIsEnabled, actorFromContext } from "./admin/auth.js";
 import { readPackageVersion } from "./admin/version.js";
 import { GitHubClient } from "./engine/github/github.js";
 import { setInstallationRepos, isManagedRepo, unmanagedReposInContext } from "./managed-repos.js";
@@ -316,8 +316,30 @@ async function main() {
       threadId,
       prePopulateBranch: ctxPrePopulateBranch,
       branch: ctxBranch,
+      triggeredBy: ctxTriggeredBy,
+      triggerActorType: ctxTriggerActorType,
+      source: ctxSource,
       ...rest
     } = context;
+
+    // Actor logging (issue #205): who triggered this run and how. Callers can
+    // set `triggerActorType` explicitly (the cron manual-fire / api routes);
+    // otherwise derive it from the dispatch shape. `triggeredBy` defaults to
+    // the acting handle (`sender`).
+    const triggeredBy =
+      (typeof ctxTriggeredBy === "string" && ctxTriggeredBy) ||
+      (typeof sender === "string" ? sender : undefined);
+    const triggerActorType: TriggerActorType =
+      (typeof ctxTriggerActorType === "string" ? (ctxTriggerActorType as TriggerActorType) : undefined) ??
+      (slackTriggerId || ctxSource === "slack"
+        ? "slack"
+        : _triggerType === "cron"
+        ? "cron"
+        : _triggerType === "api"
+        ? "cli"
+        : _triggerType === "chat"
+        ? "slack"
+        : "github");
 
     // Preserve channelId/threadId in extra so they're stored on the
     // workflow run context — needed by boot-time resume to rebuild the
@@ -406,6 +428,8 @@ async function main() {
       issueLabels: Array.isArray(labels) ? (labels as string[]) : undefined,
       commentBody: typeof commentBody === "string" ? commentBody : undefined,
       sender: typeof sender === "string" ? sender : "unknown",
+      triggeredBy,
+      triggerActorType,
       triggerId: slackTriggerId,
       extra,
       prePopulateBranch,
@@ -699,6 +723,9 @@ async function main() {
         honoApp: app,
         allowedUsers: config.slack.allowedUsers,
         deliveryChannel: config.slack.deliveryChannel,
+        // Match a Slack user's email to a `users` row so a Slack-initiated
+        // run/approval attributes to their GitHub login (issue #205).
+        users: db.users,
         botIdentifier: "", // Will be resolved from Slack API on connect
       },
       sessionManager
@@ -946,7 +973,15 @@ async function main() {
     // Run asynchronously — return immediately with a stable id the caller
     // can correlate with workflow_runs in the dashboard.
     const executionId = randomUUID();
-    dispatchWorkflow(workflowName, { ...context, _triggerType: "api" }).catch((err: unknown) => {
+    // Actor logging (issue #205): attribute to the authenticated CLI user when
+    // the token carries a login (OAuth), else dispatchWorkflow falls back to
+    // the context `sender` and the `cli` actor type (from `_triggerType: api`).
+    const apiActor = actorFromContext(c);
+    dispatchWorkflow(workflowName, {
+      ...context,
+      ...(apiActor ? { triggeredBy: apiActor } : {}),
+      _triggerType: "api",
+    }).catch((err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[api] workflow ${workflowName} failed: ${msg}`);
     });
@@ -988,6 +1023,9 @@ async function main() {
       body: issueBody || "",
       labels: resolvedLabels,
       sender: sender || "cli",
+      // Attribute to the authenticated CLI user when the token carries a login
+      // (OAuth); else falls back to the `sender` handle (issue #205).
+      ...(actorFromContext(c) ? { triggeredBy: actorFromContext(c) } : {}),
       _triggerType: "api",
     }).catch((err) => {
       console.error(`[api] Build failed:`, err);

--- a/apps/server/src/state/db.ts
+++ b/apps/server/src/state/db.ts
@@ -18,7 +18,7 @@ export type { User, TriggerActorType } from "./user-store.js";
 export { ExecutionStore } from "./execution-store.js";
 export { ApprovalStore } from "./approval-store.js";
 export { WorkflowRunStore } from "./workflow-run-store.js";
-export { UserStore } from "./user-store.js";
+export { UserStore, TRIGGER_ACTOR_TYPES, isTriggerActorType } from "./user-store.js";
 
 const DEFAULT_DB_PATH = "lastlight.db";
 

--- a/apps/server/src/state/db.ts
+++ b/apps/server/src/state/db.ts
@@ -4,6 +4,7 @@ import { migrate } from "./migrate.js";
 import { ExecutionStore } from "./execution-store.js";
 import { ApprovalStore } from "./approval-store.js";
 import { WorkflowRunStore } from "./workflow-run-store.js";
+import { UserStore } from "./user-store.js";
 
 // Re-export the types that moved out to the per-table stores so existing
 // import sites (`import { WorkflowRun } from "../state/db.js"`, etc.) keep
@@ -13,9 +14,11 @@ import { WorkflowRunStore } from "./workflow-run-store.js";
 export type { ExecutionRecord } from "./execution-store.js";
 export type { WorkflowApproval } from "./approval-store.js";
 export type { WorkflowRun, PhaseHistoryEntry, PhaseMarker } from "./workflow-run-store.js";
+export type { User, TriggerActorType } from "./user-store.js";
 export { ExecutionStore } from "./execution-store.js";
 export { ApprovalStore } from "./approval-store.js";
 export { WorkflowRunStore } from "./workflow-run-store.js";
+export { UserStore } from "./user-store.js";
 
 const DEFAULT_DB_PATH = "lastlight.db";
 
@@ -62,6 +65,8 @@ export class StateDb {
   readonly approvals: ApprovalStore;
   /** Aggregate root for `workflow_runs` + the atomic lifecycle operations. */
   readonly runs: WorkflowRunStore;
+  /** First-class user identity — populated on dashboard login (issue #205). */
+  readonly users: UserStore;
 
   constructor(dbPath?: string) {
     // ":memory:" stays a real per-connection in-memory DB (used by tests for
@@ -77,6 +82,7 @@ export class StateDb {
     this.executions = new ExecutionStore(this.db);
     this.approvals = new ApprovalStore(this.db);
     this.runs = new WorkflowRunStore(this.db, { approvals: this.approvals });
+    this.users = new UserStore(this.db);
   }
 
   // ── Cron overrides ─────────────────────────────────────────────

--- a/apps/server/src/state/execution-store.ts
+++ b/apps/server/src/state/execution-store.ts
@@ -1,10 +1,19 @@
 import type Database from "better-sqlite3";
 import { randomUUID } from "crypto";
+import type { TriggerActorType } from "./user-store.js";
 
 export interface ExecutionRecord {
   id: string;
   triggerType: "webhook" | "cron" | "chat" | "api";
   triggerId: string;
+  /**
+   * Who triggered/acted on this execution (issue #205) — a GitHub login, a
+   * Slack display name, or `cli`/`cron`/`admin`. Free-text; joined to `users`
+   * on `login` for enrichment. Null on rows written before the column existed.
+   */
+  triggeredBy?: string;
+  /** Coarse actor category for {@link triggeredBy}. */
+  triggerActorType?: TriggerActorType;
   skill: string;
   repo?: string;
   issueNumber?: number;
@@ -67,8 +76,8 @@ export class ExecutionStore {
 
   recordStart(record: Omit<ExecutionRecord, "finishedAt" | "success" | "error" | "turns" | "durationMs">): void {
     this.db.prepare(`
-      INSERT INTO executions (id, trigger_type, trigger_id, skill, repo, issue_number, started_at, workflow_run_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO executions (id, trigger_type, trigger_id, skill, repo, issue_number, started_at, workflow_run_id, triggered_by, trigger_actor_type)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       record.id,
       record.triggerType,
@@ -78,6 +87,8 @@ export class ExecutionStore {
       record.issueNumber,
       record.startedAt,
       record.workflowRunId ?? null,
+      record.triggeredBy ?? null,
+      record.triggerActorType ?? null,
     );
   }
 

--- a/apps/server/src/state/migrate.ts
+++ b/apps/server/src/state/migrate.ts
@@ -85,7 +85,50 @@ export function migrate(db: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS idx_approvals_workflow ON workflow_approvals(workflow_run_id);
     CREATE INDEX IF NOT EXISTS idx_approvals_status ON workflow_approvals(status);
+
+    -- First-class user identity (issue #205). An ADDITIVE enrichment table:
+    -- every actor column elsewhere stays free-text \`login\`, and \`users\` is
+    -- LEFT-JOINed on it to resolve a real person (name / email / avatar) for
+    -- the dashboard and future email. \`github_id\` / \`slack_user_id\` are the
+    -- stable upsert keys; \`login\` is the soft join key. \`email\` is indexed but
+    -- deliberately NOT unique (corporate shared mailboxes + many null Slack-only
+    -- rows would collide a UNIQUE constraint) — see issue #205 decisions.
+    CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY,                    -- randomUUID
+      github_id INTEGER UNIQUE,               -- stable numeric id (upsert key); null for Slack-only rows
+      login TEXT UNIQUE,                      -- GitHub login = the soft join key used everywhere
+      name TEXT,
+      email TEXT,                             -- captured for future email; indexed, NOT unique
+      avatar_url TEXT,
+      slack_user_id TEXT UNIQUE,              -- U… id, linked lazily on Slack match
+      is_blocked INTEGER NOT NULL DEFAULT 0,
+      email_is_placeholder INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      last_login_at TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_users_login ON users(login);
+    CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+    CREATE INDEX IF NOT EXISTS idx_users_slack ON users(slack_user_id);
   `);
+
+  // Actor logging (issue #205): who triggered a run and how. Additive on both
+  // the append-only `executions` ledger and the `workflow_runs` aggregate. The
+  // run's `triggered_by` is the ORIGINAL trigger; retry/cancel/approve actors
+  // land on the executions ledger, never overwriting the run's origin value.
+  // `trigger_actor_type` is one of github | slack | cli | cron | admin | system.
+  for (const table of ["executions", "workflow_runs"]) {
+    try {
+      db.exec(`ALTER TABLE ${table} ADD COLUMN triggered_by TEXT`);
+    } catch {
+      // Column already exists — ignore
+    }
+    try {
+      db.exec(`ALTER TABLE ${table} ADD COLUMN trigger_actor_type TEXT`);
+    } catch {
+      // Column already exists — ignore
+    }
+  }
 
   // Mutable phase-to-phase state for features like the socratic explore
   // loop that accumulate data across reply-gate pauses.

--- a/apps/server/src/state/user-store.ts
+++ b/apps/server/src/state/user-store.ts
@@ -8,6 +8,20 @@ import { randomUUID } from "crypto";
  */
 export type TriggerActorType = "github" | "slack" | "cli" | "cron" | "admin" | "system";
 
+/** The runtime membership set for {@link TriggerActorType} (guards untrusted input). */
+export const TRIGGER_ACTOR_TYPES = ["github", "slack", "cli", "cron", "admin", "system"] as const;
+
+/**
+ * Narrow an arbitrary value to a {@link TriggerActorType}. The dispatch context
+ * is a `Record<string, unknown>` that a cron definition or external API caller
+ * can spread arbitrary keys into, so a bare `as` cast would persist an
+ * unrecognised `trigger_actor_type`. Callers use this to fall through to their
+ * derived default instead.
+ */
+export function isTriggerActorType(value: unknown): value is TriggerActorType {
+  return typeof value === "string" && (TRIGGER_ACTOR_TYPES as readonly string[]).includes(value);
+}
+
 /**
  * A first-class user identity (issue #205). Captures a GitHub identity
  * (stable numeric id + login + name + email + avatar) and a lazily-linked

--- a/apps/server/src/state/user-store.ts
+++ b/apps/server/src/state/user-store.ts
@@ -1,0 +1,223 @@
+import type Database from "better-sqlite3";
+import { randomUUID } from "crypto";
+
+/**
+ * Who acted on / triggered a workflow, coarsely. Persisted in the
+ * `trigger_actor_type` column on both `executions` and `workflow_runs`
+ * (issue #205) alongside the free-text `triggered_by` login/handle.
+ */
+export type TriggerActorType = "github" | "slack" | "cli" | "cron" | "admin" | "system";
+
+/**
+ * A first-class user identity (issue #205). Captures a GitHub identity
+ * (stable numeric id + login + name + email + avatar) and a lazily-linked
+ * Slack user id, so the dashboard can show a real person and a future sender
+ * can email them. This is an ADDITIVE enrichment table — every actor column
+ * elsewhere stays free-text `login`, and this row is resolved by LEFT-JOIN on
+ * `login`. `email` is the future email hook; nothing sends yet.
+ */
+export interface User {
+  id: string;
+  /** Stable GitHub numeric id — the upsert key for GitHub logins. Null for Slack-only rows. */
+  githubId?: number;
+  /** GitHub login — the soft join key every actor column already stores. */
+  login?: string;
+  name?: string;
+  /** Captured for future outbound email; nothing sends yet. Indexed, NOT unique. */
+  email?: string;
+  avatarUrl?: string;
+  /** Slack `U…` id, linked lazily when a Slack user's email matches this row. */
+  slackUserId?: string;
+  isBlocked: boolean;
+  /** True when `email` is a synthetic placeholder a future sender should skip. */
+  emailIsPlaceholder: boolean;
+  createdAt: string;
+  updatedAt: string;
+  lastLoginAt?: string;
+}
+
+/**
+ * Owns every read/write against the `users` table. Mirrors the other per-table
+ * stores ({@link ExecutionStore} / {@link ApprovalStore}): constructed from the
+ * single shared `Database`, all reads flow through one `deserialize` helper.
+ *
+ * Upserts key on the stable ids (`github_id` for GitHub logins, `slack_user_id`
+ * for Slack) — never on `email`, which is non-unique. The GitHub `login` stays
+ * the soft join key used everywhere else in the schema.
+ */
+export class UserStore {
+  constructor(private db: Database.Database) {}
+
+  /**
+   * Upsert a GitHub-authenticated user on their stable numeric id. On conflict,
+   * refreshes the mutable identity fields (login/name/email/avatar) and bumps
+   * `last_login_at` + `updated_at`. Called on every dashboard GitHub login so a
+   * renamed login or new avatar is picked up. Returns the stored row.
+   *
+   * `email` is captured here as the future outbound-email hook (issue #205);
+   * no sender exists yet.
+   */
+  getOrCreateUserByGithub(input: {
+    githubId: number;
+    login: string;
+    name?: string | null;
+    email?: string | null;
+    avatarUrl?: string | null;
+  }): User {
+    const now = new Date().toISOString();
+    const existing = this.findByGithubId(input.githubId);
+    if (existing) {
+      this.db
+        .prepare(
+          `UPDATE users
+             SET login = ?, name = ?, email = ?, avatar_url = ?,
+                 updated_at = ?, last_login_at = ?
+           WHERE github_id = ?`,
+        )
+        .run(
+          input.login,
+          input.name ?? existing.name ?? null,
+          input.email ?? existing.email ?? null,
+          input.avatarUrl ?? existing.avatarUrl ?? null,
+          now,
+          now,
+          input.githubId,
+        );
+      return this.findByGithubId(input.githubId)!;
+    }
+    const id = randomUUID();
+    this.db
+      .prepare(
+        `INSERT INTO users
+           (id, github_id, login, name, email, avatar_url, created_at, updated_at, last_login_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        input.githubId,
+        input.login,
+        input.name ?? null,
+        input.email ?? null,
+        input.avatarUrl ?? null,
+        now,
+        now,
+        now,
+      );
+    return this.getById(id)!;
+  }
+
+  /**
+   * Upsert a Slack-authenticated user. Matches by email to an existing row
+   * (typically a GitHub login who signed in with the same corporate address)
+   * and links `slack_user_id` onto it; otherwise creates a Slack-only row
+   * (no `login`, no `github_id`). Returns the stored row so the caller can
+   * carry its `login` (if any) into the session token.
+   */
+  upsertSlackUser(input: {
+    slackUserId: string;
+    name?: string | null;
+    email?: string | null;
+  }): User {
+    const now = new Date().toISOString();
+    // Fast path: already linked.
+    const linked = this.findBySlackUserId(input.slackUserId);
+    if (linked) {
+      this.db
+        .prepare(
+          `UPDATE users
+             SET name = COALESCE(?, name), email = COALESCE(?, email),
+                 updated_at = ?, last_login_at = ?
+           WHERE slack_user_id = ?`,
+        )
+        .run(input.name ?? null, input.email ?? null, now, now, input.slackUserId);
+      return this.findBySlackUserId(input.slackUserId)!;
+    }
+    // Match an existing (GitHub) row by email and link Slack onto it.
+    const byEmail = input.email ? this.findByEmail(input.email) : null;
+    if (byEmail) {
+      this.linkSlackUser(byEmail.id, input.slackUserId);
+      this.db
+        .prepare(
+          `UPDATE users SET name = COALESCE(name, ?), updated_at = ?, last_login_at = ? WHERE id = ?`,
+        )
+        .run(input.name ?? null, now, now, byEmail.id);
+      return this.getById(byEmail.id)!;
+    }
+    // No match — create a Slack-only row.
+    const id = randomUUID();
+    this.db
+      .prepare(
+        `INSERT INTO users
+           (id, slack_user_id, name, email, created_at, updated_at, last_login_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(id, input.slackUserId, input.name ?? null, input.email ?? null, now, now, now);
+    return this.getById(id)!;
+  }
+
+  /** Link a Slack user id onto an existing row (e.g. a GitHub login matched by email). */
+  linkSlackUser(userId: string, slackUserId: string): void {
+    const now = new Date().toISOString();
+    this.db
+      .prepare(`UPDATE users SET slack_user_id = ?, updated_at = ? WHERE id = ?`)
+      .run(slackUserId, now, userId);
+  }
+
+  getById(id: string): User | null {
+    const row = this.db.prepare(`SELECT * FROM users WHERE id = ?`).get(id) as
+      | Record<string, unknown>
+      | undefined;
+    return row ? this.deserialize(row) : null;
+  }
+
+  findByGithubId(githubId: number): User | null {
+    const row = this.db.prepare(`SELECT * FROM users WHERE github_id = ?`).get(githubId) as
+      | Record<string, unknown>
+      | undefined;
+    return row ? this.deserialize(row) : null;
+  }
+
+  /** Look up by the GitHub login — the soft join key used across the schema. */
+  findByLogin(login: string): User | null {
+    const row = this.db.prepare(`SELECT * FROM users WHERE login = ?`).get(login) as
+      | Record<string, unknown>
+      | undefined;
+    return row ? this.deserialize(row) : null;
+  }
+
+  /**
+   * First row matching `email`. `email` is non-unique (shared mailboxes), so
+   * this returns the earliest-created match deterministically. Used to link a
+   * Slack login to an existing GitHub identity by email.
+   */
+  findByEmail(email: string): User | null {
+    const row = this.db
+      .prepare(`SELECT * FROM users WHERE email = ? ORDER BY created_at ASC LIMIT 1`)
+      .get(email) as Record<string, unknown> | undefined;
+    return row ? this.deserialize(row) : null;
+  }
+
+  findBySlackUserId(slackUserId: string): User | null {
+    const row = this.db
+      .prepare(`SELECT * FROM users WHERE slack_user_id = ?`)
+      .get(slackUserId) as Record<string, unknown> | undefined;
+    return row ? this.deserialize(row) : null;
+  }
+
+  private deserialize(row: Record<string, unknown>): User {
+    return {
+      id: row.id as string,
+      githubId: (row.github_id as number | null) ?? undefined,
+      login: (row.login as string | null) ?? undefined,
+      name: (row.name as string | null) ?? undefined,
+      email: (row.email as string | null) ?? undefined,
+      avatarUrl: (row.avatar_url as string | null) ?? undefined,
+      slackUserId: (row.slack_user_id as string | null) ?? undefined,
+      isBlocked: (row.is_blocked as number) === 1,
+      emailIsPlaceholder: (row.email_is_placeholder as number) === 1,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+      lastLoginAt: (row.last_login_at as string | null) ?? undefined,
+    };
+  }
+}

--- a/apps/server/src/state/workflow-run-store.ts
+++ b/apps/server/src/state/workflow-run-store.ts
@@ -1,5 +1,6 @@
 import type Database from "better-sqlite3";
 import type { ApprovalStore } from "./approval-store.js";
+import type { TriggerActorType } from "./user-store.js";
 
 export interface PhaseHistoryEntry {
   phase: string;
@@ -18,6 +19,15 @@ export interface WorkflowRun {
   /** BARE repo name (no owner) — kept path-safe for taskIds / workspace dirs. */
   repo?: string;
   issueNumber?: number;
+  /**
+   * Who originally triggered this run (issue #205) — a GitHub login, a Slack
+   * display name, or `cli`/`cron`. The run's value is the ORIGINAL trigger;
+   * retry/cancel/approve actors land on the `executions` ledger, never
+   * overwriting this. Free-text, joined to `users` on `login` for enrichment.
+   */
+  triggeredBy?: string;
+  /** Coarse actor category for {@link triggeredBy}. */
+  triggerActorType?: TriggerActorType;
   currentPhase: string;
   phaseHistory: PhaseHistoryEntry[];
   status: "queued" | "running" | "paused" | "succeeded" | "failed" | "cancelled";
@@ -94,8 +104,8 @@ export class WorkflowRunStore {
   createRun(run: Omit<WorkflowRun, "phaseHistory" | "updatedAt">): void {
     const now = new Date().toISOString();
     this.db.prepare(`
-      INSERT INTO workflow_runs (id, workflow_name, trigger_id, owner, repo, issue_number, current_phase, phase_history, status, context, scratch, started_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, '[]', ?, ?, ?, ?, ?)
+      INSERT INTO workflow_runs (id, workflow_name, trigger_id, owner, repo, issue_number, current_phase, phase_history, status, context, scratch, started_at, updated_at, triggered_by, trigger_actor_type)
+      VALUES (?, ?, ?, ?, ?, ?, ?, '[]', ?, ?, ?, ?, ?, ?, ?)
     `).run(
       run.id,
       run.workflowName,
@@ -109,6 +119,8 @@ export class WorkflowRunStore {
       run.scratch ? JSON.stringify(run.scratch) : null,
       run.startedAt,
       now,
+      run.triggeredBy ?? null,
+      run.triggerActorType ?? null,
     );
   }
 
@@ -293,6 +305,7 @@ export class WorkflowRunStore {
            id, workflow_name, trigger_id, owner, repo, issue_number,
            current_phase, phase_history, status,
            restart_count, started_at, updated_at, finished_at,
+           triggered_by, trigger_actor_type,
            COALESCE(agg.total_cost_usd, 0) AS total_cost_usd,
            COALESCE(agg.total_tokens, 0)   AS total_tokens
          FROM workflow_runs
@@ -559,6 +572,8 @@ export class WorkflowRunStore {
       owner: (row.owner as string | null) ?? undefined,
       repo: row.repo as string | undefined,
       issueNumber: row.issue_number as number | undefined,
+      triggeredBy: (row.triggered_by as string | null) ?? undefined,
+      triggerActorType: (row.trigger_actor_type as TriggerActorType | null) ?? undefined,
       currentPhase: row.current_phase as string,
       phaseHistory: JSON.parse(row.phase_history as string) as PhaseHistoryEntry[],
       status: row.status as WorkflowRun["status"],

--- a/apps/server/src/workflows/simple.ts
+++ b/apps/server/src/workflows/simple.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import type { ExecutorConfig } from "../engine/github/profiles.js";
-import type { StateDb, WorkflowRun } from "../state/db.js";
+import type { StateDb, WorkflowRun, TriggerActorType } from "../state/db.js";
 import { getBotName, type ModelConfig, type VariantConfig } from "../config/config.js";
 import { getWorkflow } from "./loader.js";
 import {
@@ -47,6 +47,13 @@ export interface SimpleWorkflowRequest {
   commentBody?: string;
   /** Originating user (or "cli" / "cron" etc.) */
   sender: string;
+  /**
+   * Actor logging (issue #205): who triggered this run and how, persisted on
+   * the `workflow_runs` row for the dashboard's "Triggered by". Defaults to
+   * `sender` / undefined when the dispatch layer doesn't supply them.
+   */
+  triggeredBy?: string;
+  triggerActorType?: TriggerActorType;
   /**
    * Explicit trigger id override. Slack-initiated workflows pass a
    * `slack:{teamId}:{channel}:{threadTs}` string here so pause/resume uses
@@ -306,6 +313,10 @@ export async function runSimpleWorkflow(
       issueNumber: issueNumber ?? prNumber,
       currentPhase: definition.phases[0]?.name || "phase_0",
       status: runStatus,
+      // Actor logging (issue #205): the ORIGINAL trigger. Falls back to
+      // `sender` so pre-actor callers still attribute to the acting handle.
+      triggeredBy: request.triggeredBy ?? request.sender,
+      triggerActorType: request.triggerActorType,
       context: {
         kind: definition.kind,
         owner,

--- a/apps/server/tests/admin/auth.test.ts
+++ b/apps/server/tests/admin/auth.test.ts
@@ -109,6 +109,23 @@ describe("decodeToken", () => {
     expect(decodeToken(signToken({ exp: nowS() + 100, method: "evil" }))?.method).toBeUndefined();
   });
 
+  it("carries a verified login and survives decode (issue #205)", () => {
+    const token = createToken(SECRET, "github", "octocat");
+    expect(verifyToken(token, SECRET)).toBe(true);
+    const decoded = decodeToken(token);
+    expect(decoded?.method).toBe("github");
+    expect(decoded?.login).toBe("octocat");
+  });
+
+  it("login is absent for 2-arg (signature-compatible) callers", () => {
+    expect(decodeToken(createToken(SECRET, "password"))?.login).toBeUndefined();
+    expect(decodeToken(createToken(SECRET))?.login).toBeUndefined();
+  });
+
+  it("drops a non-string login", () => {
+    expect(decodeToken(signToken({ exp: nowS() + 100, login: 123 }))?.login).toBeUndefined();
+  });
+
   it("returns null when exp is missing", () => {
     expect(decodeToken(signToken({ method: "slack" }))).toBeNull();
   });

--- a/apps/server/tests/admin/routes.test.ts
+++ b/apps/server/tests/admin/routes.test.ts
@@ -70,6 +70,13 @@ const mockDb = {
     listPending: vi.fn(() => []),
     listByArtifact: vi.fn(() => []),
   },
+  users: {
+    findByLogin: vi.fn(() => null),
+    findByEmail: vi.fn(() => null),
+    findBySlackUserId: vi.fn(() => null),
+    getOrCreateUserByGithub: vi.fn(),
+    upsertSlackUser: vi.fn(),
+  },
 } as unknown as StateDb;
 
 const mockSessions = {

--- a/apps/server/tests/admin/routes.test.ts
+++ b/apps/server/tests/admin/routes.test.ts
@@ -717,6 +717,76 @@ describe("POST /login (password)", () => {
   });
 });
 
+describe("GET /workflow-runs/:id — actor enrichment (issue #205)", () => {
+  function makeDetailDb(opts: {
+    triggeredBy?: string;
+    user?: { login?: string; name?: string | null; avatarUrl?: string | null } | null;
+  }): StateDb {
+    const findByLogin = vi.fn(() => opts.user ?? null);
+    return {
+      ...((mockDb as unknown) as Record<string, unknown>),
+      runs: {
+        ...((mockDb as unknown as { runs: Record<string, unknown> }).runs),
+        getRun: vi.fn(() => ({
+          id: "r1",
+          workflowName: "pr-review",
+          triggerId: "t1",
+          currentPhase: "review",
+          phaseHistory: [],
+          status: "succeeded",
+          triggeredBy: opts.triggeredBy,
+          triggerActorType: opts.triggeredBy ? "github" : undefined,
+          startedAt: "",
+          updatedAt: "",
+        })),
+      },
+      users: {
+        ...((mockDb as unknown as { users: Record<string, unknown> }).users),
+        findByLogin,
+      },
+    } as unknown as StateDb;
+  }
+
+  it("returns triggeredByUser: null when the actor has no users row", async () => {
+    const db = makeDetailDb({ triggeredBy: "octocat", user: null });
+    const app = createAdminRoutes(db, mockSessions, mockSessions, makeConfig({ adminPassword: "" }));
+    const res = await request(app, "/workflow-runs/r1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { workflowRun: { triggeredBy?: string }; triggeredByUser: unknown };
+    expect(body.workflowRun.triggeredBy).toBe("octocat");
+    expect(body.triggeredByUser).toBeNull();
+  });
+
+  it("returns the matched users identity (login/name/avatarUrl) when findByLogin hits", async () => {
+    const db = makeDetailDb({
+      triggeredBy: "octocat",
+      user: { login: "octocat", name: "The Octocat", avatarUrl: "https://a.png" },
+    });
+    const app = createAdminRoutes(db, mockSessions, mockSessions, makeConfig({ adminPassword: "" }));
+    const res = await request(app, "/workflow-runs/r1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      triggeredByUser: { login: string; name: string; avatarUrl: string } | null;
+    };
+    expect(body.triggeredByUser).toEqual({
+      login: "octocat",
+      name: "The Octocat",
+      avatarUrl: "https://a.png",
+    });
+  });
+
+  it("skips the users lookup and returns null when the run has no triggeredBy", async () => {
+    const db = makeDetailDb({ triggeredBy: undefined });
+    const findByLogin = (db as unknown as { users: { findByLogin: ReturnType<typeof vi.fn> } }).users
+      .findByLogin;
+    const app = createAdminRoutes(db, mockSessions, mockSessions, makeConfig({ adminPassword: "" }));
+    const res = await request(app, "/workflow-runs/r1");
+    const body = (await res.json()) as { triggeredByUser: unknown };
+    expect(body.triggeredByUser).toBeNull();
+    expect(findByLogin).not.toHaveBeenCalled();
+  });
+});
+
 describe("POST /workflow-runs/:id/cancel", () => {
   // Helper to make a cancel-test db that returns a single run and
   // records calls to the mutating methods we care about.

--- a/apps/server/tests/admin/routes.test.ts
+++ b/apps/server/tests/admin/routes.test.ts
@@ -520,6 +520,168 @@ describe("GET /oauth/github/callback", () => {
   });
 });
 
+// Identity capture on login (issue #205). Uses a real in-memory StateDb so the
+// created `users` row can be asserted, and decodes the minted token to prove
+// the verified login rides it + survives refresh.
+describe("OAuth identity capture (issue #205)", () => {
+  /** GitHub fetch mock that returns a full /user profile + /user/emails list. */
+  function mockGithubFetchFull(opts: {
+    id: number;
+    login: string;
+    name?: string | null;
+    email?: string | null;
+    avatarUrl?: string | null;
+    primaryEmail?: string;
+    orgStatus?: number;
+  }) {
+    return vi.fn(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+      if (urlStr.includes("login/oauth/access_token")) {
+        return new Response(JSON.stringify({ access_token: "gho_test" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (urlStr.includes("/user/emails")) {
+        return new Response(
+          JSON.stringify([
+            { email: "unverified@example.com", primary: false, verified: false },
+            { email: opts.primaryEmail ?? "primary@example.com", primary: true, verified: true },
+          ]),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (urlStr.includes("/orgs/")) {
+        return new Response(null, { status: opts.orgStatus ?? 204 });
+      }
+      // /user
+      return new Response(
+        JSON.stringify({
+          id: opts.id,
+          login: opts.login,
+          name: opts.name ?? null,
+          email: opts.email ?? null,
+          avatar_url: opts.avatarUrl ?? null,
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+  }
+
+  function tokenFromRedirect(location: string): string {
+    return decodeURIComponent(new URL(location, "http://localhost").searchParams.get("token")!);
+  }
+
+  let realDb: StateDb;
+  beforeEach(async () => {
+    const { StateDb } = await import("#src/state/db.js");
+    realDb = new StateDb(":memory:");
+  });
+  afterEach(() => realDb.close());
+
+  it("GitHub login creates a users row + carries the login in the token", async () => {
+    const originalFetch = global.fetch;
+    global.fetch = mockGithubFetchFull({
+      id: 4242,
+      login: "octocat",
+      name: "The Octocat",
+      avatarUrl: "https://avatars/oct.png",
+    });
+    const { decodeToken } = await import("#src/admin/auth.js");
+
+    const app = createAdminRoutes(realDb, mockSessions, mockSessions, makeConfig({
+      githubOAuthClientId: "GH_CLIENT",
+      githubOAuthClientSecret: "GH_SECRET",
+      githubOAuthRedirectUri: "http://localhost/callback",
+      githubAllowedOrg: "acme",
+    }));
+
+    const state = "s-gh-1";
+    const res = await app.fetch(
+      new Request(`http://localhost/oauth/github/callback?code=abc&state=${state}`, {
+        headers: { Cookie: `github_oauth_state=${state}` },
+      }),
+    );
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("/admin/?token=");
+
+    // A users row was created with the profile fields + the /user/emails fallback.
+    const user = realDb.users.findByGithubId(4242);
+    expect(user?.login).toBe("octocat");
+    expect(user?.name).toBe("The Octocat");
+    expect(user?.avatarUrl).toBe("https://avatars/oct.png");
+    expect(user?.email).toBe("primary@example.com"); // primary+verified from /user/emails
+
+    // The token carries the verified login.
+    expect(decodeToken(tokenFromRedirect(location))?.login).toBe("octocat");
+
+    global.fetch = originalFetch;
+  });
+
+  it("persists identity even under githubAllowAnyUser (no org gate)", async () => {
+    const originalFetch = global.fetch;
+    global.fetch = mockGithubFetchFull({ id: 7, login: "anyuser", email: "any@example.com" });
+
+    const app = createAdminRoutes(realDb, mockSessions, mockSessions, makeConfig({
+      githubOAuthClientId: "GH_CLIENT",
+      githubOAuthClientSecret: "GH_SECRET",
+      githubOAuthRedirectUri: "http://localhost/callback",
+      githubAllowedOrg: "*",
+    }));
+
+    const state = "s-gh-2";
+    const res = await app.fetch(
+      new Request(`http://localhost/oauth/github/callback?code=abc&state=${state}`, {
+        headers: { Cookie: `github_oauth_state=${state}` },
+      }),
+    );
+    expect(res.status).toBe(302);
+    expect(realDb.users.findByGithubId(7)?.login).toBe("anyuser");
+    expect(realDb.users.findByGithubId(7)?.email).toBe("any@example.com"); // from /user, no fallback
+
+    global.fetch = originalFetch;
+  });
+
+  it("Slack login whose email matches a GitHub row links slack_user_id + carries that login", async () => {
+    // Seed a GitHub identity first.
+    realDb.users.getOrCreateUserByGithub({ githubId: 99, login: "dev", email: "dev@corp.com" });
+
+    const originalFetch = global.fetch;
+    global.fetch = mockSlackFetch({
+      sub: "U777",
+      name: "Dev Eloper",
+      email: "dev@corp.com",
+      "https://slack.com/team_id": "TANY",
+      "https://slack.com/user_id": "U777",
+    });
+    const { decodeToken } = await import("#src/admin/auth.js");
+
+    const app = createAdminRoutes(realDb, mockSessions, mockSessions, makeConfig({
+      slackOAuthClientId: "C123",
+      slackOAuthClientSecret: "secret",
+      slackOAuthRedirectUri: "http://localhost/callback",
+    }));
+
+    const state = "s-slack-1";
+    const res = await app.fetch(
+      new Request(`http://localhost/oauth/slack/callback?code=abc&state=${state}`, {
+        headers: { Cookie: `slack_oauth_state=${state}` },
+      }),
+    );
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+
+    // The Slack id linked onto the existing GitHub row (same person).
+    const linked = realDb.users.findBySlackUserId("U777");
+    expect(linked?.login).toBe("dev");
+    expect(linked?.githubId).toBe(99);
+    // The token carries the matched GitHub login.
+    expect(decodeToken(tokenFromRedirect(location))?.login).toBe("dev");
+
+    global.fetch = originalFetch;
+  });
+});
+
 describe("POST /login (password)", () => {
   it("still works with correct password", async () => {
     const app = createAdminRoutes(mockDb, mockSessions, mockSessions, makeConfig({
@@ -634,7 +796,8 @@ describe("POST /workflow-runs/:id/cancel", () => {
     expect(killMock).toHaveBeenCalledWith("lastlight-sandbox-task-xyz-review-bbbbbbbb");
     expect(killMock).not.toHaveBeenCalledWith("lastlight-sandbox-other-cccccccc");
     expect(finishes.map((f) => f.id).sort()).toEqual(["e1", "e2"]);
-    expect(finishes.every((f) => f.error === "cancelled via admin dashboard")).toBe(true);
+    // Auth disabled in this test → no actor login, so it falls back to `admin`.
+    expect(finishes.every((f) => f.error === "cancelled via admin dashboard by admin")).toBe(true);
   });
 
   it("does NOT mark sibling-run executions as failed when cancelling a run with a shared triggerId", async () => {

--- a/apps/server/tests/connectors/slack/connector.test.ts
+++ b/apps/server/tests/connectors/slack/connector.test.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import Database from "better-sqlite3";
 import { SlackConnector, verifySlackSignature } from "#src/connectors/slack/connector.js";
 import { SessionManager } from "#src/connectors/messaging/session-manager.js";
+import { StateDb } from "#src/state/db.js";
 import type { EventEnvelope } from "#src/connectors/types.js";
 
 function sign(secret: string, ts: string, body: string): string {
@@ -279,5 +280,62 @@ describe("SlackConnector webhook receiver", () => {
     await postInteraction(approvePayload()); // Slack retry, identical trigger_id
     await settle();
     expect(actions).toHaveLength(1);
+  });
+});
+
+// Slack → user identity matching (issue #205). resolveUsername prefers the
+// matched GitHub login so a Slack-initiated run attributes to the same person.
+describe("SlackConnector user identity matching", () => {
+  let db: Database.Database;
+  let store: StateDb;
+  let conn: SlackConnector;
+
+  function makeConn(profileEmail?: string): SlackConnector {
+    const sm = new SessionManager(db);
+    const c = new SlackConnector(
+      { botToken: "xoxb-test", mode: "socket", appToken: "xapp-test", botIdentifier: "", users: store.users } as never,
+      sm,
+    );
+    (c as any).web = {
+      users: {
+        info: async () => ({ user: { name: "slackname", real_name: "Real Name", profile: profileEmail ? { email: profileEmail } : {} } }),
+      },
+    };
+    return c;
+  }
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    store = new StateDb(":memory:");
+  });
+  afterEach(() => {
+    db.close();
+    store.close();
+  });
+
+  it("returns the GitHub login when the Slack email matches a users row + links the slack id", async () => {
+    store.users.getOrCreateUserByGithub({ githubId: 5, login: "ghdev", email: "dev@corp.com" });
+    conn = makeConn("dev@corp.com");
+    const resolved = await (conn as any).resolveUsername("U555");
+    expect(resolved).toBe("ghdev");
+    expect(store.users.findBySlackUserId("U555")?.login).toBe("ghdev");
+  });
+
+  it("fast-paths an already-linked slack id without needing the email again", async () => {
+    const u = store.users.getOrCreateUserByGithub({ githubId: 6, login: "linked", email: "l@corp.com" });
+    store.users.linkSlackUser(u.id, "U666");
+    conn = makeConn(undefined); // no email scope
+    expect(await (conn as any).resolveUsername("U666")).toBe("linked");
+  });
+
+  it("falls back to the Slack username when there's no match", async () => {
+    conn = makeConn("stranger@corp.com");
+    expect(await (conn as any).resolveUsername("U000")).toBe("slackname");
+  });
+
+  it("falls back to the Slack username when the email scope is missing", async () => {
+    store.users.getOrCreateUserByGithub({ githubId: 7, login: "hidden", email: "h@corp.com" });
+    conn = makeConn(undefined); // users:read.email not granted → no email
+    expect(await (conn as any).resolveUsername("U111")).toBe("slackname");
   });
 });

--- a/apps/server/tests/state/user-store.test.ts
+++ b/apps/server/tests/state/user-store.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { StateDb } from "#src/state/db.js";
+import { StateDb, isTriggerActorType, TRIGGER_ACTOR_TYPES } from "#src/state/db.js";
+
+describe("isTriggerActorType", () => {
+  it("accepts every member of the union", () => {
+    for (const t of TRIGGER_ACTOR_TYPES) expect(isTriggerActorType(t)).toBe(true);
+  });
+
+  it("rejects an unrecognised string, so untrusted context falls through", () => {
+    expect(isTriggerActorType("hacker")).toBe(false);
+    expect(isTriggerActorType("GITHUB")).toBe(false); // case-sensitive
+  });
+
+  it("rejects non-string values", () => {
+    expect(isTriggerActorType(undefined)).toBe(false);
+    expect(isTriggerActorType(null)).toBe(false);
+    expect(isTriggerActorType(42)).toBe(false);
+    expect(isTriggerActorType({})).toBe(false);
+  });
+});
 
 let db: StateDb;
 

--- a/apps/server/tests/state/user-store.test.ts
+++ b/apps/server/tests/state/user-store.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { StateDb } from "#src/state/db.js";
+
+let db: StateDb;
+
+beforeEach(() => {
+  db = new StateDb(":memory:");
+});
+
+afterEach(() => {
+  db.close();
+});
+
+describe("UserStore.getOrCreateUserByGithub", () => {
+  it("creates a user capturing id/login/name/email/avatar", () => {
+    const user = db.users.getOrCreateUserByGithub({
+      githubId: 42,
+      login: "octocat",
+      name: "The Octocat",
+      email: "octo@example.com",
+      avatarUrl: "https://avatars/oct.png",
+    });
+    expect(user.githubId).toBe(42);
+    expect(user.login).toBe("octocat");
+    expect(user.name).toBe("The Octocat");
+    expect(user.email).toBe("octo@example.com");
+    expect(user.avatarUrl).toBe("https://avatars/oct.png");
+    expect(user.isBlocked).toBe(false);
+    expect(user.emailIsPlaceholder).toBe(false);
+    expect(user.lastLoginAt).toBeTruthy();
+  });
+
+  it("upserts on github_id — refreshes mutable fields and bumps last_login_at", () => {
+    const first = db.users.getOrCreateUserByGithub({
+      githubId: 42,
+      login: "octocat",
+      name: "Old Name",
+      email: "old@example.com",
+    });
+    const second = db.users.getOrCreateUserByGithub({
+      githubId: 42,
+      login: "octocat-renamed",
+      name: "New Name",
+      email: "new@example.com",
+      avatarUrl: "https://a.png",
+    });
+    expect(second.id).toBe(first.id); // same row
+    expect(second.login).toBe("octocat-renamed");
+    expect(second.name).toBe("New Name");
+    expect(second.email).toBe("new@example.com");
+    expect(second.avatarUrl).toBe("https://a.png");
+    // Only one row exists.
+    expect(db.users.findByGithubId(42)?.id).toBe(first.id);
+  });
+
+  it("preserves existing name/email/avatar when a refresh omits them", () => {
+    db.users.getOrCreateUserByGithub({
+      githubId: 7,
+      login: "a",
+      name: "Ada",
+      email: "ada@example.com",
+      avatarUrl: "https://ada.png",
+    });
+    const refreshed = db.users.getOrCreateUserByGithub({ githubId: 7, login: "a" });
+    expect(refreshed.name).toBe("Ada");
+    expect(refreshed.email).toBe("ada@example.com");
+    expect(refreshed.avatarUrl).toBe("https://ada.png");
+  });
+
+  it("is findable by login and email", () => {
+    db.users.getOrCreateUserByGithub({ githubId: 42, login: "octocat", email: "octo@example.com" });
+    expect(db.users.findByLogin("octocat")?.githubId).toBe(42);
+    expect(db.users.findByEmail("octo@example.com")?.login).toBe("octocat");
+  });
+});
+
+describe("UserStore.upsertSlackUser", () => {
+  it("matches an existing GitHub row by email and links slack_user_id", () => {
+    const gh = db.users.getOrCreateUserByGithub({
+      githubId: 42,
+      login: "octocat",
+      email: "octo@example.com",
+    });
+    const matched = db.users.upsertSlackUser({
+      slackUserId: "U123",
+      name: "Octo",
+      email: "octo@example.com",
+    });
+    expect(matched.id).toBe(gh.id);
+    expect(matched.login).toBe("octocat"); // retains GitHub identity
+    expect(matched.slackUserId).toBe("U123");
+    expect(db.users.findBySlackUserId("U123")?.login).toBe("octocat");
+  });
+
+  it("creates a Slack-only row when no email matches", () => {
+    const slackOnly = db.users.upsertSlackUser({
+      slackUserId: "U999",
+      name: "Stranger",
+      email: "nobody@example.com",
+    });
+    expect(slackOnly.login).toBeUndefined();
+    expect(slackOnly.githubId).toBeUndefined();
+    expect(slackOnly.slackUserId).toBe("U999");
+    expect(slackOnly.name).toBe("Stranger");
+  });
+
+  it("is idempotent on slack_user_id (fast path re-links, no duplicate row)", () => {
+    const first = db.users.upsertSlackUser({ slackUserId: "U1", name: "One" });
+    const second = db.users.upsertSlackUser({ slackUserId: "U1", email: "one@example.com" });
+    expect(second.id).toBe(first.id);
+    expect(second.email).toBe("one@example.com");
+    expect(second.name).toBe("One");
+  });
+});
+
+describe("UserStore.linkSlackUser", () => {
+  it("links a slack id onto an existing user", () => {
+    const gh = db.users.getOrCreateUserByGithub({ githubId: 1, login: "a" });
+    db.users.linkSlackUser(gh.id, "U-link");
+    expect(db.users.findBySlackUserId("U-link")?.id).toBe(gh.id);
+  });
+});

--- a/apps/server/tests/state/workflow-run-store.test.ts
+++ b/apps/server/tests/state/workflow-run-store.test.ts
@@ -31,6 +31,28 @@ function makeRun(overrides: Partial<Parameters<WorkflowRunStore["createRun"]>[0]
   return id;
 }
 
+describe("actor logging (issue #205)", () => {
+  it("persists triggered_by / trigger_actor_type and surfaces them on read", () => {
+    const id = makeRun({ triggeredBy: "octocat", triggerActorType: "github" });
+    const run = db.runs.getRun(id);
+    expect(run?.triggeredBy).toBe("octocat");
+    expect(run?.triggerActorType).toBe("github");
+  });
+
+  it("surfaces the actor on the paginated list() rows too", () => {
+    makeRun({ triggeredBy: "alice", triggerActorType: "cli" });
+    const { runs } = db.runs.list();
+    expect(runs[0]?.triggeredBy).toBe("alice");
+    expect(runs[0]?.triggerActorType).toBe("cli");
+  });
+
+  it("leaves the actor undefined when not supplied (additive, back-compat)", () => {
+    const run = db.runs.getRun(makeRun());
+    expect(run?.triggeredBy).toBeUndefined();
+    expect(run?.triggerActorType).toBeUndefined();
+  });
+});
+
 describe("pauseForApproval", () => {
   it("creates the approval, appends the marker, merges scratch, and pauses — in one step", () => {
     const runId = makeRun();


### PR DESCRIPTION
Closes #205. Foundation for team-based per-repo visibility (#169).

Establishes a first-class user identity and threads real actor attribution through every workflow-invocation path. Implemented in the issue's 7-step order — each step additive and independently green.

## What's in it

**1. `users` table + `UserStore`** (`state/user-store.ts`) — captures GitHub identity (id/login/name/email/avatar) plus a lazily-linked Slack user id. Additive enrichment table joined on `login`; upserts key on `github_id` / `slack_user_id`; `email` indexed but **non-unique** (shared mailboxes + null Slack rows). Wired as `db.users` into the `StateDb` root.

**2. Token identity** (`admin/auth.ts`) — `createToken` gained an optional 3rd `login` arg (signature-compatible; 2-arg callers unchanged); `login` round-trips through decode + refresh; new `actorFromContext(c)` seam, set by `authMiddleware`.

**3. OAuth callbacks** — GitHub widened to read id/name/email/avatar with a `/user/emails` primary+verified fallback, upserts the user, carries `login` in the token (even under `githubAllowAnyUser`). Slack requests the `email` scope, matches/links by email, carries the matched GitHub login.

**4. Actor logging** — additive `triggered_by` / `trigger_actor_type` columns on `executions` and `workflow_runs`. Run stores the **original** trigger; retry/cancel/approve actors land on the append-only `executions` ledger. Derived in `dispatchWorkflow`; CLI/cron/retry/cancel/approval attribute to the authenticated user (falling back to `cli`/`admin`).

**5. Slack → user matching** — the connector resolves a Slack user's email to a `users` row and prefers their GitHub login (fast-path on `slack_user_id` → email match → link), degrading to the Slack username without the `users:read.email` scope. Never blocks the run.

**Docs** — spec `10-state.md` (users table + actor columns + semantics), `CLAUDE.md` + `.env.example` (the `users:read.email` setup step).

## Design decisions (per the issue)

- `email` non-unique (index only); upserts key on the stable ids.
- Identity captured even for `githubAllowAnyUser` logins (orthogonal to the auth gate).
- Semantics: run `triggered_by` = original trigger; retry/cancel/approve actors go on the executions ledger, not overwriting the run's origin.
- **No new audit table** here — attribution reuses the existing ledgers. A single append-only cross-cutting Activity Log is the deliberate follow-up: **#206**.

## Testing

`pnpm --filter lastlight-core typecheck` clean; full suite green (**1196 passed / 7 skipped**), including new coverage for `UserStore`, the token `login` round-trip, the GitHub + Slack OAuth identity capture (real in-memory `StateDb`), the run-store actor columns, and the Slack connector email match/fallback.

## Not included

An unrelated working-tree edit to `apps/server/CONTEXT.md` (a "RunIdentity" refactor note that doesn't correspond to current code) was deliberately left out to keep this PR scoped to #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
