### PR TITLE
fix(pr-review): treat a scan with no PR to review as a clean no-op

### DIFF
--- a/apps/server/skills/pr-review/SKILL.md
+++ b/apps/server/skills/pr-review/SKILL.md
@@ -46,7 +46,11 @@ If `prNumber` (or `issueNumber`) is set in the Context block, **that is your
 target** — go straight to `github_get_pull_request` with it. Do **not** call
 `github_list_pull_requests` to "find" or "confirm" it; you were handed it, and
 listing dumps a large payload for nothing. Only when no PR is given (a repo-wide
-`mode: scan`) do you list open PRs and pick the most recent unreviewed one.
+`mode: scan`) do you list open PRs and pick the most recent unreviewed one. **If
+the scan finds no open PRs, write `{"skip": true, "summary": "no open PRs to
+review"}` and stop** — an empty repo is a clean no-op, not a failure. (Do this
+only when the list genuinely comes back empty; if listing *errors*, do NOT write
+a skip — let it fail so the real problem surfaces.)
 
 **Stop conditions** (check before reviewing):
 - PR authored by `last-light[bot]` → skip. Never self-review.
@@ -135,8 +139,10 @@ Rules:
   `mkdir -p .lastlight/pr-review && echo '.lastlight/' >> .git/info/exclude`.
 
 **Stop / skip:** if a stop condition in §1 holds (bot-authored, merged, already
-reviewed at the current head SHA), write `{"skip": true, "summary": "<reason>"}`
-and stop — the follow-up step then posts nothing.
+reviewed at the current head SHA), or a `mode: scan` finds no open PRs to review,
+write `{"skip": true, "summary": "<reason>"}` and stop — the follow-up step then
+posts nothing. A skip is a clean no-op even in scan mode where no PR was handed
+in; only a *missing* findings file (never written) fails the run.
 
 ## Verification
 

--- a/apps/server/spec/06-workflow-engine.md
+++ b/apps/server/spec/06-workflow-engine.md
@@ -163,7 +163,11 @@ deterministic `bash` / `script` pair (a command, no LLM).
   prod; a bearer token + `config.githubApiBaseUrl` against the eval mock, which
   serves no App-token or diff endpoint). A genuine failure — missing findings
   after a real review, or a GitHub error surviving the body-only retry — **fails
-  the phase**; a legitimate `skip` succeeds without posting. Idempotent on
+  the phase**; a legitimate `skip` succeeds without posting. The `skip` is
+  honoured **before** the PR-number requirement, so a `mode: scan` run over a
+  repo with **no open PRs** (the agent writes `{skip}`; no PR was handed in) is a
+  clean no-op rather than a "no PR number in run context" failure — a quiet
+  managed repo doesn't red-X every cron tick. Idempotent on
   resume (no-op when a bot review already exists on the head SHA). This replaced
   the earlier in-sandbox `type: script` poster, which depended on the AI
   hand-writing `pr_number`/`base_ref`/`head_sha` into the JSON and silently

--- a/apps/server/src/workflows/handlers/post-review.ts
+++ b/apps/server/src/workflows/handlers/post-review.ts
@@ -93,29 +93,38 @@ export class GitHubPostReviewHandler implements PhaseTypeHandler {
     const ctx = this.run.ctx;
     const owner = String(ctx.owner);
     const repo = String(ctx.repo);
+    // Read the agent's findings from the host checkout FIRST. The review phase
+    // writes it at `.lastlight/pr-review/findings.json` relative to the repo
+    // cwd; the workspace persists on the host between phases (see sandbox/index.ts).
+    const hostRepoDir = this.resolveHostRepoDir(repo);
+    const findingsPath = join(hostRepoDir, ".lastlight", "pr-review", "findings.json");
+    let doc: ReviewFindingsDoc | undefined;
+    let readErr: string | undefined;
+    try {
+      doc = JSON.parse(readFileSync(findingsPath, "utf8")) as ReviewFindingsDoc;
+    } catch (err) {
+      readErr = err instanceof Error ? err.message : String(err);
+    }
+
+    // A deliberate skip is a clean no-op even when scan handed us no PR: a repo
+    // with no open PRs has nothing to review and must not fail the run. This is
+    // checked BEFORE the prNumber gate so an empty-repo skip isn't rejected for
+    // lacking a PR it never needed (a cron `mode: scan` over quiet repos would
+    // otherwise red-X every 30 min). Only a review with real content to post
+    // needs a PR number, resolved below.
+    if (doc?.skip) {
+      return succeed(`skipped: ${doc.summary || "agent skipped review"}`);
+    }
+
     const prNumber =
       (typeof ctx.prNumber === "number" ? ctx.prNumber : undefined) ??
       (typeof ctx.issueNumber === "number" && ctx.issueNumber > 0 ? ctx.issueNumber : undefined);
     if (!prNumber) return fail("post-review: no PR number in run context; cannot post review");
 
-    // Read the agent's findings from the host checkout. The review phase writes
-    // it at `.lastlight/pr-review/findings.json` relative to the repo cwd; the
-    // workspace persists on the host between phases (see sandbox/index.ts).
-    const hostRepoDir = this.resolveHostRepoDir(repo);
-    const findingsPath = join(hostRepoDir, ".lastlight", "pr-review", "findings.json");
-    let doc: ReviewFindingsDoc;
-    try {
-      doc = JSON.parse(readFileSync(findingsPath, "utf8")) as ReviewFindingsDoc;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      // A missing/unreadable file after a completed review means the review
-      // phase didn't honour its contract — surface it, don't post silently.
-      return fail(`post-review: could not read findings (${findingsPath}): ${msg}`);
-    }
-
-    if (doc.skip) {
-      return succeed(`skipped: ${doc.summary || "agent skipped review"}`);
-    }
+    // Findings must be present to post a real review. A missing/unreadable file
+    // for a targeted PR means the review phase didn't honour its contract (or
+    // the agent couldn't reach the repo) — surface it, never post silently.
+    if (!doc) return fail(`post-review: could not read findings (${findingsPath}): ${readErr}`);
 
     const github = this.buildReviewClient();
 

--- a/apps/server/tests/workflows/post-review.test.ts
+++ b/apps/server/tests/workflows/post-review.test.ts
@@ -150,6 +150,20 @@ describe("post-review action (runPostReview)", () => {
     return { executor: { execute: (node: DagNode, outputs: Record<string, unknown>) => handler.execute(PHASE, node, outputs) }, rep };
   }
 
+  it("scan with nothing to review (skip, no PR number) is a clean no-op, not a failure", async () => {
+    // A cron `mode: scan` run on a repo with no open PRs: the agent writes a
+    // skip and no PR is handed in. This must succeed as a no-op rather than
+    // red-X every quiet repo every 30 min — the prNumber gate used to fail the
+    // run before the skip was ever read.
+    const taskId = "widget-pr-review-scan";
+    seedFindings(taskId, "widget", { skip: true, summary: "no open PRs to review" });
+    const { executor, rep } = makeExecutor(taskId, { issueNumber: 0 }); // scan: no PR handed in
+    const outcome = await executor.execute(NODE, {});
+    expect(rep.failed, "a scan skip must not fail the workflow").toEqual([]);
+    expect(outcome.status).toBe("succeeded");
+    expect(reviews).toHaveLength(0); // nothing posted
+  });
+
   it("posts a review from content-only findings (no pr_number/base_ref/head_sha)", async () => {
     const taskId = "widget-42-pr-review";
     seedFindings(taskId, "widget", {


### PR DESCRIPTION
## Problem

A cron `mode: scan` pr-review (`cron-review.yaml` → `check-prs-awaiting-review`) over a repo with **no open PRs** fails the run at `post-review` with:

```
post-review: no PR number in run context; cannot post review
```

The review phase completes fine (nothing to review), but `PhaseExecutor.runPostReview` checks `prNumber` **before** reading the findings file and honouring `doc.skip`. In scan mode no PR is handed in, so a legitimate "nothing to review" can never reach the skip branch — the run red-Xes. Every quiet managed repo therefore fails every cron tick.

This is the actual cause behind reports that the pr-review cron "fails on private repos": a repo with no open PRs fails regardless of visibility; private repos are just the ones an operator notices (and, on a token-less code path, a private repo additionally 404s on the listing — tracked separately). The visible red X is this post-review false-failure.

## Fix

- **`post-review`**: read `findings.json` and honour an explicit `doc.skip` **before** the `prNumber` gate. A deliberate skip is a clean no-op even when scan handed in no PR. A **missing** findings file still fails loudly — so a review that couldn't actually run (e.g. the agent errored listing PRs) is surfaced, not silently swallowed.
- **`pr-review` skill**: instruct the agent to write `{skip, summary}` when a scan finds **no open PRs** — and explicitly **not** when listing *errors* — so the no-op is a deliberate skip rather than an absent file.
- **spec** (`06-workflow-engine.md`): document the skip-before-prNumber ordering.

## Tests

`tests/workflows/post-review.test.ts`:
- new: a scan with `{skip:true}` and no PR number **succeeds as a no-op** (nothing posted) — fails before this change with the exact `no PR number` error.
- unchanged: the four existing posting tests still pass (targeted-PR posting, missing-findings-after-a-real-review still fails, etc.).

Full `tests/workflows/` suite green (301 tests). No new type errors.

## Scope

Behavioural fix + skill contract. Related to the pr-review-cron discussion in #213 (the private-repo framing there resolves to this + a separate token-less-retry path, which is not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
