### PR TITLE
fix: repair the pr-review cron — migrate off mode:scan + honest token refresh

### DIFF
--- a/apps/evals/src/mechanism.test.ts
+++ b/apps/evals/src/mechanism.test.ts
@@ -25,7 +25,7 @@ import { loadMergedConfig, resolvePhaseModel } from "./config.js";
 import { modelsArm, configArm, releaseOverlayGuard } from "./arm.js";
 import { collectMetrics } from "./metrics.js";
 
-const staticAuth = { getToken: async () => "fake-token", expiresAt: null };
+const staticAuth = { getToken: async () => "fake-token", expiresAt: null, canRefresh: false };
 
 describe("fake GitHub + agentic-pi github tools (baseUrl seam)", () => {
   it("serves seeded issues and records mutations made through the real GitHubClient", async () => {

--- a/apps/server/src/cron/review-discovery.ts
+++ b/apps/server/src/cron/review-discovery.ts
@@ -55,9 +55,11 @@ export interface ReviewDiscoverOptions {
    */
   botLogin?: string;
   /**
-   * Cap candidates assessed per repo so one busy repo can't spin hundreds of
-   * runs; the next tick picks up any remainder. Runs queue against the global
-   * admission cap anyway — this just bounds the row count. Default 25.
+   * Cap the number of runs DISPATCHED per repo per tick (not candidates
+   * examined) so one busy repo can't spin hundreds of runs at once. The check
+   * walks all open PRs and stops after this many *unreviewed* ones, so
+   * already-reviewed PRs in the oldest positions never starve unreviewed PRs
+   * behind them. Runs also queue against the global admission cap. Default 25.
    */
   maxPerRepo?: number;
 }
@@ -93,10 +95,15 @@ export async function discoverPrsAwaitingReview(
 
     const candidates = open
       .filter((pr) => !pr.draft && pr.authorLogin !== botLogin)
-      .sort((a, b) => a.number - b.number) // oldest first — deterministic, fair
-      .slice(0, maxPerRepo);
+      .sort((a, b) => a.number - b.number); // oldest first — deterministic, fair
 
+    // Cap RUNS dispatched, not candidates examined: walk every open PR and stop
+    // once we've queued `maxPerRepo` UNreviewed ones. Slicing before the review
+    // check would starve unreviewed PRs behind a block of already-reviewed ones
+    // (the steady state), deferring them indefinitely.
+    let dispatched = 0;
     for (const pr of candidates) {
+      if (dispatched >= maxPerRepo) break;
       let reviewed: boolean;
       try {
         reviewed = !!(await gh.getLatestBotReview(owner, repo, pr.number, pr.headSha, botLogin));
@@ -109,6 +116,7 @@ export async function discoverPrsAwaitingReview(
       }
       if (reviewed) continue; // already reviewed at the current head SHA
       out.push({ repo: full, prNumber: pr.number, title: pr.title, branch: pr.headRef });
+      dispatched++;
     }
   }
 

--- a/apps/server/src/cron/review-discovery.ts
+++ b/apps/server/src/cron/review-discovery.ts
@@ -1,0 +1,116 @@
+/**
+ * Deterministic discovery for the pr-review cron (`check-prs-awaiting-review`).
+ *
+ * Finds the open PRs that need a review — open, non-draft, NOT authored by the
+ * bot, and WITHOUT a bot review at the PR's current head SHA — across `repos`,
+ * in code (no LLM). The caller fans out one bounded single-PR `pr-review` run
+ * per result, with `prNumber` + head ref set (see `src/index.ts`) — the exact
+ * shape the `pr.opened` webhook produces: a fresh per-repo scoped token, a
+ * pre-clone of the PR head, and a real PR number for `post-review` to post to.
+ *
+ * This replaces the old `mode: scan` run, whose single agent listed and reviewed
+ * PRs itself inside the sandbox — which couldn't reliably auth (a static token
+ * with no in-sandbox re-mint), couldn't pre-clone (no PR known up front), and
+ * had no way to hand its chosen PR back to `post-review`, so it could never
+ * actually post. The dependabot crons were migrated off `mode: scan` for the
+ * same reasons (`src/cron/dependabot-discovery.ts`); this is that same move.
+ */
+
+import type { DependencyPr } from "./dependabot-discovery.js";
+
+/** The subset of the harness GitHub client this needs — keeps it fake-able. */
+export interface ReviewDiscoveryClient {
+  listOpenPullRequests(
+    owner: string,
+    repo: string,
+  ): Promise<
+    Array<{
+      number: number;
+      title: string;
+      draft: boolean;
+      authorLogin: string;
+      labels: string[];
+      headRef: string;
+      headSha: string;
+    }>
+  >;
+  /** The bot's most recent review on this PR's CURRENT head SHA, or null when
+   * the bot hasn't reviewed this SHA yet (re-pushes invalidate a stale review). */
+  getLatestBotReview(
+    owner: string,
+    repo: string,
+    pullNumber: number,
+    headSha: string,
+    botLogin?: string,
+  ): Promise<{ state: string } | null>;
+}
+
+export interface ReviewDiscoverOptions {
+  log?: (msg: string) => void;
+  /**
+   * Bot login incl. the `[bot]` suffix (e.g. `last-light[bot]`). The bot's own
+   * PRs are skipped (never self-review), and its review at the current head SHA
+   * marks a PR done. Defaults to `last-light[bot]`; the caller passes the
+   * configured `botLogin` so a renamed App slug matches.
+   */
+  botLogin?: string;
+  /**
+   * Cap candidates assessed per repo so one busy repo can't spin hundreds of
+   * runs; the next tick picks up any remainder. Runs queue against the global
+   * admission cap anyway — this just bounds the row count. Default 25.
+   */
+  maxPerRepo?: number;
+}
+
+const DEFAULT_BOT_LOGIN = "last-light[bot]";
+const DEFAULT_MAX_PER_REPO = 25;
+
+export async function discoverPrsAwaitingReview(
+  repos: string[],
+  gh: ReviewDiscoveryClient,
+  opts: ReviewDiscoverOptions = {},
+): Promise<DependencyPr[]> {
+  const botLogin = opts.botLogin ?? DEFAULT_BOT_LOGIN;
+  const maxPerRepo = opts.maxPerRepo ?? DEFAULT_MAX_PER_REPO;
+  const out: DependencyPr[] = [];
+
+  for (const full of repos) {
+    const [owner, repo] = full.split("/");
+    if (!owner || !repo) {
+      opts.log?.(`[review-discovery] skipping malformed repo "${full}"`);
+      continue;
+    }
+
+    let open: Awaited<ReturnType<ReviewDiscoveryClient["listOpenPullRequests"]>>;
+    try {
+      open = await gh.listOpenPullRequests(owner, repo);
+    } catch (err) {
+      // Per-repo failure is logged and skipped, never fatal, so one inaccessible
+      // repo doesn't sink the sweep.
+      opts.log?.(`[review-discovery] ${full}: listing PRs failed — ${String(err)}`);
+      continue;
+    }
+
+    const candidates = open
+      .filter((pr) => !pr.draft && pr.authorLogin !== botLogin)
+      .sort((a, b) => a.number - b.number) // oldest first — deterministic, fair
+      .slice(0, maxPerRepo);
+
+    for (const pr of candidates) {
+      let reviewed: boolean;
+      try {
+        reviewed = !!(await gh.getLatestBotReview(owner, repo, pr.number, pr.headSha, botLogin));
+      } catch (err) {
+        // Can't tell → skip this tick rather than risk a duplicate review. The
+        // next tick retries, and `post-review` is itself idempotent on the head
+        // SHA, so a missed check here can't cause a double-post downstream.
+        opts.log?.(`[review-discovery] ${full}#${pr.number}: review lookup failed — ${String(err)}`);
+        continue;
+      }
+      if (reviewed) continue; // already reviewed at the current head SHA
+      out.push({ repo: full, prNumber: pr.number, title: pr.title, branch: pr.headRef });
+    }
+  }
+
+  return out;
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -21,8 +21,8 @@ import {
   discoverGreenDependencyPrs,
   discoverRedDependencyPrs,
   type DependencyPr,
-  type PrDiscoveryClient,
 } from "./cron/dependabot-discovery.js";
+import { discoverPrsAwaitingReview } from "./cron/review-discovery.js";
 import { mountAdmin } from "./admin/index.js";
 import { cleanupOrphanedSandboxes } from "./sandbox/index.js";
 import { writeEgressFirewallConfigs, writeOtelCollectorConfig } from "./sandbox/egress-firewall-config.js";
@@ -742,20 +742,28 @@ async function main() {
     }
   }
 
-  // Dependency-PR discoverers keyed by a cron context's `discover` value. Each
-  // returns the eligible PRs (in code, no LLM); the runner fans out one run per
-  // PR. Add a discoverer + a `cron-*.yaml` with the matching `discover:` key to
-  // introduce a new backstop sweep.
-  const DEP_PR_DISCOVERERS: Record<
+  // PR discoverers keyed by a cron context's `discover` value. Each returns the
+  // eligible PRs (in code, no LLM) and the runner fans out one bounded single-PR
+  // run each (with prNumber + head ref) — the shape the pr.* webhooks produce.
+  // Add a discoverer + a `cron-*.yaml` with the matching `discover:` key to
+  // introduce a new sweep. The harness `github` client (App auth) is passed to
+  // every discoverer, so a discoverer only needs the subset of it it uses.
+  const PR_DISCOVERERS: Record<
     string,
     (
       repos: string[],
-      gh: PrDiscoveryClient,
+      gh: GitHubClient,
       opts: { log?: (msg: string) => void },
     ) => Promise<DependencyPr[]>
   > = {
     "green-dependency-prs": discoverGreenDependencyPrs,
     "red-dependency-prs": discoverRedDependencyPrs,
+    // The pr-review cron: find open PRs awaiting review and fan out one single-PR
+    // pr-review run each. Replaces the old `mode: scan` review run, which ran the
+    // whole listing/reviewing inside the sandbox with a static token it couldn't
+    // re-mint and no way to hand its chosen PR to post-review.
+    "prs-awaiting-review": (repos, gh, opts) =>
+      discoverPrsAwaitingReview(repos, gh, { ...opts, botLogin: config.botLogin }),
   };
 
   // Construct the cron scheduler before mounting admin so the dashboard can
@@ -773,7 +781,7 @@ async function main() {
     // we dispatch one run each — the same shape the pr.checks_passed /
     // pr.checks_failed webhooks produce. Runs queue against the global cap.
     const discoverKey = typeof context.discover === "string" ? context.discover : undefined;
-    const discoverer = discoverKey ? DEP_PR_DISCOVERERS[discoverKey] : undefined;
+    const discoverer = discoverKey ? PR_DISCOVERERS[discoverKey] : undefined;
     if (discoverer) {
       const repos = Array.isArray(context.repos)
         ? (context.repos as unknown[]).filter((r): r is string => typeof r === "string")

--- a/apps/server/src/workflows/handlers/post-review.ts
+++ b/apps/server/src/workflows/handlers/post-review.ts
@@ -32,6 +32,35 @@ export interface PostReviewRunScope {
 }
 
 /**
+ * Build post-review's own GitHub client from STABLE config, never the live
+ * `process.env`. A concurrent in-process (gondolin) run clears `GITHUB_APP_*`
+ * in the shared `process.env` (agent-executor `applyEnv`, hard rule #8) for the
+ * duration of its agent turn; reading the PEM path from `process.env` mid-clear
+ * yields `""` → `resolve("")` = the cwd (a directory) → `readFileSync` EISDIR.
+ * The pr-review cron surfaced this by fanning out concurrent runs, but it bites
+ * any two overlapping in-process runs. `getRuntimeConfig()` is loaded once at
+ * boot, so its `githubApp`/`githubToken` are immune to the race. Exported for
+ * the concurrent-clear regression test.
+ */
+export function resolveReviewGitHubClient(runConfig: { githubApiBaseUrl?: string }): GitHubClient {
+  const baseUrl = runConfig.githubApiBaseUrl;
+  if (baseUrl) {
+    // Eval / test path: the mock ignores auth; any bearer token works.
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "eval-fake-token";
+    return GitHubClient.withToken(token, baseUrl);
+  }
+  const cfg = getRuntimeConfig();
+  if (cfg?.githubApp) return new GitHubClient(cfg.githubApp);
+  if (cfg?.githubToken) return GitHubClient.withToken(cfg.githubToken);
+  // Last resort — runtime config not loaded (shouldn't happen in a live harness).
+  return new GitHubClient({
+    appId: process.env.GITHUB_APP_ID || "",
+    privateKeyPath: process.env.GITHUB_APP_PRIVATE_KEY_PATH || "",
+    installationId: process.env.GITHUB_APP_INSTALLATION_ID || "",
+  });
+}
+
+/**
  * The `type: post-review` phase — the one workflow body genuinely coupled to
  * GitHub, lifted out of the engine into an app-registered {@link PhaseTypeHandler}.
  *
@@ -185,17 +214,7 @@ export class GitHubPostReviewHandler implements PhaseTypeHandler {
 
   /** Build the GitHub client for the post: token+baseUrl in evals, App auth in prod. */
   private buildReviewClient(): GitHubClient {
-    const baseUrl = this.run.config.githubApiBaseUrl;
-    if (baseUrl) {
-      // Eval / test path: the mock ignores auth; any bearer token works.
-      const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "eval-fake-token";
-      return GitHubClient.withToken(token, baseUrl);
-    }
-    return new GitHubClient({
-      appId: process.env.GITHUB_APP_ID || "",
-      privateKeyPath: process.env.GITHUB_APP_PRIVATE_KEY_PATH || "",
-      installationId: process.env.GITHUB_APP_INSTALLATION_ID || "",
-    });
+    return resolveReviewGitHubClient(this.run.config);
   }
 
   private gitHeadSha(repoDir: string): string | undefined {

--- a/apps/server/tests/cron/review-discovery.test.ts
+++ b/apps/server/tests/cron/review-discovery.test.ts
@@ -90,4 +90,25 @@ describe("discoverPrsAwaitingReview", () => {
     const out = await discoverPrsAwaitingReview(["yo61/repo"], gh, { botLogin: "nearform-lastlight[bot]" });
     expect(out.map((p) => p.prNumber)).toEqual([9]); // the bot's own PR (8) is skipped
   });
+
+  it("caps RUNS dispatched, not candidates examined — reviewed PRs don't starve unreviewed ones behind them", async () => {
+    // Steady state: the two oldest open PRs are already reviewed. With
+    // maxPerRepo=2 the cap must still surface 2 UNreviewed PRs from behind them,
+    // not stop after examining the first 2 (which would yield zero and defer the
+    // rest indefinitely).
+    const gh = fakeGh(
+      {
+        "yo61/repo": [
+          { number: 1, title: "old reviewed", draft: false, authorLogin: "a" },
+          { number: 2, title: "old reviewed", draft: false, authorLogin: "b" },
+          { number: 3, title: "unreviewed", draft: false, authorLogin: "c" },
+          { number: 4, title: "unreviewed", draft: false, authorLogin: "d" },
+          { number: 5, title: "unreviewed", draft: false, authorLogin: "e" },
+        ],
+      },
+      new Set(["yo61/repo#1@sha-1", "yo61/repo#2@sha-2"]),
+    );
+    const out = await discoverPrsAwaitingReview(["yo61/repo"], gh, { maxPerRepo: 2 });
+    expect(out.map((p) => p.prNumber)).toEqual([3, 4]); // 2 dispatched, not starved by 1 & 2
+  });
 });

--- a/apps/server/tests/cron/review-discovery.test.ts
+++ b/apps/server/tests/cron/review-discovery.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  discoverPrsAwaitingReview,
+  type ReviewDiscoveryClient,
+} from "#src/cron/review-discovery.js";
+
+type PrEntry = {
+  number: number;
+  title: string;
+  draft: boolean;
+  authorLogin: string;
+  headRef?: string;
+  headSha?: string;
+};
+
+function normalize(p: PrEntry) {
+  return {
+    number: p.number,
+    title: p.title,
+    draft: p.draft,
+    authorLogin: p.authorLogin,
+    labels: [] as string[],
+    headRef: p.headRef ?? `feature-${p.number}`,
+    headSha: p.headSha ?? `sha-${p.number}`,
+  };
+}
+
+/** `reviewed` holds `owner/repo#num@headSha` keys the bot has already reviewed. */
+function fakeGh(listing: Record<string, PrEntry[]>, reviewed: Set<string>): ReviewDiscoveryClient {
+  return {
+    listOpenPullRequests: vi.fn(async (owner: string, repo: string) =>
+      (listing[`${owner}/${repo}`] ?? []).map(normalize),
+    ),
+    getLatestBotReview: vi.fn(async (owner: string, repo: string, n: number, headSha: string) =>
+      reviewed.has(`${owner}/${repo}#${n}@${headSha}`) ? { state: "COMMENTED" } : null,
+    ),
+  };
+}
+
+describe("discoverPrsAwaitingReview", () => {
+  it("returns open, non-draft, non-bot, unreviewed PRs — shaped for dispatch with prNumber + branch", async () => {
+    const gh = fakeGh(
+      {
+        "yo61/repo": [
+          { number: 3, title: "Add X", draft: false, authorLogin: "alice", headRef: "feat/x" },
+          { number: 4, title: "Draft Y", draft: true, authorLogin: "bob" }, // draft → skip
+          { number: 5, title: "Bot chore", draft: false, authorLogin: "last-light[bot]" }, // our own → skip
+          { number: 6, title: "Already reviewed", draft: false, authorLogin: "carol" }, // reviewed@head → skip
+        ],
+      },
+      new Set(["yo61/repo#6@sha-6"]),
+    );
+
+    const out = await discoverPrsAwaitingReview(["yo61/repo"], gh);
+    expect(out).toEqual([{ repo: "yo61/repo", prNumber: 3, title: "Add X", branch: "feat/x" }]);
+  });
+
+  it("re-reviews a PR whose latest bot review is on an OLD head SHA (new commits landed)", async () => {
+    const gh = fakeGh(
+      { "yo61/repo": [{ number: 7, title: "Reworked", draft: false, authorLogin: "dave", headSha: "sha-new" }] },
+      new Set(["yo61/repo#7@sha-old"]), // reviewed at an old sha, not the current one
+    );
+    const out = await discoverPrsAwaitingReview(["yo61/repo"], gh);
+    expect(out.map((p) => p.prNumber)).toEqual([7]);
+  });
+
+  it("isolates a per-repo listing failure — one bad repo doesn't sink the sweep", async () => {
+    const gh: ReviewDiscoveryClient = {
+      listOpenPullRequests: vi.fn(async (_owner: string, repo: string) =>
+        repo === "bad"
+          ? Promise.reject(new Error("boom"))
+          : [normalize({ number: 1, title: "ok", draft: false, authorLogin: "alice" })],
+      ),
+      getLatestBotReview: vi.fn(async () => null),
+    };
+    const out = await discoverPrsAwaitingReview(["yo61/bad", "yo61/good"], gh, { log: () => {} });
+    expect(out.map((p) => p.repo)).toEqual(["yo61/good"]);
+  });
+
+  it("honours a custom botLogin for both self-PR skip and prior-review dedup", async () => {
+    const gh = fakeGh(
+      {
+        "yo61/repo": [
+          { number: 8, title: "custom bot self PR", draft: false, authorLogin: "nearform-lastlight[bot]" },
+          { number: 9, title: "human PR", draft: false, authorLogin: "erin" },
+        ],
+      },
+      new Set(),
+    );
+    const out = await discoverPrsAwaitingReview(["yo61/repo"], gh, { botLogin: "nearform-lastlight[bot]" });
+    expect(out.map((p) => p.prNumber)).toEqual([9]); // the bot's own PR (8) is skipped
+  });
+});

--- a/apps/server/tests/workflows/post-review-client.test.ts
+++ b/apps/server/tests/workflows/post-review-client.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The fix reads the App PEM path from getRuntimeConfig() (boot-stable), NOT the
+// live process.env a concurrent gondolin run transiently clears. Keep the rest
+// of the config module real; only stub getRuntimeConfig.
+vi.mock("#src/config/config.js", async (orig) => ({
+  ...(await orig<typeof import("#src/config/config.js")>()),
+  getRuntimeConfig: vi.fn(),
+}));
+
+import { getRuntimeConfig } from "#src/config/config.js";
+import { resolveReviewGitHubClient } from "#src/workflows/handlers/post-review.js";
+
+describe("resolveReviewGitHubClient — stable config, immune to the process.env race", () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env.GITHUB_APP_PRIVATE_KEY_PATH;
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.GITHUB_APP_PRIVATE_KEY_PATH;
+    else process.env.GITHUB_APP_PRIVATE_KEY_PATH = saved;
+    vi.clearAllMocks();
+  });
+
+  it("reads the App PEM path from getRuntimeConfig even when process.env is cleared mid-run", () => {
+    const dir = mkdtempSync(join(tmpdir(), "review-client-"));
+    const pem = join(dir, "app.pem");
+    writeFileSync(pem, "-----BEGIN PRIVATE KEY-----\nk\n-----END PRIVATE KEY-----\n");
+    vi.mocked(getRuntimeConfig).mockReturnValue({
+      githubApp: { appId: "1", privateKeyPath: pem, installationId: "2" },
+    } as unknown as ReturnType<typeof getRuntimeConfig>);
+
+    // Simulate a concurrent gondolin run having cleared the shared process.env
+    // (agent-executor applyEnv sets GITHUB_APP_* to "" for in-process runs).
+    process.env.GITHUB_APP_PRIVATE_KEY_PATH = "";
+
+    // Must NOT throw EISDIR: reading process.env="" resolves to the cwd (a
+    // directory) and readFileSync blows up — that was the bug.
+    expect(() => resolveReviewGitHubClient({})).not.toThrow();
+  });
+
+  it("the eval path (githubApiBaseUrl) uses a bearer token, no App PEM read", () => {
+    vi.mocked(getRuntimeConfig).mockReturnValue(undefined);
+    expect(() =>
+      resolveReviewGitHubClient({ githubApiBaseUrl: "http://127.0.0.1:1/api" }),
+    ).not.toThrow();
+  });
+});

--- a/apps/server/workflows/cron-review.yaml
+++ b/apps/server/workflows/cron-review.yaml
@@ -3,6 +3,19 @@ name: check-prs-awaiting-review
 schedule: "*/30 * * * *"
 workflow: pr-review
 context:
-  mode: scan
+  # `discover: prs-awaiting-review` makes the cron runner (src/index.ts) find the
+  # open PRs needing review across managed repos IN CODE
+  # (src/cron/review-discovery.ts) and fan out one bounded single-PR `pr-review`
+  # run per PR — with prNumber + head ref set, the same shape the pr.opened
+  # webhook produces. This replaced the old `mode: scan` run: that single agent
+  # listed and reviewed PRs itself inside the sandbox, where it couldn't reliably
+  # authenticate (a static token it couldn't re-mint), couldn't pre-clone (no PR
+  # known up front), and had no way to hand its chosen PR to the post-review step
+  # — so it could never actually post a review. One PR per run fixes all three
+  # (real prNumber, fresh per-repo scoped token, pre-cloned head).
+  discover: prs-awaiting-review
 condition:
+  # Real-time review comes from the pr.opened webhook; this sweep is the fallback
+  # for deployments without webhooks configured (and a backstop for missed
+  # deliveries). Filtered out when webhooks are enabled.
   unless: webhooksEnabled

--- a/packages/agentic-pi/src/extensions/github/auth.ts
+++ b/packages/agentic-pi/src/extensions/github/auth.ts
@@ -15,6 +15,15 @@ export interface GitHubAuth {
   getToken(): Promise<string>;
   /** When the cached App token expires (null for static-token mode). */
   readonly expiresAt: Date | null;
+  /**
+   * Whether this auth can mint a NEW token. App auth can (re-mint from the
+   * installation); a static injected `GITHUB_TOKEN` cannot — it's fixed for the
+   * life of the process. Consumers use this to report honestly from
+   * `github_refresh_git_auth` (which otherwise claims success while changing
+   * nothing) and to avoid advising a refresh that can't help — e.g. a sandbox
+   * run, where the harness injects a scoped token and clears the App key.
+   */
+  readonly canRefresh: boolean;
 }
 
 export interface GitHubAppAuthOptions {
@@ -81,6 +90,11 @@ export class GitHubAppAuth implements GitHubAuth {
   get expiresAt(): Date | null {
     return this._expiresAt;
   }
+
+  /** App auth re-mints installation tokens from the private key on demand. */
+  get canRefresh(): boolean {
+    return true;
+  }
 }
 
 class StaticTokenAuth implements GitHubAuth {
@@ -90,6 +104,10 @@ class StaticTokenAuth implements GitHubAuth {
   }
   get expiresAt(): Date | null {
     return null;
+  }
+  /** A fixed injected token has no private key to re-mint from — it's stuck. */
+  get canRefresh(): boolean {
+    return false;
   }
 }
 

--- a/packages/agentic-pi/src/extensions/github/tools.ts
+++ b/packages/agentic-pi/src/extensions/github/tools.ts
@@ -39,7 +39,7 @@ function jsonContent(data: unknown) {
  * Wrap a handler so errors become structured JSON results instead of throws.
  * Matches mcp-github-app's `run()` helper exactly.
  */
-async function safeRun<T>(fn: () => Promise<T>) {
+async function safeRun<T>(fn: () => Promise<T>, canRefresh = true) {
   try {
     return jsonContent(await fn());
   } catch (err) {
@@ -54,7 +54,9 @@ async function safeRun<T>(fn: () => Promise<T>) {
       hint: isTransient
         ? "This is a transient error. The request was retried automatically but still failed. Wait and try again."
         : status === 401
-          ? "Authentication failed. Call github_refresh_git_auth to get a fresh token."
+          ? canRefresh
+            ? "Authentication failed. Call github_refresh_git_auth to get a fresh token."
+            : "Authentication failed and the token CANNOT be refreshed here — a fixed GITHUB_TOKEN was injected for this run, so github_refresh_git_auth can't re-mint it. Do not retry in a loop; report the auth failure."
           : null,
     });
   }
@@ -83,7 +85,7 @@ export function buildGitHubTools(
       description,
       parameters,
       async execute(_id, params) {
-        return safeRun(() => handler(params));
+        return safeRun(() => handler(params), auth.canRefresh);
       },
     });
 
@@ -140,7 +142,19 @@ export function buildGitHubTools(
         path: Type.String({ description: "Path to the git repository" }),
       }),
       async ({ path }) => {
-        // Refresh-if-expired; the (possibly new) token flows into every
+        // A static injected token has no private key to re-mint from — calling
+        // getToken() would hand back the SAME value. Report that honestly rather
+        // than a misleading `refreshed: true`, so the agent stops looping on a
+        // credential that can't change (the sandbox case).
+        if (!auth.canRefresh) {
+          return {
+            refreshed: false,
+            path,
+            reason:
+              "This run uses a fixed GITHUB_TOKEN that cannot be re-minted here; the credential is unchanged. If calls keep 401-ing the token is stuck — report the failure rather than retrying.",
+          };
+        }
+        // App auth: refresh-if-expired; the (possibly new) token flows into every
         // subsequent git child via gitAuthEnv (and the harness's ambient env in
         // the sandbox). No file to rewrite.
         await auth.getToken();

--- a/packages/agentic-pi/test/extensions/github/auth-refresh.test.ts
+++ b/packages/agentic-pi/test/extensions/github/auth-refresh.test.ts
@@ -1,0 +1,32 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildAuthFromEnv } from "../../../src/extensions/github/auth.js";
+
+/**
+ * `canRefresh` is what `github_refresh_git_auth` and the 401 hint branch on: a
+ * static injected token cannot be re-minted in-sandbox, so the tool must report
+ * `refreshed:false` and the hint must not advise a refresh that can't help.
+ * Regression guard for the "refreshed:true but the token never changes" loop.
+ */
+describe("GitHubAuth.canRefresh — honest refreshability", () => {
+  test("a static GITHUB_TOKEN cannot refresh (no key to re-mint from)", () => {
+    const { auth } = buildAuthFromEnv({ GITHUB_TOKEN: "ghs_static" });
+    assert.equal(auth?.canRefresh, false);
+  });
+
+  test("App auth can refresh (re-mints from the installation key)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "canrefresh-"));
+    const pem = join(dir, "app.pem");
+    writeFileSync(pem, "-----BEGIN PRIVATE KEY-----\nfixture\n-----END PRIVATE KEY-----\n");
+    const { auth } = buildAuthFromEnv({
+      GITHUB_APP_ID: "123",
+      GITHUB_APP_PRIVATE_KEY_PATH: pem,
+      GITHUB_APP_INSTALLATION_ID: "456",
+    });
+    assert.equal(auth?.canRefresh, true);
+  });
+});

--- a/packages/agentic-pi/test/extensions/github/client.test.ts
+++ b/packages/agentic-pi/test/extensions/github/client.test.ts
@@ -9,6 +9,7 @@ import type { GitHubAuth } from "../../../src/extensions/github/auth.js";
 const staticAuth: GitHubAuth = {
   getToken: async () => "test-token",
   expiresAt: null,
+  canRefresh: false,
 };
 
 /** A throwaway HTTP server that records the paths it was asked for. */


### PR DESCRIPTION
## Problem

`check-prs-awaiting-review` (the pr-review cron, `mode: scan`) didn't reliably review PRs. Several interacting contributory factors:

1. **Scan mode never propagated the reviewed PR's number to `post-review`** — the agent picks a PR internally and writes content-only findings (no PR number), so `post-review` has no `prNumber` and fails on any repo that *has* a PR.
2. **In-sandbox auth is a static token that can't re-mint.** The harness injects a scoped `GITHUB_TOKEN` and clears the App key (hard rule #8), so auth is `StaticTokenAuth`. When that token is bad, `github_refresh_git_auth` calls `auth.getToken()`, gets the same value, and reports `refreshed: true` anyway — and the 401 hint tells the agent to call it. Private repos 401 and loop.
3. **Empty repos fail** at `post-review` with "no PR number".

The **general** factor tying these together: `mode: scan` is a deprecated pattern — the dependabot crons were already migrated off it to code-based discovery + one bounded run per PR. `check-prs-awaiting-review` was the last holdout, and was never actually functional for posting.

## Changes

**1. Migrate the cron off `mode: scan` → discovery + per-PR fan-out** (`fix(pr-review)` commit)
- New `discoverPrsAwaitingReview` (`src/cron/review-discovery.ts`): finds open, non-draft, non-bot PRs without a bot review at the current head SHA, in code via the harness App-auth client (`listOpenPullRequests` + `getLatestBotReview`).
- Wired into the cron runner's discoverer map (renamed `DEP_PR_DISCOVERERS` → `PR_DISCOVERERS`, since it now serves review *and* dependency sweeps).
- `cron-review.yaml`: `mode: scan` → `discover: prs-awaiting-review`.

Each discovered PR fans out one bounded single-PR `pr-review` run with `prNumber` + head ref — the same shape the `pr.opened` webhook produces (a fresh per-repo scoped token, a pre-clone of the PR head, a real PR number for `post-review`). Empty repos produce **no runs**. This fixes factors 1 and 3, and removes the scan path where factor 2 bit.

**2. Make `github_refresh_git_auth` honest** (`fix(agentic-pi/github)` commit)
- Add `canRefresh` to `GitHubAuth`: `true` for App auth (re-mints from the key), `false` for a static injected token.
- The tool returns `{refreshed: false, reason}` when it can't re-mint, instead of a misleading `true`.
- The 401 hint advises the refresh tool only when it can actually help; otherwise it says the credential is stuck and to report the failure. (Independent correctness fix — factor 2 as a standalone.)

## Tests

- `review-discovery`: open/non-draft/non-bot/unreviewed selection, re-review on a new head SHA, per-repo failure isolation, custom `botLogin`.
- `auth-refresh`: static token → `canRefresh: false`, App auth → `true`.
- Full cron + workflows suites green (336), agentic-pi unit tests green (192). No new type errors.

## Supersedes #221

#221 (Fix A) patched the empty-repo `post-review` failure on the scan path by honouring the agent's `skip` before the PR-number gate. But that let a genuine auth failure (the agent skipping because it couldn't review) surface as a **false green**. This migration removes the scan path entirely — empty repos simply produce no runs — so #221 is no longer needed and should be closed in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
