### PR TITLE
fix(workflows): retract the enqueue ack when a queued run leaves the queue

### DIFF
--- a/apps/server/spec/06-workflow-engine.md
+++ b/apps/server/spec/06-workflow-engine.md
@@ -451,6 +451,16 @@ execute outside the cap). Resumes and orphan restarts **bypass** the cap:
 they re-enter `runWorkflow` directly, finishing in-flight work rather than
 re-queuing behind it.
 
+**The enqueue ack is transient.** It is a promise about the future, so it
+must not outlive the run's stay in the queue. `RunnerCallbacks.postComment`
+resolves to the created GitHub comment id (`void` on Slack, or when the post
+failed), and `simple.ts` stashes it at `scratch.queuedAck.commentId`.
+Whichever way the run then leaves the queue, the admission controller
+resolves that comment — see below. Without this the ack is the *only*
+visible trace of a run that starts and then legitimately no-ops (e.g. a
+re-triage of an already-triaged issue), which reads as "it queued and never
+came back".
+
 **Admission.** `createAdmissionController` (`src/workflows/admission.ts`)
 promotes queued runs to running as slots free, reusing `resumeSimpleRun`
 (a queued run's stored `context` is shaped exactly like a resume's, and no
@@ -461,12 +471,24 @@ phase has run yet, so the ledger runs them all). Promotion is FIFO by
 1. **Event-driven** — `admitNext()` runs in `dispatchWorkflow`'s `finally`
    block, so a just-finished run immediately pulls the next queued one in.
 2. **Periodic sweep** — a `setInterval(sweep, 15s)` also **TTL-expires**
-   queued runs older than `concurrency.maxQueueWaitMs` (default 30 min;
+   queued runs older than `concurrency.maxQueueWaitMs` (default 1 hr;
    env `MAX_QUEUE_WAIT_MS`) — transitioning them to `cancelled` with a
-   "dropped from queue after waiting too long" notice posted back to the
-   originating GitHub issue or Slack thread — before admitting. The sweeper
-   starts after boot's orphan recovery, so a run that was `queued` when the
-   harness crashed is picked up on the first tick.
+   "dropped from queue after waiting too long" reason in `context.error` —
+   before admitting. The sweeper starts after boot's orphan recovery, so a
+   run that was `queued` when the harness crashed is picked up on the first
+   tick.
+
+Both exits resolve the enqueue ack, so it never lingers as a stale promise:
+
+- **Admitted** → `retractQueuedAck` **deletes** the ack comment. It has been
+  honoured, and whatever the run itself posts is now the real answer.
+- **TTL-expired** → `postExpiryAck` **rewrites the ack in place** to the drop
+  notice. Editing adds nothing to the thread and GitHub does not notify
+  watchers on edits, so this does not reintroduce the comment flood that made
+  expiry silent on GitHub in the first place. A **Slack**-originated run
+  instead gets a normal thread reply (a human explicitly asked for the work);
+  a GitHub run that left no ack stays silent, its drop visible only in the
+  dashboard and `lastlight workflow list`.
 
 The `queued?: boolean` on `WorkflowResult` propagates up through
 `dispatchWorkflow` and the [dispatcher](/spec/06-workflow-engine): queued

--- a/apps/server/src/engine/github/github.ts
+++ b/apps/server/src/engine/github/github.ts
@@ -89,6 +89,21 @@ export class GitHubClient {
   }
 
   /**
+   * Delete an issue/PR comment the bot posted earlier. Used to retract a
+   * *transient* status comment once it stops being true — currently the
+   * concurrency-cap enqueue ack, which promises "it'll start automatically when
+   * a slot frees" and is meaningless (issue #244) the moment the run is
+   * admitted. Only ever call this on a comment id this harness created.
+   */
+  async deleteComment(owner: string, repo: string, commentId: number): Promise<void> {
+    await this.octokit.rest.issues.deleteComment({
+      owner,
+      repo,
+      comment_id: commentId,
+    });
+  }
+
+  /**
    * Add an emoji reaction to a specific issue comment. Used as an immediate
    * (silent) acknowledgment that the agent has accepted a request, before
    * any actual work — and any chatty bot comments — start.

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -609,7 +609,9 @@ async function main() {
         ?? (github && issueNumber
           ? async (msg) => {
               try {
-                await github.postComment(owner, repo, issueNumber as number, msg);
+                // Return the new comment id: a transient comment (the enqueue
+                // ack) needs a handle to retract itself with later (#244).
+                return await github.postComment(owner, repo, issueNumber as number, msg);
               } catch (err: unknown) {
                 const m = err instanceof Error ? err.message : String(err);
                 console.warn(`[dispatch] Failed to post comment: ${m}`);

--- a/apps/server/src/workflows/admission.ts
+++ b/apps/server/src/workflows/admission.ts
@@ -20,6 +20,13 @@
  * and the ledger's `shouldRunPhase` will run all phases (none have run yet).
  * This avoids duplicating dispatch plumbing and naturally bypasses the cap
  * (resumes enter `runWorkflow` directly, not the fresh-run gate).
+ *
+ * **The enqueue ack is transient (issue #244).** `simple.ts` posts "…is queued,
+ * it'll start automatically when a slot frees" and stashes the comment handle in
+ * `scratch.queuedAck.commentId`. Whichever way the run leaves the queue, this
+ * controller resolves that comment rather than leaving a stale promise behind:
+ * admitted → `retractQueuedAck` deletes it; TTL-expired → `postExpiryAck`
+ * rewrites it in place to the drop notice.
  */
 
 import type { StateDb } from "../state/db.js";
@@ -83,6 +90,13 @@ export function createAdmissionController(deps: AdmissionDeps): AdmissionControl
       // background. Do NOT await — this is a long-running sandbox dispatch.
       const admitted = db.runs.getRun(next.id);
       if (admitted) {
+        // The enqueue ack ("it'll start automatically when a slot frees") has
+        // now been honoured, so retract it before the run posts anything of its
+        // own (issue #244). Fire-and-forget: a failed retract is cosmetic.
+        retractQueuedAck(admitted, resumeOpts).catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn(`[admission] Failed to retract queued ack for ${admitted.id}: ${msg}`);
+        });
         dispatchAdmitted(admitted, resumeOpts);
       }
       // Backpressure mode: promote ONE probe per invocation. In app-count mode,
@@ -148,31 +162,74 @@ async function expireStaleRuns(
 }
 
 /**
- * Best-effort: notify the ORIGINATING SLACK THREAD that a queued run was
- * dropped. A Slack run is a human explicitly asking for work, so a "it didn't
- * run" reply is useful. Never throws — the row has already been transitioned, so
- * a failed ack is a UI gap, not a data hazard.
+ * The GitHub comment handle `simple.ts` stashes when it posts the enqueue ack,
+ * so a later transition can retract or rewrite that comment (issue #244).
+ * Absent for Slack-originated runs and for any run whose ack failed to post.
+ */
+function queuedAckCommentId(run: WorkflowRun): number | undefined {
+  const ack = (run.scratch?.queuedAck ?? {}) as { commentId?: unknown };
+  return typeof ack.commentId === "number" ? ack.commentId : undefined;
+}
+
+/**
+ * Best-effort: delete the enqueue ack once the run has actually been admitted.
  *
- * GitHub-originated runs get NO comment: these are mostly automated
- * dependency-PR / review webhooks, and a "dropped from queue" comment on every
- * TTL-expired run floods the PR with noise (the symptom that surfaced this). The
- * drop is still visible in the dashboard + `lastlight workflow list` (status
- * `cancelled`, `context.error` = the reason), and such a run can now be retried.
+ * The ack exists only to say "hang tight, this will start" — once it has, the
+ * comment is a stale promise, and on a workflow that legitimately no-ops (a
+ * re-triage of an already-triaged issue) it would otherwise be the run's ONLY
+ * visible trace, reading as "it queued and never came back" (issue #244).
+ * Deleting rather than editing keeps the thread clean: whatever the run itself
+ * posts becomes the real answer, and the run stays fully visible in the
+ * dashboard + `lastlight workflow list` either way.
+ *
+ * Never throws — a failed retract is cosmetic, and the run is already running.
+ */
+async function retractQueuedAck(run: WorkflowRun, resumeOpts: ResumeOptions): Promise<void> {
+  const commentId = queuedAckCommentId(run);
+  if (commentId === undefined) return;
+  const { github } = resumeOpts;
+  if (!github || !run.owner || !run.repo) return;
+  await github.deleteComment(run.owner, run.repo, commentId);
+}
+
+/**
+ * Best-effort: tell the originating surface that a queued run was dropped.
+ * Never throws — the row has already been transitioned, so a failed ack is a UI
+ * gap, not a data hazard.
+ *
+ * **Slack** runs get a thread reply: a Slack run is a human explicitly asking
+ * for work, so an "it didn't run" message is useful.
+ *
+ * **GitHub** runs get no NEW comment — these are mostly automated dependency-PR
+ * / review webhooks, and a fresh "dropped from queue" comment on every TTL
+ * expiry floods the PR with noise (the symptom that surfaced this). But when the
+ * run posted an enqueue ack, that comment is now actively false, so it is
+ * rewritten IN PLACE (issue #244). That adds nothing to the thread — the comment
+ * is already there — and GitHub does not notify watchers on edits, so the
+ * anti-noise property holds.
  */
 async function postExpiryAck(
   run: WorkflowRun,
   reason: string,
   resumeOpts: ResumeOptions,
 ): Promise<void> {
+  const msg = `Workflow \`${run.workflowName}\` was ${reason}.`;
+
   // Slack-originated run: use slackPoster (channel/thread stored in context).
   if (run.triggerId.startsWith("slack:")) {
-    const msg = `Workflow \`${run.workflowName}\` was ${reason}.`;
     const stored = (run.context || {}) as Record<string, unknown>;
     const channelId = stored.channelId as string | undefined;
     const threadId = stored.threadId as string | undefined;
     if (resumeOpts.slackPoster && channelId && threadId) {
       await resumeOpts.slackPoster(channelId, threadId, msg);
     }
+    return;
   }
-  // GitHub-originated runs: intentionally no PR comment (see doc above).
+
+  // GitHub-originated run: rewrite the stale ack if we left one, else stay quiet.
+  const commentId = queuedAckCommentId(run);
+  if (commentId === undefined) return;
+  const { github } = resumeOpts;
+  if (!github || !run.owner || !run.repo) return;
+  await github.updateComment(run.owner, run.repo, commentId, msg);
 }

--- a/apps/server/src/workflows/runner.ts
+++ b/apps/server/src/workflows/runner.ts
@@ -50,7 +50,14 @@ export type ApprovalGateConfig = Record<string, boolean>;
 export interface RunnerCallbacks {
   onPhaseStart?: (phase: string) => Promise<void>;
   onPhaseEnd?: (phase: string, result: PhaseResult) => Promise<void>;
-  postComment?: (body: string) => Promise<void>;
+  /**
+   * Post a one-off comment to whichever surface triggered the run. Resolves to
+   * the created GitHub comment id when the surface is a GitHub issue/PR and the
+   * id is known, so a caller can retract or edit that comment later — the
+   * enqueue ack does this (issue #244). Resolves to `void` for Slack and for
+   * any post that failed; callers posting a permanent comment ignore it.
+   */
+  postComment?: (body: string) => Promise<number | void>;
   /**
    * In-place "task list" progress surface. When set (workflows that opt in via
    * `status_checklist: true`), the runner drives this instead of posting a new

--- a/apps/server/src/workflows/simple.ts
+++ b/apps/server/src/workflows/simple.ts
@@ -388,10 +388,19 @@ export async function runSimpleWorkflow(
         config.sandbox === "kubernetes"
           ? `the safety fuse (${admitCap}) is reached`
           : `the concurrency limit (${admitCap}) is reached`;
-      await notify(
+      const ackId = await notify(
         `\`${workflowName}\` is queued — ${capReason}.` +
         ` It'll start automatically when a slot frees.`,
       );
+      // The ack is TRANSIENT: it promises the run will start, so it stops being
+      // true the moment the run leaves the queue. Stash the comment handle so
+      // the admission controller can retract it on admit / rewrite it on TTL
+      // expiry (issue #244) — otherwise a run that starts and then legitimately
+      // no-ops leaves this comment as the only trace, reading as "it queued and
+      // never came back". Only GitHub surfaces return an id; Slack resolves void.
+      if (typeof ackId === "number") {
+        db.runs.mergeScratch(workflowId, { queuedAck: { commentId: ackId } });
+      }
       return { success: true, queued: true, phases: [] };
     }
   }
@@ -598,7 +607,7 @@ export async function runSimpleWorkflow(
 async function handleExistingRun(
   run: WorkflowRun,
   definition: ReturnType<typeof getWorkflow>,
-  notify: (msg: string) => Promise<void>,
+  notify: (msg: string) => Promise<number | void>,
   db: StateDb,
 ): Promise<WorkflowResult | null> {
   // Dedup: a duplicate trigger on an already-queued run must be a no-op.

--- a/apps/server/tests/workflows/admission.test.ts
+++ b/apps/server/tests/workflows/admission.test.ts
@@ -53,6 +53,38 @@ function makeQueuedRun(db: StateDb, id: string, startedAt: string): void {
   });
 }
 
+/**
+ * A queued GitHub-triggered run that left an enqueue ack behind — the shape
+ * `simple.ts` persists when it posts the "…is queued" comment (#244).
+ */
+function makeQueuedRunWithAck(
+  db: StateDb,
+  id: string,
+  startedAt: string,
+  commentId: number,
+): void {
+  db.runs.createRun({
+    id,
+    workflowName: "issue-triage",
+    triggerId: `acme/widgets#${id.slice(-2)}`,
+    owner: "acme",
+    repo: "widgets",
+    issueNumber: 215,
+    currentPhase: "triage",
+    status: "queued",
+    startedAt,
+  });
+  db.runs.mergeScratch(id, { queuedAck: { commentId } });
+}
+
+function makeGithubStub() {
+  return {
+    postComment: vi.fn(async () => 1),
+    updateComment: vi.fn(async () => {}),
+    deleteComment: vi.fn(async () => {}),
+  };
+}
+
 function makeRunningRun(db: StateDb, id: string): void {
   db.runs.createRun({
     id,
@@ -232,6 +264,94 @@ describe("createAdmissionController", () => {
 
     expect(db.runs.getRun("gh-stale")!.status).toBe("cancelled");
     expect(postComment).not.toHaveBeenCalled();
+  });
+
+  // ── enqueue-ack lifecycle (issue #244) ──────────────────────────────────
+  //
+  // The ack promises "it'll start automatically when a slot frees", so it must
+  // not survive the run leaving the queue — otherwise a run that starts and
+  // then legitimately no-ops leaves that comment as its only visible trace.
+
+  it("admitNext: deletes the enqueue ack once the run is admitted", async () => {
+    makeQueuedRunWithAck(db, "run-ack", "2024-01-01T00:00:00.000Z", 5060108290);
+    const github = makeGithubStub();
+
+    const ctrl = createAdmissionController({
+      db,
+      resumeOpts: { ...makeResumeOpts(db), github: github as never },
+      maxWorkflows: 4,
+      maxQueueWaitMs: 1_800_000,
+    });
+    await ctrl.admitNext();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(db.runs.getRun("run-ack")!.status).toBe("running");
+    expect(github.deleteComment).toHaveBeenCalledWith("acme", "widgets", 5060108290);
+    // Retracted, not rewritten — the run's own output is the real answer now.
+    expect(github.updateComment).not.toHaveBeenCalled();
+  });
+
+  it("admitNext: admits normally when no ack was recorded (Slack / failed post)", async () => {
+    makeQueuedRun(db, "run-noack", "2024-01-01T00:00:00.000Z");
+    const github = makeGithubStub();
+
+    const ctrl = createAdmissionController({
+      db,
+      resumeOpts: { ...makeResumeOpts(db), github: github as never },
+      maxWorkflows: 4,
+      maxQueueWaitMs: 1_800_000,
+    });
+    await ctrl.admitNext();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(db.runs.getRun("run-noack")!.status).toBe("running");
+    expect(github.deleteComment).not.toHaveBeenCalled();
+  });
+
+  it("admitNext: a failing retract does not block the run from dispatching", async () => {
+    makeQueuedRunWithAck(db, "run-boom", "2024-01-01T00:00:00.000Z", 42);
+    const github = makeGithubStub();
+    github.deleteComment.mockRejectedValue(new Error("404 comment gone"));
+
+    const ctrl = createAdmissionController({
+      db,
+      resumeOpts: { ...makeResumeOpts(db), github: github as never },
+      maxWorkflows: 4,
+      maxQueueWaitMs: 1_800_000,
+    });
+    await ctrl.admitNext();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(db.runs.getRun("run-boom")!.status).toBe("running");
+    expect(mockResumeSimpleRun).toHaveBeenCalledOnce();
+  });
+
+  it("sweep: rewrites the stale ack IN PLACE on TTL expiry rather than posting anew", async () => {
+    const oldTime = new Date(Date.now() - 3_600_000).toISOString();
+    makeQueuedRunWithAck(db, "gh-ack-stale", oldTime, 777);
+    const github = makeGithubStub();
+
+    const ctrl = createAdmissionController({
+      db,
+      resumeOpts: { ...makeResumeOpts(db), github: github as never },
+      maxWorkflows: 4,
+      maxQueueWaitMs: 1_800_000,
+    });
+    await ctrl.sweep();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(db.runs.getRun("gh-ack-stale")!.status).toBe("cancelled");
+    expect(github.updateComment).toHaveBeenCalledOnce();
+    const [owner, repo, commentId, body] = github.updateComment.mock.calls[0] as unknown as [
+      string,
+      string,
+      number,
+      string,
+    ];
+    expect([owner, repo, commentId]).toEqual(["acme", "widgets", 777]);
+    expect(body).toMatch(/waiting too long/);
+    // Editing an existing comment, never adding one — that was the noise source.
+    expect(github.postComment).not.toHaveBeenCalled();
   });
 
   it("start/stop: can start the interval and stop it without throwing", () => {

--- a/apps/server/tests/workflows/simple-cap.test.ts
+++ b/apps/server/tests/workflows/simple-cap.test.ts
@@ -143,6 +143,65 @@ describe("runSimpleWorkflow — concurrency cap (issue #172)", () => {
     expect(callbacks.postComment).toHaveBeenCalledOnce();
   });
 
+  it("stashes the enqueue ack's comment id so admission can retract it (#244)", async () => {
+    db.runs.createRun({
+      id: "blocker",
+      workflowName: "build",
+      triggerId: "acme/widgets#100",
+      currentPhase: "architect",
+      status: "running",
+      startedAt: new Date().toISOString(),
+    });
+
+    // A GitHub surface resolves the new comment id; Slack resolves void.
+    const callbacks = { ...makeCallbacks(), postComment: vi.fn(async () => 5060108290) };
+    await runSimpleWorkflow(
+      "explore",
+      makeRequest({ issueNumber: 215 }),
+      makeConfig(),
+      callbacks,
+      db,
+      undefined,
+      undefined,
+      "lastlight:bootstrap",
+      undefined,
+      { maxWorkflows: 1, maxQueueWaitMs: 1_800_000 },
+    );
+
+    const run = db.runs.getByTrigger("acme/widgets#215")!;
+    expect(run.status).toBe("queued");
+    expect(run.scratch?.queuedAck).toEqual({ commentId: 5060108290 });
+  });
+
+  it("records no ack handle when the surface returns no comment id (Slack)", async () => {
+    db.runs.createRun({
+      id: "blocker",
+      workflowName: "build",
+      triggerId: "acme/widgets#100",
+      currentPhase: "architect",
+      status: "running",
+      startedAt: new Date().toISOString(),
+    });
+
+    const callbacks = makeCallbacks(); // postComment resolves void
+    await runSimpleWorkflow(
+      "explore",
+      makeRequest({ issueNumber: 216 }),
+      makeConfig(),
+      callbacks,
+      db,
+      undefined,
+      undefined,
+      "lastlight:bootstrap",
+      undefined,
+      { maxWorkflows: 1, maxQueueWaitMs: 1_800_000 },
+    );
+
+    const run = db.runs.getByTrigger("acme/widgets#216")!;
+    expect(run.status).toBe("queued");
+    expect(run.scratch?.queuedAck).toBeUndefined();
+  });
+
   it("dedup: a duplicate trigger on a queued run returns queued without executing", async () => {
     // Create a queued run for the trigger
     db.runs.createRun({


### PR DESCRIPTION
Fixes #244.

## The problem

The concurrency-cap ack is posted and then never resolved. Nothing touches it when the run is admitted, and nothing touches it when the run is TTL-dropped. It is a promise about the future that outlives the thing it promises.

That is invisible most of the time, because most runs go on to post something of their own. It becomes very visible when a run legitimately no-ops. On nearform/lastlight#215 a reporter follow-up re-triaged an already-triaged issue: the run was queued behind 4 in-flight runs, admitted 54s later, ran 36s, succeeded — and concluded "no changes needed", because the labels were already correct. The only thing left on the issue was https://github.com/nearform/lastlight/issues/215#issuecomment-5060108290, saying work was queued. It reads as "it queued and never came back". Nothing was actually broken except the comment.

## The fix

Give the ack a handle, then resolve it on whichever exit the run takes.

`GitHubClient.postComment` already returned the new comment id; the dispatch wiring in `index.ts` was throwing it away. `RunnerCallbacks.postComment` now resolves to `number | void` (void for Slack, and for a post that failed), and `simple.ts` stashes the id at `scratch.queuedAck.commentId` next to the `queued` row.

The admission controller then closes the loop:

| exit | what happens to the ack |
|---|---|
| **admitted** | deleted — the promise was honoured, and whatever the run posts next is the real answer |
| **TTL-expired** | rewritten in place to the drop notice |

Deleting on admission is deliberate over editing: for the no-op case the ideal end state is a clean thread, and the run remains fully visible in the dashboard and `lastlight workflow list` regardless.

Rewriting on expiry also closes a related gap. `postExpiryAck` deliberately posts nothing to GitHub, because a fresh "dropped from queue" comment on every TTL expiry used to flood dependency PRs — but that left the ack standing and now actively false. Editing the existing comment is not the thing that caused the flood: it adds nothing to the thread, and GitHub does not notify watchers on edits. Slack keeps its normal thread reply, and a GitHub run that never left an ack stays silent exactly as before.

Adds `GitHubClient.deleteComment` as the sibling of the existing `updateComment`.

## Not covered

Cancelling a queued run from the dashboard/admin route takes a third exit that still leaves the ack behind. Same shape, different call site — worth a follow-up if it shows up in practice.

## Tests

Five new cases across `admission.test.ts` and `simple-cap.test.ts`: the ack id is stashed on enqueue and *not* stashed when the surface returns no id; the ack is deleted (not edited) on admission; a failing retract still dispatches the run; expiry edits in place and never calls `postComment`. Full server suite green — 1577 passed.

## Docs

`spec/06-workflow-engine.md` gains the ack lifecycle, and two stale claims are corrected while I was in there: `maxQueueWaitMs` defaults to 1 hr (not 30 min), and expiry did not in fact notify the originating GitHub issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)