### PR TITLE
fix(dashboard): stop the live workflow pipeline blanking mid-run

### DIFF
--- a/apps/server/dashboard/src/components/WorkflowPipeline.tsx
+++ b/apps/server/dashboard/src/components/WorkflowPipeline.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   ReactFlow,
+  useNodesState,
+  useEdgesState,
   type Node,
   type Edge,
   type ReactFlowInstance,
@@ -24,6 +26,78 @@ import {
 type PhaseNodeData = PipelineNodeData;
 
 const nodeTypes = pipelineNodeTypes;
+
+/** Compare the run-view fields we actually render, to skip needless updates. */
+function nodeDataEqual(a: PhaseNodeData, b: PhaseNodeData): boolean {
+  return (
+    a.label === b.label &&
+    a.status === b.status &&
+    a.timestamp === b.timestamp &&
+    a.duration === b.duration &&
+    a.selected === b.selected &&
+    a.kind === b.kind &&
+    a.pulse === b.pulse
+  );
+}
+
+/**
+ * Merge freshly-computed nodes into the live xyflow state, preserving the
+ * object identity — and thus xyflow's measured dimensions — of any node whose
+ * id, position and rendered data are unchanged. Returns `prev` untouched when
+ * nothing changed so React bails out of the update entirely. The pipeline
+ * polls every few seconds, so this keeps the per-poll churn (and the window for
+ * the fitView-vs-store-update race that blanked the canvas) to a minimum.
+ */
+function reconcileNodes(
+  prev: Node<PhaseNodeData>[],
+  next: Node<PhaseNodeData>[],
+): Node<PhaseNodeData>[] {
+  const prevById = new Map(prev.map((n) => [n.id, n] as const));
+  let changed = prev.length !== next.length;
+  const merged = next.map((n) => {
+    const old = prevById.get(n.id);
+    if (
+      old &&
+      old.position.x === n.position.x &&
+      old.position.y === n.position.y &&
+      nodeDataEqual(old.data, n.data)
+    ) {
+      return old; // unchanged — keep identity + xyflow's measured dimensions
+    }
+    changed = true;
+    return old ? { ...old, position: n.position, data: n.data, style: n.style } : n;
+  });
+  if (!changed) {
+    for (let i = 0; i < merged.length; i++) {
+      if (merged[i] !== prev[i]) {
+        changed = true;
+        break;
+      }
+    }
+  }
+  return changed ? merged : prev;
+}
+
+/** Same idea for edges — they only change when nodes are added / removed. */
+function reconcileEdges(prev: Edge[], next: Edge[]): Edge[] {
+  const prevById = new Map(prev.map((e) => [e.id, e] as const));
+  let changed = prev.length !== next.length;
+  const merged = next.map((e) => {
+    const old = prevById.get(e.id);
+    if (old && old.source === e.source && old.target === e.target) return old;
+    changed = true;
+    return e;
+  });
+  if (!changed) {
+    for (let i = 0; i < merged.length; i++) {
+      if (merged[i] !== prev[i]) {
+        changed = true;
+        break;
+      }
+    }
+  }
+  return changed ? merged : prev;
+}
 
 const NODE_WIDTH = 110;
 const NODE_GAP = 40;
@@ -100,7 +174,7 @@ export function WorkflowPipeline({
   selectedPhase,
   onPhaseClick,
 }: Props) {
-  const { nodes, edges, canvasHeight } = useMemo(() => {
+  const computed = useMemo(() => {
     if (!definition) {
       return { nodes: [] as Node<PhaseNodeData>[], edges: [] as Edge[], canvasHeight: 0 };
     }
@@ -384,18 +458,46 @@ export function WorkflowPipeline({
     return { nodes: reactFlowNodes, edges: reactFlowEdges, canvasHeight };
   }, [definition, run, executions, approvals, selectedPhase]);
 
-  // Re-center on resize. The pipeline section is wrapped in a draggable
-  // divider; without this the nodes drift off-screen as the section shrinks.
-  // The `mounted` guard + try/catch + no-animation prevent xyflow's async
-  // tick from accessing a torn-down store when the component is unmounted
-  // or the run is swapped mid-fit (manifests as
-  // `Cannot read properties of undefined (reading 'payload')`).
-  //
-  // Hooks must be declared before any conditional return — keep these above
-  // the `!definition` short-circuit to satisfy the rules of hooks.
+  // ── Live React Flow state ──────────────────────────────────────────────
+  // Hold the graph in xyflow's own state and reconcile `computed` into it each
+  // poll, rather than feeding <ReactFlow> a brand-new node/edge array every few
+  // seconds. Reusing node identities (and their measured dimensions) cuts the
+  // per-poll churn that widened the fitView-vs-store-update race window.
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node<PhaseNodeData>>(computed.nodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(computed.edges);
+  useEffect(() => {
+    setNodes((prev) => reconcileNodes(prev, computed.nodes));
+  }, [computed.nodes, setNodes]);
+  useEffect(() => {
+    setEdges((prev) => reconcileEdges(prev, computed.edges));
+  }, [computed.edges, setEdges]);
+
   const wrapperRef = useRef<HTMLDivElement>(null);
   const flowRef = useRef<ReactFlowInstance<Node<PhaseNodeData>, Edge> | null>(null);
   const mountedRef = useRef(true);
+
+  // Fit the viewport, but never leave it collapsed. xyflow throws
+  // `Cannot read properties of undefined (reading 'payload')` when fitView
+  // races a node-list / store update mid-poll; the old code swallowed that
+  // throw and the canvas stayed blank until a resize that never came. Retry
+  // once on the next frame so a transient race self-heals instead of blanking.
+  const safeFitView = useCallback((retry = true) => {
+    if (!mountedRef.current) return;
+    const flow = flowRef.current;
+    if (!flow) return;
+    try {
+      if (flow.getNodes().length === 0) return;
+      flow.fitView({ padding: 0.2, minZoom: 0.4, maxZoom: 1 });
+    } catch {
+      if (retry) requestAnimationFrame(() => safeFitView(false));
+    }
+  }, []);
+
+  // Re-center on resize. The pipeline section is wrapped in a draggable
+  // divider; without this the nodes drift off-screen as the section shrinks.
+  //
+  // Hooks must be declared before any conditional return — keep these above
+  // the `!definition` short-circuit to satisfy the rules of hooks.
   useEffect(() => {
     mountedRef.current = true;
     const el = wrapperRef.current;
@@ -403,17 +505,7 @@ export function WorkflowPipeline({
     let raf = 0;
     const ro = new ResizeObserver(() => {
       cancelAnimationFrame(raf);
-      raf = requestAnimationFrame(() => {
-        if (!mountedRef.current) return;
-        const flow = flowRef.current;
-        if (!flow) return;
-        try {
-          if (flow.getNodes().length === 0) return;
-          flow.fitView({ padding: 0.2, minZoom: 0.4, maxZoom: 1 });
-        } catch {
-          /* fitView raced against unmount / node-list update — safe to ignore */
-        }
-      });
+      raf = requestAnimationFrame(() => safeFitView());
     });
     ro.observe(el);
     return () => {
@@ -422,7 +514,26 @@ export function WorkflowPipeline({
       ro.disconnect();
       flowRef.current = null;
     };
-  }, []);
+  }, [safeFitView]);
+
+  // Re-fit whenever the graph's *topology* changes — a phase or loop iteration
+  // appearing / disappearing shifts every downstream node, so the previous fit
+  // no longer frames the graph. Keyed on the node id set (not their data), so a
+  // plain status / timing tick doesn't jerk the viewport. Double-rAF so xyflow
+  // has measured the new nodes before we fit to them.
+  const topoKey = useMemo(() => computed.nodes.map((n) => n.id).join("|"), [computed.nodes]);
+  useEffect(() => {
+    if (!topoKey) return undefined;
+    let raf1 = 0;
+    let raf2 = 0;
+    raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => safeFitView());
+    });
+    return () => {
+      cancelAnimationFrame(raf1);
+      cancelAnimationFrame(raf2);
+    };
+  }, [topoKey, safeFitView]);
 
   if (!definition) {
     return (
@@ -434,13 +545,15 @@ export function WorkflowPipeline({
   // `height` prop is the minimum (used by simple linear runs); when there
   // are children, expand to fit them.
   const numericHeight = typeof height === "number" ? height : 180;
-  const effectiveHeight = Math.max(numericHeight, canvasHeight);
+  const effectiveHeight = Math.max(numericHeight, computed.canvasHeight);
 
   return (
     <div ref={wrapperRef} style={{ width: "100%", height: effectiveHeight }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
         nodeTypes={nodeTypes}
         fitView
         // Cap auto-fit zoom so single-node workflows (e.g. triage) don't


### PR DESCRIPTION
## The bug

While watching an **active** run in the workflow-runs view, the React Flow pipeline at the top would sometimes vanish — a blank canvas, **no** "Loading…" text and **no** console error — even though the run, its phase detail, and the message feed kept updating fine. Reloading brought it back.

## Root cause

The pipeline is fully data-driven and the parent polls `run` (5s), `executions` (3s) and `approvals` (3s). Each poll rebuilds the **entire** node + edge array, and the only thing re-centering the viewport was a `ResizeObserver` → `fitView` whose `try/catch` **swallowed** xyflow's `Cannot read properties of undefined (reading 'payload')` throw when the fit raced a concurrent node-list update. The swallowed throw left the viewport in a collapsed state, and since the canvas height is fixed (180px) no further resize fired to trigger a re-fit — so it stayed blank until a manual reload.

It was intermittent (a race) and specific to live runs (only they poll), which matches the "after a while it disappears, no logs" report.

## The fix (`WorkflowPipeline.tsx`)

1. **Re-fit on topology change, not just resize** — an effect keyed on the node id set re-fits via a double-`requestAnimationFrame` after new phases / loop iterations appear, so the viewport is restored whenever a poll swaps the node set. Keyed on ids only, so a plain status/timing tick no longer jerks the graph.
2. **`safeFitView` retries once** on the next frame instead of swallowing the store-race throw, so a transient race self-heals rather than leaving the canvas collapsed.
3. **Hold the graph in xyflow state** (`useNodesState` / `useEdgesState`) and reconcile `computed` into it each poll, preserving node identity — and xyflow's measured dimensions — for anything that didn't actually change (returns the previous array untouched when nothing changed). This shrinks the per-poll churn, and with it the window for the race in #1/#2.

## Testing

- `pnpm --filter @lastlight/dashboard typecheck` ✅
- `pnpm --filter @lastlight/dashboard build` ✅
- No automated coverage exists for this component; behaviour verified by reasoning against the reported repro (same run/phase rendering correctly vs. blank). Worth a manual soak-test watching a live `build` run through its phase transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)