### PR TITLE
fix(workflows): require a completion marker for issue-triage

### DIFF
--- a/apps/server/skills/issue-triage/SKILL.md
+++ b/apps/server/skills/issue-triage/SKILL.md
@@ -147,3 +147,20 @@ closing, creating labels. Never `gh` CLI, `curl`, or raw HTTP.
 - Don't close aggressively — when genuinely in doubt, leave it open as `needs-triage`.
 - Don't change priority or state on issues a maintainer already triaged.
 - Check existing labels before adding — don't duplicate.
+
+## Completion
+
+When you have finished — every target issue classified and labelled, or a
+batch/cron scan that confirmed there was nothing new to triage — end your final
+message with a single marker line:
+
+```
+TRIAGE_COMPLETE: repo=<owner/repo> triaged=<N> labelled=<N> commented=<N>
+```
+
+Emit it **only after actually doing the work** with the `github_*` tools (a scan
+that legitimately found nothing to do still counts — set the counts to 0). If you
+**cannot** triage — the `github_*` tools aren't available, the repo is
+inaccessible, or an error you can't recover from — **do not** emit the marker.
+Stop and explain what blocked you, so the run is recorded as failed rather than a
+silent no-op green.

--- a/apps/server/tests/workflows/issue-triage.test.ts
+++ b/apps/server/tests/workflows/issue-triage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getWorkflow, getWorkflowByIntent } from "#src/workflows/loader.js";
+import { getWorkflow, getWorkflowByIntent, getCronWorkflows } from "#src/workflows/loader.js";
 
 /**
  * Contract test for the built-in issue-triage workflow. Loads the REAL
@@ -25,5 +25,17 @@ describe("issue-triage — built-in workflow", () => {
 
   it("is resolvable by the triage intent", () => {
     expect(getWorkflowByIntent("triage")?.name).toBe("issue-triage");
+  });
+
+  it("is dispatched by the triage-new-issues cron, so the marker covers cron runs too", () => {
+    // The every-15-min scan (webhooks-disabled backstop) is exactly the
+    // batch/cron path that produced the false-green bail this marker fixes. If
+    // this `workflow:` wiring drifts — a rename, an accidental edit — the marker
+    // enforcement silently stops applying to cron-triggered runs, and nothing
+    // else catches it. (Mirrors dependabot-pr-merge.test.ts's cron coverage.)
+    const cron = getCronWorkflows().find((c) => c.workflow === "issue-triage");
+    expect(cron).toBeDefined();
+    expect(cron!.name).toBe("triage-new-issues");
+    expect(cron!.context?.mode).toBe("scan");
   });
 });

--- a/apps/server/tests/workflows/issue-triage.test.ts
+++ b/apps/server/tests/workflows/issue-triage.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { getWorkflow, getWorkflowByIntent } from "#src/workflows/loader.js";
+
+/**
+ * Contract test for the built-in issue-triage workflow. Loads the REAL
+ * workflows/ dir (like golden-build.test.ts) so a schema break or a dropped
+ * postcondition is caught.
+ */
+describe("issue-triage — built-in workflow", () => {
+  it("loads with a single triage phase using the issue-triage skill", () => {
+    const def = getWorkflow("issue-triage");
+    expect(def.name).toBe("issue-triage");
+    expect(def.phases.map((p) => p.name)).toEqual(["triage"]);
+    expect(def.phases[0].skill).toBe("issue-triage");
+  });
+
+  it("gates the triage phase on a completion marker (no silent no-op successes)", () => {
+    // Without this, an agent that bails — e.g. the k8s sandbox exposed no
+    // github_* tools, so it couldn't list/label issues and just explained it
+    // couldn't proceed — still scored `succeeded`. The marker turns that
+    // bail-out RED (the skill only emits it after doing the work).
+    const def = getWorkflow("issue-triage");
+    expect(def.phases[0].on_output?.requires_marker).toBe("TRIAGE_COMPLETE");
+  });
+
+  it("is resolvable by the triage intent", () => {
+    expect(getWorkflowByIntent("triage")?.name).toBe("issue-triage");
+  });
+});

--- a/apps/server/workflows/issue-triage.yaml
+++ b/apps/server/workflows/issue-triage.yaml
@@ -20,3 +20,9 @@ phases:
     label: Triage
     skill: issue-triage
     model: "{{models.triage}}"
+    # Postcondition: the triage skill must end with the TRIAGE_COMPLETE marker,
+    # emitted only after the work is actually done (see skills/issue-triage).
+    # An agent that bails — no github_* tools, repo inaccessible, "re-invoke me" —
+    # never prints it, so the phase fails instead of greening a silent no-op.
+    on_output:
+      requires_marker: "TRIAGE_COMPLETE"


### PR DESCRIPTION
## Problem

The `issue-triage` phase has no `on_output` postcondition, so **any** agent completion scores `succeeded` — including a bail-out that did no work. We hit this when a triage agent came back with a coherent "I don't have the tools to do this, please re-invoke me" message: the phase greened while accomplishing nothing. `reclassifySuccess` doesn't catch it (the output isn't empty), and the phase declares no marker.

## Fix

Add `on_output.requires_marker: "TRIAGE_COMPLETE"` to the triage phase, plus a completion contract in the skill:
- Emit `TRIAGE_COMPLETE: repo=… triaged=… labelled=… commented=…` **only after actually triaging** (a scan that legitimately found nothing still counts — counts=0).
- **Never** emit it when blocked (tools unavailable, repo inaccessible, unrecoverable error).

A bailed run omits the marker, so the phase fails instead of a false green. This mirrors the existing `dependabot-pr-merge` → `ASSESSMENT_COMPLETE` pattern and reuses the engine's existing `requires_marker` enforcement.

Adds a contract test (`issue-triage.test.ts`) in the style of `dependabot-pr-merge.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)