### PR TITLE
feat(github): log token scope on mint and on 403/404

### DIFF
--- a/apps/server/src/engine/github/git-auth.ts
+++ b/apps/server/src/engine/github/git-auth.ts
@@ -173,6 +173,22 @@ async function getInstallationToken(config: {
   }
 
   const data = await res.json();
+
+  // Log the scope GitHub actually GRANTED the minted token (the executor already
+  // logs the *requested* profile before this call). The mint response carries
+  // `repository_selection` + `permissions` — the exact datapoint that
+  // distinguishes "the injected token is correctly write-scoped, so a downstream
+  // 403 is a transit/env narrowing" from "the mint itself came back read-only /
+  // wrong-repo" (issue #215). For a repo-scoped mint `repositories` names the
+  // covered repos; for a full-installation mint it's absent and selection="all".
+  const grantedRepos = Array.isArray(data.repositories)
+    ? data.repositories.map((r: { full_name?: string; name?: string }) => r.full_name ?? r.name).join(",")
+    : "(all)";
+  console.log(
+    `[git-auth] Mint granted: repository_selection=${data.repository_selection ?? "?"}, ` +
+      `permissions=${data.permissions ? JSON.stringify(data.permissions) : "?"}, repositories=${grantedRepos}`,
+  );
+
   return { token: data.token, expiresAt: data.expires_at };
 }
 

--- a/apps/server/src/engine/github/github-app-client.ts
+++ b/apps/server/src/engine/github/github-app-client.ts
@@ -20,10 +20,52 @@ function normalizeBaseUrl(baseUrl: string | undefined): string | undefined {
   return baseUrl ? baseUrl.replace(/\/+$/, "") : undefined;
 }
 
+/**
+ * Log a diagnostic on a 403/404 from the GitHub REST API and re-throw — no
+ * behaviour change. Records the request, the endpoint's REQUIRED permissions
+ * (`x-accepted-github-permissions`), and — for App-auth clients — the actual
+ * `repository_selection` + permissions of the installation token that was used.
+ *
+ * This is the shared instrument for the two open token-scope bugs: the
+ * private-repo enumeration 404 (issue #213 — is the enumeration token's
+ * `repository_selection` really `all`, and does the 404 endpoint want a
+ * permission the token lacks?) and any "Resource not accessible by integration"
+ * 403. The token introspection reuses the strategy's CACHED installation auth
+ * (the request we just made minted it), so it adds no extra network round-trip.
+ */
+function installScopeDiagnostics(octokit: Octokit, appAuth: boolean): void {
+  octokit.hook.error("request", async (error, options) => {
+    const status = (error as { status?: number }).status;
+    if (status === 403 || status === 404) {
+      const headers =
+        (error as { response?: { headers?: Record<string, string> } }).response?.headers ?? {};
+      const accepted = headers["x-accepted-github-permissions"] ?? "(none)";
+      let scope = "";
+      if (appAuth) {
+        try {
+          const auth = (await octokit.auth({ type: "installation" })) as {
+            repositorySelection?: string;
+            permissions?: Record<string, string>;
+          };
+          const perms = auth.permissions ? Object.keys(auth.permissions).join(",") : "?";
+          scope = `; token repository_selection=${auth.repositorySelection ?? "?"}, permissions=${perms}`;
+        } catch {
+          // Introspection is best-effort — never mask the real request error.
+        }
+      }
+      console.warn(
+        `[github-diag] ${options.method} ${options.url} -> ${status}; ` +
+          `x-accepted-github-permissions=${accepted}${scope}`,
+      );
+    }
+    throw error;
+  });
+}
+
 export function githubAppClient(config: GitHubAppClientConfig): Octokit {
   const privateKey = readFileSync(resolve(config.privateKeyPath), "utf-8");
   const baseUrl = normalizeBaseUrl(config.baseUrl);
-  return new Octokit({
+  const octokit = new Octokit({
     authStrategy: createAppAuth,
     auth: {
       appId: config.appId,
@@ -32,6 +74,8 @@ export function githubAppClient(config: GitHubAppClientConfig): Octokit {
     },
     ...(baseUrl ? { baseUrl } : {}),
   });
+  installScopeDiagnostics(octokit, true);
+  return octokit;
 }
 
 /**
@@ -44,5 +88,9 @@ export function githubAppClient(config: GitHubAppClientConfig): Octokit {
  */
 export function githubTokenClient(token: string, baseUrl?: string): Octokit {
   const url = normalizeBaseUrl(baseUrl);
-  return new Octokit({ auth: token, ...(url ? { baseUrl: url } : {}) });
+  const octokit = new Octokit({ auth: token, ...(url ? { baseUrl: url } : {}) });
+  // Raw-bearer client carries no App installation to introspect — log only the
+  // request + the endpoint's required permissions.
+  installScopeDiagnostics(octokit, false);
+  return octokit;
 }

--- a/apps/server/src/engine/github/github-app-client.ts
+++ b/apps/server/src/engine/github/github-app-client.ts
@@ -47,7 +47,11 @@ function installScopeDiagnostics(octokit: Octokit, appAuth: boolean): void {
             repositorySelection?: string;
             permissions?: Record<string, string>;
           };
-          const perms = auth.permissions ? Object.keys(auth.permissions).join(",") : "?";
+          const perms = auth.permissions
+            ? Object.entries(auth.permissions)
+                .map(([name, level]) => `${name}=${level}`)
+                .join(",")
+            : "?";
           scope = `; token repository_selection=${auth.repositorySelection ?? "?"}, permissions=${perms}`;
         } catch {
           // Introspection is best-effort — never mask the real request error.

--- a/apps/server/tests/engine/git-auth.test.ts
+++ b/apps/server/tests/engine/git-auth.test.ts
@@ -72,6 +72,30 @@ describe("git-auth — global ~/.gitconfig writes are opt-in", () => {
     expect(out.token).toBe("ghs_testtoken123");
     expect(out.expiresAt).toBe("2099-01-01T00:00:00Z");
   });
+
+  it("logs the GRANTED repository_selection + permissions from the mint response (issue #215)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          token: "ghs_scoped",
+          expires_at: "2099-01-01T00:00:00Z",
+          repository_selection: "selected",
+          permissions: { issues: "write", pull_requests: "write", contents: "write" },
+          repositories: [{ full_name: "owner/private-repo-a" }],
+        }),
+      }),
+    );
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await refreshGitAuth({ ...baseConfig, repositories: ["private-repo-a"] });
+
+    const line = log.mock.calls.map((c) => String(c[0])).find((s) => s.includes("Mint granted"))!;
+    expect(line).toContain("repository_selection=selected");
+    expect(line).toContain('"issues":"write"');
+    expect(line).toContain("owner/private-repo-a");
+    log.mockRestore();
+  });
 });
 
 describe("git-auth — opt-in global writes use execFileSync safely", () => {

--- a/apps/server/tests/engine/github-app-client.test.ts
+++ b/apps/server/tests/engine/github-app-client.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const octokitInstance = { sentinel: "octokit" };
+const hookError = vi.fn();
+const octokitInstance = { sentinel: "octokit", hook: { error: hookError }, auth: vi.fn() };
 const createAppAuth = vi.fn();
 const Octokit = vi.fn(function () {
   return octokitInstance;
@@ -48,5 +49,51 @@ describe("githubAppClient", () => {
         installationId: "456",
       },
     });
+    // The 403/404 scope diagnostic is wired onto the client's request-error hook.
+    expect(hookError).toHaveBeenCalledWith("request", expect.any(Function));
+  });
+});
+
+describe("githubAppClient — 403/404 scope diagnostic", () => {
+  async function buildAndCaptureHandler() {
+    const tempDir = mkdtempSync(join(tmpdir(), "github-app-client-"));
+    tempDirs.push(tempDir);
+    const privateKeyPath = join(tempDir, "app.pem");
+    writeFileSync(privateKeyPath, "-----BEGIN PRIVATE KEY-----\nk\n-----END PRIVATE KEY-----\n");
+    const { githubAppClient } = await import("#src/engine/github/github-app-client.js");
+    githubAppClient({ appId: "123", installationId: "456", privateKeyPath });
+    return hookError.mock.calls.at(-1)![1] as (err: unknown, opts: unknown) => Promise<void>;
+  }
+
+  it("logs the endpoint's required perms + the token's actual scope on a 404, then re-throws", async () => {
+    octokitInstance.auth.mockResolvedValue({
+      repositorySelection: "all",
+      permissions: { issues: "write", pull_requests: "write" },
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = await buildAndCaptureHandler();
+
+    const err = {
+      status: 404,
+      response: { headers: { "x-accepted-github-permissions": "pull_requests=read" } },
+    };
+    await expect(handler(err, { method: "GET", url: "/repos/o/private/pulls" })).rejects.toBe(err);
+
+    const line = warn.mock.calls.map((c) => String(c[0])).find((s) => s.includes("[github-diag]"))!;
+    expect(line).toContain("GET /repos/o/private/pulls -> 404");
+    expect(line).toContain("x-accepted-github-permissions=pull_requests=read");
+    expect(line).toContain("repository_selection=all");
+    expect(line).toContain("issues,pull_requests");
+    warn.mockRestore();
+  });
+
+  it("does not log for non-403/404 errors but still re-throws", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = await buildAndCaptureHandler();
+
+    const err = { status: 500 };
+    await expect(handler(err, { method: "GET", url: "/x" })).rejects.toBe(err);
+    expect(warn.mock.calls.some((c) => String(c[0]).includes("[github-diag]"))).toBe(false);
+    warn.mockRestore();
   });
 });

--- a/apps/server/tests/engine/github-app-client.test.ts
+++ b/apps/server/tests/engine/github-app-client.test.ts
@@ -83,7 +83,9 @@ describe("githubAppClient — 403/404 scope diagnostic", () => {
     expect(line).toContain("GET /repos/o/private/pulls -> 404");
     expect(line).toContain("x-accepted-github-permissions=pull_requests=read");
     expect(line).toContain("repository_selection=all");
-    expect(line).toContain("issues,pull_requests");
+    // Permission LEVELS are logged, not just names — so a read grant where write
+    // is required is visible against x-accepted-github-permissions (#213/#215).
+    expect(line).toContain("issues=write,pull_requests=write");
     warn.mockRestore();
   });
 


### PR DESCRIPTION
## What this does

Adds behaviour-neutral logging at the two GitHub token boundaries so token-scope problems surface as evidence instead of opaque 403/404s:

- **`git-auth.ts`** — logs the `repository_selection` + `permissions` GitHub **granted** at mint (the executor already logs the *requested* profile). Shows whether an injected token is actually write-scoped for the target repo.
- **`github-app-client.ts`** — an Octokit `hook.error` logs, on any 403/404, the request, the endpoint's required `x-accepted-github-permissions`, and (for the App client) the installation token's actual `repository_selection` + permissions, then re-throws unchanged. The token introspection reuses the strategy's cached installation auth, so it adds no extra API round-trip.

No behaviour change; no `agentic-pi` edit — the executor's scoped mint flows through `git-auth` regardless of backend.

## Why

Observability for the recurring GitHub App-token scope questions (#213, #215): rather than an opaque 403/404, the logs show the required-vs-granted permissions and the token's actual repository scope at the point of failure. Useful for diagnosing which token a given path is using and whether it covers the target repo.

## Tests

- `git-auth.test.ts` — asserts the granted `repository_selection`/permissions from the mint response are logged.
- `github-app-client.test.ts` — asserts the 403/404 hook is wired, logs required-vs-granted scope on a 404 and re-throws, and stays silent (still re-throwing) on non-403/404 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)