### PR TITLE
feat: publish lastlight-agent-qemu image for the gondolin/k8s path (#210 Gap 1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,8 +30,8 @@ name: Publish release
 # behind `checks`); it never publishes to npm — the `npm` job is gated to
 # `release` events.
 #
-# Build the four locally-built images (agent + sandbox-base + sandbox +
-# sandbox-qa) once and push them to GHCR, so `lastlight server update` PULLS them
+# Build the five locally-built images (agent + agent-qemu + sandbox-base +
+# sandbox + sandbox-qa) once and push them to GHCR, so `lastlight server update` PULLS them
 # on the deploy host instead of building from source (minutes → seconds).
 #
 # The stock sidecar images (coredns / nginx / otel-collector / caddy) are pulled
@@ -118,7 +118,7 @@ jobs:
         id: meta
         run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
-      # Required set: agent + sandbox-base + sandbox, built in one bake graph so
+      # Required set: agent + agent-qemu + sandbox-base + sandbox, built in one bake graph so
       # `sandbox` links to `target:sandbox-base` by content (see docker-bake.hcl).
       - name: Build & push core images
         # Invoke from apps/server/ (where docker-bake.hcl lives) so its

--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -782,7 +782,10 @@ sudo -u lastlight -i lastlight server update
    rather than building them on the host — a release publishes
    `ghcr.io/nearform/lastlight-{agent,sandbox-base,sandbox,sandbox-qa}` via the
    `images` job of `.github/workflows/publish.yml` (on GitHub Release +
-   `workflow_dispatch`, amd64, public). `server update` pulls the tag `resolveImageTag` returns — the
+   `workflow_dispatch`, amd64, public). (The release also publishes a fifth
+   image, `lastlight-agent-qemu` — `agent` + QEMU for the gondolin/k8s path,
+   see `deploy/k8s/` — which the compose stack doesn't use, so it isn't pulled
+   here.) `server update` pulls the tag `resolveImageTag` returns — the
    overlay's `deploy.version` pin (e.g. `v0.11.0`) when set, else `:latest` — and
    re-tags each to its **local** name (`lastlight-agent`,
    `lastlight-sandbox:latest`, …), which is what `docker-compose.yml` and the

--- a/apps/server/agent-qemu.Dockerfile
+++ b/apps/server/agent-qemu.Dockerfile
@@ -1,0 +1,14 @@
+# Last Light agent image + QEMU, so the gondolin micro-VM sandbox backend works
+# in a container/Kubernetes environment. The base ghcr.io/nearform/lastlight-agent
+# image ships no QEMU binary — it targets the `docker` backend; gondolin's QEMU
+# is otherwise only provided on the native systemd host (deploy/native/). Built
+# in the same bake graph as `agent` (docker-bake.hcl) via a content-keyed
+# context, so it re-uses the base's layers and cache. See nearform/lastlight#210.
+ARG AGENT_IMAGE=lastlight-agent:latest
+FROM ${AGENT_IMAGE}
+USER root
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends qemu-system-x86 qemu-utils \
+ && rm -rf /var/lib/apt/lists/*
+# No USER / ENTRYPOINT / CMD — inherited from the base image (its entrypoint runs
+# as root then `exec gosu lastlight`, UID 10001), so we must NOT set USER here.

--- a/apps/server/deploy/k8s/README.md
+++ b/apps/server/deploy/k8s/README.md
@@ -20,7 +20,7 @@ backend, which runs each workflow phase in a QEMU micro-VM. It uses the
   privileged. **The only privileged component here.**
 - `deployment.yaml`, `pvc.yaml`, `service.yaml`, `configmap.yaml` — the harness.
 
-## The four edits it needs
+## The edits it needs
 
 1. **Image** (`deployment.yaml`) — pin `ghcr.io/nearform/lastlight-agent-qemu`
    to a release tag.

--- a/apps/server/deploy/k8s/README.md
+++ b/apps/server/deploy/k8s/README.md
@@ -1,0 +1,56 @@
+# Running Last Light on Kubernetes (gondolin backend)
+
+A complete, `kubectl apply -k`-able example for the **default gondolin** sandbox
+backend, which runs each workflow phase in a QEMU micro-VM. It uses the
+`lastlight-agent-qemu` image (the base `lastlight-agent` image ships no QEMU).
+
+## Cluster prerequisites
+
+- Nodes with **`/dev/kvm`** present — bare metal, or a VM/cloud instance with
+  nested virtualization enabled — and the `kvm` kernel module active. Most
+  managed shared-CPU hosts (Cloud Run, Fly shared VMs) do **not** qualify.
+- A block/local StorageClass (not NFS) so the embedded SQLite DB locks safely.
+
+## What this set contains
+
+- `namespace.yaml` — the `lastlight` namespace at `privileged` PodSecurity
+  (required: `SYS_RESOURCE` exceeds `baseline`).
+- `generic-device-plugin.yaml` — `squat/generic-device-plugin` DaemonSet
+  advertising `devic.es/kvm`, so the pod gets `/dev/kvm` without being
+  privileged. **The only privileged component here.**
+- `deployment.yaml`, `pvc.yaml`, `service.yaml`, `configmap.yaml` — the harness.
+
+## The four edits it needs
+
+1. **Image** (`deployment.yaml`) — pin `ghcr.io/nearform/lastlight-agent-qemu`
+   to a release tag.
+2. **Secret** — create it (see below); the Deployment mounts `lastlight-secrets`.
+3. **StorageClass** (`pvc.yaml`) — set `storageClassName`, or rely on the
+   cluster default.
+4. **Ingress** — add your own Ingress/Gateway to reach the `lastlight` Service on
+   port 8644 (the GitHub webhook needs to reach it). Not shipped — cluster-specific.
+5. **Managed repos** (`configmap.yaml`) — set `managedRepos`.
+
+## Create the Secret
+
+```bash
+kubectl create secret generic lastlight-secrets \
+  --namespace lastlight \
+  --from-file=.env=instance/secrets/.env \
+  --from-file=app.pem=instance/secrets/app.pem
+```
+
+(The namespace must exist first: `kubectl apply -f namespace.yaml`, or apply the
+whole set and re-create the Secret — the pod stays pending until it exists.)
+
+## Apply
+
+```bash
+kubectl apply -k .
+```
+
+## Known limitation
+
+Until [nearform/lastlight#210](https://github.com/nearform/lastlight/issues/210)
+Gap 2 lands, the gondolin guest image lacks `gitleaks`/`semgrep`, so the
+`security-review` task falls back to a manual (Claude-only) pass.

--- a/apps/server/deploy/k8s/README.md
+++ b/apps/server/deploy/k8s/README.md
@@ -49,6 +49,11 @@ whole set and re-create the Secret — the pod stays pending until it exists.)
 kubectl apply -k .
 ```
 
+On the first apply the pod may sit `Pending` for a minute or two with an
+`Insufficient devic.es/kvm` event while the device-plugin DaemonSet starts and
+registers the resource on each node. Kubernetes reschedules automatically once
+it's advertised — no action needed.
+
 ## Known limitation
 
 Until [nearform/lastlight#210](https://github.com/nearform/lastlight/issues/210)

--- a/apps/server/deploy/k8s/configmap.yaml
+++ b/apps/server/deploy/k8s/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lastlight-config
+  namespace: lastlight
+data:
+  # Overlay layered over the image's config/default.yaml. At minimum set the
+  # repos the bot manages. EDIT managedRepos before applying.
+  config.yaml: |
+    managedRepos:
+      - your-org/your-repo
+    sandbox:
+      backend: gondolin

--- a/apps/server/deploy/k8s/deployment.yaml
+++ b/apps/server/deploy/k8s/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lastlight
+  namespace: lastlight
+  labels: { app: lastlight }
+spec:
+  replicas: 1
+  strategy: { type: Recreate }          # single embedded-SQLite writer on an RWO PVC
+  selector:
+    matchLabels: { app: lastlight }
+  template:
+    metadata:
+      labels: { app: lastlight }
+    spec:
+      containers:
+        - name: agent
+          # EDIT: pin to a release tag, e.g. :v0.21.8, once you cut a deploy.
+          image: ghcr.io/nearform/lastlight-agent-qemu:latest
+          # No runAsUser/runAsNonRoot — the entrypoint starts as root then
+          # `exec gosu lastlight` (UID 10001). SYS_RESOURCE is the one added
+          # capability gondolin's QEMU needs; still no privileged:true / hostPath.
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+          ports:
+            - { name: http, containerPort: 8644 }
+          env:
+            - { name: LASTLIGHT_OVERLAY_DIR, value: /app/instance }
+            - { name: STATE_DIR, value: /app/data }
+            # Persist gondolin's downloaded guest VM image on the PVC
+            # ($HOME/.cache/agentic-pi/images) so it survives restarts.
+            - { name: HOME, value: /app/data/home }
+          resources:
+            requests:
+              cpu: "500m"
+              memory: 1Gi
+            limits:
+              cpu: "4"
+              memory: 6Gi
+              devic.es/kvm: "1"       # unprivileged /dev/kvm via the device plugin
+          volumeMounts:
+            - { name: data, mountPath: /app/data }
+            - { name: secrets, mountPath: /app/instance/secrets, readOnly: true }
+            - { name: config, mountPath: /app/instance/config.yaml, subPath: config.yaml, readOnly: true }
+          startupProbe:                 # first boot downloads the guest image — be patient
+            httpGet: { path: /health, port: 8644 }
+            periodSeconds: 10
+            failureThreshold: 60        # up to 10 min
+          readinessProbe:
+            httpGet: { path: /health, port: 8644 }
+            periodSeconds: 15
+          livenessProbe:
+            httpGet: { path: /health, port: 8644 }
+            periodSeconds: 30
+            failureThreshold: 4
+      volumes:
+        - name: data
+          persistentVolumeClaim: { claimName: lastlight-data }
+        - name: secrets
+          secret: { secretName: lastlight-secrets }
+        - name: config
+          configMap: { name: lastlight-config }

--- a/apps/server/deploy/k8s/generic-device-plugin.yaml
+++ b/apps/server/deploy/k8s/generic-device-plugin.yaml
@@ -1,0 +1,63 @@
+# Exposes /dev/kvm to unprivileged pods as the schedulable resource
+# `devic.es/kvm`, so the harness can run gondolin QEMU micro-VMs without being
+# privileged. Talos/siderolabs-recommended pattern. This DaemonSet is the only
+# privileged component in this example.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: generic-device-plugin
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: generic-device-plugin
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: generic-device-plugin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: generic-device-plugin
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
+          effect: "NoExecute"
+        - operator: "Exists"
+          effect: "NoSchedule"
+      containers:
+        - name: generic-device-plugin
+          image: squat/generic-device-plugin:0.2.0
+          args:
+            - --device
+            - |
+              name: kvm
+              groups:
+                - count: 1000
+                  paths:
+                    - path: /dev/kvm
+          resources:
+            requests:
+              cpu: 50m
+              memory: 10Mi
+            limits:
+              cpu: 50m
+              memory: 20Mi
+          ports:
+            - containerPort: 8080
+              name: http
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: dev
+          hostPath:
+            path: /dev
+  updateStrategy:
+    type: RollingUpdate

--- a/apps/server/deploy/k8s/kustomization.yaml
+++ b/apps/server/deploy/k8s/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The Secret is intentionally NOT here — it carries the GitHub App key + .env and
+# is created out-of-band (see README). Everything the pod otherwise depends on,
+# including the KVM device plugin, ships in this set.
+resources:
+  - namespace.yaml
+  - generic-device-plugin.yaml
+  - configmap.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/apps/server/deploy/k8s/namespace.yaml
+++ b/apps/server/deploy/k8s/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lastlight
+  labels:
+    # gondolin's QEMU needs the SYS_RESOURCE capability, which exceeds the
+    # cluster-default "baseline" PSA — so this namespace runs at "privileged".
+    # The pod itself is NOT privileged: one added capability + the KVM device,
+    # no privileged:true, no hostPath, no host namespaces.
+    pod-security.kubernetes.io/enforce: privileged

--- a/apps/server/deploy/k8s/pvc.yaml
+++ b/apps/server/deploy/k8s/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lastlight-data
+  namespace: lastlight
+spec:
+  accessModes: ["ReadWriteOnce"]   # single embedded-SQLite writer
+  resources:
+    requests:
+      storage: 20Gi
+  # EDIT: a local/block StorageClass so SQLite file locking is safe (not NFS).
+  # Leaving this unset uses the cluster default StorageClass.
+  # storageClassName: your-block-storage-class

--- a/apps/server/deploy/k8s/service.yaml
+++ b/apps/server/deploy/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: lastlight
+  namespace: lastlight
+spec:
+  selector:
+    app: lastlight
+  ports:
+    - name: http
+      port: 8644
+      targetPort: 8644

--- a/apps/server/docker-bake.hcl
+++ b/apps/server/docker-bake.hcl
@@ -1,4 +1,4 @@
-# Build definition for the four locally-built Last Light images, driven by
+# Build definition for the five locally-built Last Light images, driven by
 # the `images` job of .github/workflows/publish.yml via `docker buildx bake`.
 #
 # WHY BAKE: the sandbox leaves (sandbox, sandbox-qa) are `FROM

--- a/apps/server/docker-bake.hcl
+++ b/apps/server/docker-bake.hcl
@@ -49,7 +49,7 @@ function "cache_to" {
 # The required set — must all succeed. sandbox-base is built once here and shared
 # (as a content-keyed context) by the sandbox target.
 group "core" {
-  targets = ["agent", "sandbox-base", "sandbox"]
+  targets = ["agent", "agent-qemu", "sandbox-base", "sandbox"]
 }
 
 # Only the agent Dockerfile takes GIT_SHA / BUILD_DATE (the drift banner).
@@ -60,6 +60,20 @@ target "agent" {
   args       = { GIT_SHA = GIT_SHA, BUILD_DATE = BUILD_DATE }
   cache-from = cache_from("lastlight-agent")
   cache-to   = cache_to("lastlight-agent")
+}
+
+# The QEMU-enabled agent variant (gondolin/k8s). FROM the agent image via a
+# content-keyed context (same pattern as sandbox→sandbox-base): the cache keys
+# on the base's CONTENT, not its pushed digest, so it hits across releases. The
+# bare context name `agent` matches `FROM ${AGENT_IMAGE}` after arg substitution.
+target "agent-qemu" {
+  dockerfile = "apps/server/agent-qemu.Dockerfile"
+  context    = "../.."
+  args       = { AGENT_IMAGE = "agent" }
+  contexts   = { agent = "target:agent" }
+  tags       = tags("lastlight-agent-qemu")
+  cache-from = cache_from("lastlight-agent-qemu")
+  cache-to   = cache_to("lastlight-agent-qemu")
 }
 
 target "sandbox-base" {

--- a/apps/server/spec/02-configuration.md
+++ b/apps/server/spec/02-configuration.md
@@ -292,7 +292,10 @@ production `deploy.sh` flow (pull overlay → converge core → **pull prebuilt
 images** → `up -d --remove-orphans` → restart egress sidecars → health-check).
 By default it *pulls* the four images from GHCR
 (`ghcr.io/nearform/lastlight-{agent,sandbox-base,sandbox,sandbox-qa}`, published
-on GitHub Release by the `images` job of `.github/workflows/publish.yml`) at the tag
+on GitHub Release by the `images` job of `.github/workflows/publish.yml`; the
+same job also publishes a fifth image, `lastlight-agent-qemu`, for the
+gondolin/k8s path, which the compose stack doesn't use and `server update`
+doesn't pull) at the tag
 `resolveImageTag` returns — the overlay `deploy.version` pin, else `:latest` —
 and re-tags each to its local name so compose + the harness (fixed names in
 `src/sandbox/images.ts`) find them unchanged; `--local` builds from source

--- a/apps/www/src/pages/run-it.astro
+++ b/apps/www/src/pages/run-it.astro
@@ -140,54 +140,10 @@ services:
 
 		<div class="step-block">
 			<h3><span class="step-label">Step 5</span> Running in Kubernetes <span class="step-label">optional</span></h3>
-		<p class="section-desc">The same Docker image works in K8s. Skip Caddy — use your cluster's Ingress controller for TLS instead.</p>
-		<pre><code>apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: lastlight
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: lastlight
-  template:
-    metadata:
-      labels:
-        app: lastlight
-    spec:
-      containers:
-      - name: agent
-        image: your-registry/lastlight:latest
-        ports:
-        - containerPort: 8644
-        env:
-        - name: LASTLIGHT_OVERLAY_DIR
-          value: /app/instance
-        volumeMounts:
-        - name: secrets
-          mountPath: /app/instance/secrets
-          readOnly: true
-        - name: state
-          mountPath: /app/data
-      volumes:
-      - name: secrets
-        secret:
-          secretName: lastlight-secrets
-      - name: state
-        persistentVolumeClaim:
-          claimName: lastlight-state
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: lastlight
-spec:
-  selector:
-    app: lastlight
-  ports:
-  - port: 8644
-    targetPort: 8644</code></pre>
-		<p class="section-note">Create the K8s Secret from your local files: <code>kubectl create secret generic lastlight-secrets --from-file=.env=instance/secrets/.env --from-file=app.pem=instance/secrets/app.pem</code></p>
+		<p class="section-desc">Which image you need depends on the sandbox backend. The default <strong>gondolin</strong> backend runs each phase in a QEMU micro-VM, so it needs QEMU in the image and <code>/dev/kvm</code> on the node — use the <code>lastlight-agent-qemu</code> variant. The base <code>lastlight-agent</code> image ships no QEMU: it targets the <code>docker</code> backend, which wants a Docker socket that containerd-based clusters don't expose.</p>
+		<p class="section-desc">A complete, <code>kubectl apply -k</code>-able example lives in <a href="https://github.com/nearform/lastlight/tree/main/apps/server/deploy/k8s" target="_blank" rel="noopener">apps/server/deploy/k8s/</a> — namespace, the KVM device plugin, Deployment, PVC, and Service. It exposes <code>/dev/kvm</code> to an otherwise-unprivileged pod via the <code>squat/generic-device-plugin</code> DaemonSet (resource <code>devic.es/kvm</code>), adds the one <code>SYS_RESOURCE</code> capability gondolin's QEMU needs (which requires the namespace to run at <code>privileged</code> PodSecurity), and keeps the guest-image cache on the PVC. Follow its README for the edits it needs (image tag, Secret, StorageClass, ingress, managed repos).</p>
+		<p class="section-note">Until <a href="https://github.com/nearform/lastlight/issues/210" target="_blank" rel="noopener">#210</a> Gap 2 lands, the gondolin guest image lacks <code>gitleaks</code>/<code>semgrep</code>, so <code>security-review</code> falls back to a manual pass.</p>
+		<p class="section-note">Create the K8s Secret from your local files: <code>kubectl create secret generic lastlight-secrets --namespace lastlight --from-file=.env=instance/secrets/.env --from-file=app.pem=instance/secrets/app.pem</code></p>
 		</div>
 	</section>
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing Last Light
 
-The monorepo publishes **six** npm packages plus **four** Docker images.
+The monorepo publishes **six** npm packages plus **five** Docker images.
 Publishing is **automated**: cutting a GitHub Release fires `publish.yml`, which
 runs CI checks → builds+pushes the GHCR images → publishes **five** of the six
 npm packages (engine → shared → core → cli → evals) in dependency order via npm
@@ -50,9 +50,11 @@ Everything else is `private: true` and never publishes: the root package
 (`lastlight-monorepo`), `lastlight-www`, `@lastlight/dashboard`,
 `@lastlight/evals-dashboard`.
 
-**Docker (GHCR, `ghcr.io/nearform/lastlight-*`):** `agent`, `sandbox-base`,
-`sandbox` (the required trio, built as one bake graph) + `sandbox-qa`
-(non-fatal). Built and pushed by `publish.yml`'s `images` job.
+**Docker (GHCR, `ghcr.io/nearform/lastlight-*`):** `agent`, `agent-qemu`,
+`sandbox-base`, `sandbox` (the required set, built as one bake graph) +
+`sandbox-qa` (non-fatal). Built and pushed by `publish.yml`'s `images` job.
+`agent-qemu` is `agent` + QEMU (gondolin/k8s) — a variant with no separate
+version line; it tracks the release tag. See nearform/lastlight#210.
 
 ## The dependency graph (why order matters)
 


### PR DESCRIPTION
Fixes Gap 1 of #210. The published `lastlight-agent` image ships no QEMU, so the
default `gondolin` sandbox backend can't run in a container/Kubernetes
environment — every workflow phase fails with `qemu-not-installed`. The
`run-it` k8s docs ("the same Docker image works in K8s") don't hold for the
shipped default.

## What this does

- **New `lastlight-agent-qemu` image** (`apps/server/agent-qemu.Dockerfile`):
  base `agent` + `qemu-system-x86` + `qemu-utils`. Wired into `docker-bake.hcl`
  as a content-keyed context target (the same pattern `sandbox` uses against
  `sandbox-base`) and added to the `core` bake group, so `publish.yml` builds
  and pushes it on release with `:vX.Y.Z`/`:latest` — no workflow change.
- **k8s example** under `apps/server/deploy/k8s/`: a `kubectl apply -k`-able set
  (namespace at `privileged` PSA, the `squat/generic-device-plugin` DaemonSet
  advertising `devic.es/kvm`, Deployment/PVC/Service/ConfigMap) plus a README.
  The pod stays unprivileged apart from one `SYS_RESOURCE` capability + the KVM
  device — no `privileged: true`, hostPath, or host namespaces.
- **Docs**: `run-it` Step 5 rewritten to explain the backend/image split and
  point at the example; `RELEASING.md`, `apps/server/CLAUDE.md`, the spec, and
  the bake/publish comments updated to record the fifth image (noting it is
  published but not pulled by the compose `server update` flow).

## Design note for review

QEMU ships as a **separate `-qemu` variant** to keep the base image lean for
docker-backend users (QEMU adds a few hundred MB they never use), matching the
proposal in #210. Since gondolin is the *default* backend, there's a reasonable
alternative: bake QEMU into the base `lastlight-agent` so the default works
everywhere out of the box. Happy to switch to that if you'd prefer — it's a
small change (move the apt layer into `apps/server/Dockerfile`, drop the variant
target). Your call.

## Scope

Gap 2 (the gondolin guest image lacks `gitleaks`/`semgrep`, so `security-review`
degrades to a manual pass) is **not** in this PR — a follow-up. #210 stays open;
the README and `run-it` note the limitation.

## Verification

- `docker buildx bake --print core` lists the new `agent-qemu` target with the
  content-keyed `agent` context and correct tags.
- Built the image locally (amd64): `qemu-system-x86_64` present (QEMU 7.2.22).
- `kustomize build` + `kubectl apply -k --dry-run` validate the example set.
- Against a Talos/KVM cluster with this recipe, `repo-health`,
  `security-review`, and `issue-triage` complete in gondolin micro-VMs — the
  deployment this example generalizes from.
