### PR TITLE
fix(github): grant `issues-write` `pull_requests:write` so PR comments post

### DIFF
--- a/apps/server/spec/09-sandbox.md
+++ b/apps/server/spec/09-sandbox.md
@@ -625,11 +625,23 @@ export type GitAccessProfile = "read" | "issues-write" | "review-write" | "repo-
 // :130–155
 export const GITHUB_PERMISSION_PROFILES = {
   read:           { contents: "read",  issues: "read",  pull_requests: "read",  metadata: "read" },
-  "issues-write": { contents: "read",  issues: "write", pull_requests: "read",  metadata: "read" },
+  "issues-write": { contents: "read",  issues: "write", pull_requests: "write", metadata: "read" },
   "review-write": { contents: "read",  issues: "write", pull_requests: "write", metadata: "read" },
   "repo-write":   { contents: "write", issues: "write", pull_requests: "write", workflows: "write", metadata: "read" },
 };
 ```
+
+`issues-write` and `review-write` carry the **same token scopes**. Commenting
+or labelling on a pull request requires `pull_requests: write` — GitHub
+resolves `POST /repos/:owner/:repo/issues/:n/comments` against the *target's*
+type (an issue checks `issues`, a PR checks `pull_requests`), and `write` is
+the coarsest grain it offers. Without it a `pr-comment` / `verify` / `qa-test`
+/ `demo` run 403s with "Resource not accessible by integration" the moment it
+tries to post (issue #239). The two profiles stay distinct in the **tool set**
+agentic-pi registers: only `review-write`+ gets
+`github_create_pull_request` / `github_create_pull_request_review`. That
+registration gate — not the token scope — is what stops a comment workflow
+submitting a formal review.
 
 Per phase:
 

--- a/apps/server/src/engine/github/profiles.ts
+++ b/apps/server/src/engine/github/profiles.ts
@@ -54,12 +54,28 @@ export const GITHUB_PERMISSION_PROFILES: Record<GitAccessProfile, GitHubTokenPer
     pull_requests: "read",
     metadata: "read",
   },
+  // `pull_requests: "write"` is NOT an over-grant — it is what "comment on a
+  // PR" costs. GitHub resolves `POST /repos/:o/:r/issues/:n/comments` against
+  // the *target's* type: an issue checks `issues`, a pull request checks
+  // `pull_requests`. So an issues-write token could comment on issues but 403'd
+  // ("Resource not accessible by integration") on every PR — breaking
+  // `pr-comment`, and `verify` / `qa-test` / `demo` / `issue-comment` whenever
+  // they land on a PR (issue #239). The same rule governs labels + assignees on
+  // a PR. The profile's tool set (`ISSUES_WRITE_TOOLS` in agentic-pi) is
+  // unchanged and stays the behavioural boundary: no PR-review or
+  // PR-creation tool is registered here — that's still `review-write`.
   "issues-write": {
     contents: "read",
     issues: "write",
-    pull_requests: "read",
+    pull_requests: "write",
     metadata: "read",
   },
+  // Same token scope as `issues-write` since #239 — GitHub has no finer grain
+  // than `pull_requests: write` for "comment on a PR" vs "submit a review".
+  // The two profiles stay distinct because the *tool set* differs:
+  // `REVIEW_WRITE_TOOLS` adds `github_create_pull_request` +
+  // `github_create_pull_request_review`, which the comment workflows must not
+  // be able to call.
   "review-write": {
     contents: "read",
     issues: "write",

--- a/apps/server/src/workflows/runner.ts
+++ b/apps/server/src/workflows/runner.ts
@@ -88,7 +88,8 @@ export function gitAccessProfileForWorkflow(workflowName: string): GitAccessProf
     case "answer":
     case "security-review":
     // verify / qa-test / demo read the repo and post a findings/demo comment —
-    // they never push code, so issues-write (contents:read + issues:write) is
+    // they never push code, so issues-write (contents:read + issues:write +
+    // pull_requests:write, the last needed to comment on a PR at all) is
     // enough.
     case "verify":
     case "qa-test":

--- a/apps/server/tests/engine/github/permission-profiles.test.ts
+++ b/apps/server/tests/engine/github/permission-profiles.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { GITHUB_PERMISSION_PROFILES } from "#src/engine/github/profiles.js";
+import { gitAccessProfileForWorkflow } from "#src/workflows/runner.js";
+
+/**
+ * Issue #239: a `pr-comment` run 403'd ("Resource not accessible by
+ * integration") on every attempt to post its answer, while the identical
+ * `issue-comment` call succeeded — because GitHub resolves
+ * `POST /repos/:owner/:repo/issues/:n/comments` against the TARGET's type:
+ * an issue is checked against `issues`, a pull request against
+ * `pull_requests`. Any profile allowed to comment must therefore carry
+ * `pull_requests: write`, however issue-shaped the endpoint looks.
+ */
+describe("GITHUB_PERMISSION_PROFILES", () => {
+  it("keeps `read` read-only across every scope", () => {
+    expect(GITHUB_PERMISSION_PROFILES.read).toEqual({
+      contents: "read",
+      issues: "read",
+      pull_requests: "read",
+      metadata: "read",
+    });
+  });
+
+  it("grants issues-write pull_requests:write so it can comment on a PR (#239)", () => {
+    expect(GITHUB_PERMISSION_PROFILES["issues-write"]).toEqual({
+      contents: "read",
+      issues: "write",
+      pull_requests: "write",
+      metadata: "read",
+    });
+  });
+
+  it("never lets a comment profile write code", () => {
+    for (const profile of ["read", "issues-write", "review-write"] as const) {
+      expect(GITHUB_PERMISSION_PROFILES[profile].contents).toBe("read");
+      expect(GITHUB_PERMISSION_PROFILES[profile]).not.toHaveProperty("workflows");
+    }
+  });
+
+  it("keeps repo-write the only contents/workflows writer", () => {
+    expect(GITHUB_PERMISSION_PROFILES["repo-write"]).toEqual({
+      contents: "write",
+      issues: "write",
+      pull_requests: "write",
+      workflows: "write",
+      metadata: "read",
+    });
+  });
+});
+
+describe("PR-reachable workflows can write to a PR", () => {
+  // Every handler the router can pick for a comment on a PR
+  // (src/engine/router.ts — the `if (envelope.prNumber)` branch).
+  const PR_REACHABLE = ["pr-comment", "pr-fix", "pr-review", "verify", "qa-test", "demo"];
+
+  for (const workflow of PR_REACHABLE) {
+    it(`${workflow} gets a profile with pull_requests:write`, () => {
+      const profile = gitAccessProfileForWorkflow(workflow);
+      expect(GITHUB_PERMISSION_PROFILES[profile].pull_requests).toBe("write");
+    });
+  }
+
+  it("issue-comment can also write to a PR — the router sends it PR targets too", () => {
+    const profile = gitAccessProfileForWorkflow("issue-comment");
+    expect(GITHUB_PERMISSION_PROFILES[profile].pull_requests).toBe("write");
+  });
+});

--- a/packages/agentic-pi/src/extensions/github/profiles.ts
+++ b/packages/agentic-pi/src/extensions/github/profiles.ts
@@ -8,9 +8,17 @@
  *
  * Mirrors lastlight's `GITHUB_PERMISSION_PROFILES` token scopes:
  *   read         → contents:r, issues:r, pull_requests:r, metadata:r
- *   issues-write → ditto + issues:w
- *   review-write → ditto + pull_requests:w
- *   repo-write   → ditto + contents:w
+ *   issues-write → ditto + issues:w + pull_requests:w
+ *   review-write → same scopes as issues-write
+ *   repo-write   → ditto + contents:w + workflows:w
+ *
+ * `issues-write` and `review-write` carry the same TOKEN scopes: commenting or
+ * labelling on a pull request requires `pull_requests: write` (GitHub checks
+ * the target's type, not the endpoint's path — lastlight issue #239), and
+ * that is also the coarsest grain GitHub offers. The profiles diverge here, in
+ * the tool sets: only `review-write`+ registers `github_create_pull_request` /
+ * `github_create_pull_request_review`. This gate — not the token — is what
+ * keeps a comment workflow from submitting a formal review.
  */
 
 export type GitAccessProfile = "read" | "issues-write" | "review-write" | "repo-write";


### PR DESCRIPTION
Fixes #239.

## The bug

`pr-comment` never posts. Its one deliverable — the answer — dies on a `403 Resource not accessible by integration`, and the run is still recorded as **succeeded**, so the answer only exists in the transcript.

GitHub resolves `POST /repos/:owner/:repo/issues/:n/comments` against the **target's type**, not the endpoint's path: an issue is checked against the `issues` permission, a pull request against `pull_requests`. The [permissions reference](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps) lists that one endpoint under *both*. Our `issues-write` profile minted `pull_requests: read`, so it could comment on issues and never on a PR.

## Evidence (live nearform instance, v0.21.11)

Same repo, same App, same profile, ~30 minutes apart:

| Run | Target | Result |
|---|---|---|
| `issue-comment` `699d686a` | nearform/skillspro **#1597** (issue) | comment posted |
| `pr-comment` `bc8d0bf9` | nearform/skillspro **#1540** (PR) | `403 Resource not accessible by integration` |

The mint was faithful to the profile — this is not #215 (no transit narrowing, no wrong repo). From the prod log, for the failing run:

```
[executor] Minting git token: profile=issues-write, repo=skillspro, permissions=contents,issues,pull_requests,metadata
[git-auth] Mint granted: repository_selection=selected, permissions={"contents":"read","issues":"write","metadata":"read","pull_requests":"read"}, repositories=nearform/skillspro
```

Every *read* in that run (get PR, get diff) succeeded; only the write failed.

## Blast radius

`gitAccessProfileForWorkflow` gives `issues-write` to `pr-comment`, `verify`, `qa-test`, `demo`, `answer`, `security-review`. Per the router's `if (envelope.prNumber)` branch, `pr-comment` / `verify` / `qa-test` / `demo` are all reachable **on a PR**, and `issue-comment` handles PR targets too. All of them were silently unable to comment or label there. `pr-review` was unaffected: it maps to `review-write` and posts harness-side.

## The change

`issues-write` gains `pull_requests: write`. It now carries the same token scopes as `review-write` — `pull_requests: write` is the coarsest grain GitHub offers, with no split between "comment on a PR" and "submit a review". The two profiles stay distinct where it counts, in the **tool set** agentic-pi registers: only `review-write`+ gets `github_create_pull_request` / `github_create_pull_request_review`. That registration gate, not the token scope, is what stops a comment workflow submitting a formal review. Tool sets are unchanged by this PR.

The residual widening is raw-API-only: an agent that ignored its tools and curled the API directly could now open or approve a PR (merge stays blocked — `contents: read`). Alternatives considered and rejected: mapping `pr-comment` → `review-write` (fixes one workflow, and trades an enforced gate for a prompt-level "don't post a review" rule), and a fifth profile (same token scopes as `review-write`, so it buys nothing the tool gate doesn't already give).

- `apps/server/src/engine/github/profiles.ts` — the fix, with the GitHub rule written down next to it.
- `apps/server/tests/engine/github/permission-profiles.test.ts` — new. Pins each profile's scopes and asserts every PR-reachable workflow resolves to a profile with `pull_requests: write`. Verified to fail (6 of 11) against the old value.
- `apps/server/spec/09-sandbox.md` — the profile table + why the two profiles now share scopes. (The www copy is generated from it.)
- `packages/agentic-pi/src/extensions/github/profiles.ts`, `apps/server/src/workflows/runner.ts` — comments only, keeping the mirrored descriptions honest.

`pnpm turbo run typecheck test --filter=lastlight-core --filter=agentic-pi`: 1571 passed, 15 skipped, dep-cruiser clean.

## Not in this PR

The **silent failure** is a separate defect and deserves its own issue: the agent's comment 403'd, the phase reported success, and nothing surfaced it. `pr-review` avoids this by posting harness-side (`post-review`); the comment workflows trust the agent and don't check. Happy to file it.

This is prod-facing, so it needs a release + `deploy.version` bump to reach an instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)