### PR TITLE
fix(workflows): skip the local post-review git diff when there is no checkout (k8s)

### DIFF
--- a/apps/server/src/workflows/handlers/post-review.ts
+++ b/apps/server/src/workflows/handlers/post-review.ts
@@ -150,10 +150,15 @@ export class GitHubPostReviewHandler implements PhaseTypeHandler {
 
     // Head SHA + base ref come from the checkout / run context, never the agent.
     const baseRef = typeof ctx.baseBranch === "string" && ctx.baseBranch ? ctx.baseBranch : undefined;
-    let headSha = this.gitHeadSha(hostRepoDir);
-    // No local checkout (k8s: only the artifact store's `.lastlight/`) — fetch
-    // the head SHA from the GitHub API so the idempotency check below and inline
-    // comments (which require a commit id) both work.
+    // `git rev-parse HEAD` doubles as the "is there a local checkout?" probe: it
+    // returns a SHA on host-checkout backends (docker/none/gondolin) and
+    // undefined on k8s, where the workspace lives in a sandbox PVC and only the
+    // harvested `.lastlight/` reaches the harness.
+    const localHeadSha = this.gitHeadSha(hostRepoDir);
+    // No local checkout (k8s) — fetch the head SHA from the GitHub API so the
+    // idempotency check below and inline comments (which require a commit id)
+    // both work.
+    let headSha = localHeadSha;
     if (!headSha) headSha = await github.getPullRequestHeadSha(owner, repo, prNumber).catch(() => undefined);
 
     // Idempotency: skip if a bot review already exists on this head SHA (guards
@@ -168,8 +173,13 @@ export class GitHubPostReviewHandler implements PhaseTypeHandler {
     }
 
     // Commentable line set from the local checkout diff. Failure → null → all
-    // findings demoted to the body (the review still posts).
-    let commentable = baseRef ? this.gitCommentableDiff(hostRepoDir, baseRef) : null;
+    // findings demoted to the body (the review still posts). Gated on a local
+    // checkout actually existing: without that guard, k8s (no `.git` on the
+    // harness) runs a guaranteed-to-fail `git diff` that dumps a usage block and
+    // a FALSE "demoting all findings to the body" on every run — before the API
+    // fallback silently rescues the findings.
+    let commentable =
+      localHeadSha && baseRef ? this.gitCommentableDiff(hostRepoDir, baseRef) : null;
     // No local checkout (or no base ref) — fall back to GitHub's own PR diff
     // (the same merge-base diff) so findings still anchor inline on k8s instead
     // of demoting to the body.
@@ -227,7 +237,13 @@ export class GitHubPostReviewHandler implements PhaseTypeHandler {
 
   private gitHeadSha(repoDir: string): string | undefined {
     try {
-      return execFileSync("git", ["-C", repoDir, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+      // Also the "is there a local checkout?" probe (undefined on k8s), so it
+      // runs on every run — silence stderr ("fatal: not a git repository") that
+      // execFileSync otherwise inherits to the console.
+      return execFileSync("git", ["-C", repoDir, "rev-parse", "HEAD"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
     } catch {
       return undefined;
     }

--- a/apps/server/tests/workflows/post-review.test.ts
+++ b/apps/server/tests/workflows/post-review.test.ts
@@ -251,6 +251,45 @@ describe("post-review action (runPostReview)", () => {
     expect(body.body).not.toContain("Additional findings");
   });
 
+  it("does NOT shell out to the local git diff when there is no checkout, even with a base ref (k8s)", async () => {
+    // Robin's homelab hit this: a real PR carries `baseBranch` ("main"), so
+    // pre-fix `gitCommentableDiff` ran against the harness path — which on k8s
+    // holds only the harvested `.lastlight/`, never a `.git`. Every git call
+    // failed with `fatal: not a git repository`, dumping the giant `git diff`
+    // usage block + a FALSE "demoting all findings to the body" (the API
+    // fallback then rescued the findings). The handler must detect the absent
+    // checkout and skip straight to the API diff — no failing subprocess, no
+    // misleading log. seedFindings writes findings.json but no `.git`, exactly
+    // reproducing the k8s state; the base ref present is what triggers the bug.
+    const gitDiffSpy = vi.spyOn(
+      GitHubPostReviewHandler.prototype as unknown as { gitCommentableDiff: () => unknown },
+      "gitCommentableDiff",
+    );
+    try {
+      const taskId = "widget-42-nogit-baseref";
+      seedFindings(taskId, "widget", {
+        summary: "One issue.",
+        event: "REQUEST_CHANGES",
+        findings: [
+          { path: "src/foo.ts", line: 10, side: "RIGHT", severity: "Important", title: "bug", body: "fix this" },
+        ],
+      });
+      const { executor, rep } = makeExecutor(taskId, { baseBranch: "main" });
+      const outcome = await executor.execute(NODE, {});
+      expect(outcome.status).toBe("succeeded");
+      expect(rep.failed).toHaveLength(0);
+      // The crux: with no local `.git`, the local git diff must never run.
+      expect(gitDiffSpy).not.toHaveBeenCalled();
+      // …and the finding still anchors inline via the GitHub API diff.
+      const body = reviews[0]!.body as { comments: { path: string; line: number }[] };
+      expect(body.comments).toHaveLength(1);
+      expect(body.comments[0]!.path).toBe("src/foo.ts");
+      expect(body.comments[0]!.line).toBe(10);
+    } finally {
+      gitDiffSpy.mockRestore();
+    }
+  });
+
   it("skips (no post) when the agent recorded skip:true", async () => {
     const taskId = "widget-42-skip";
     seedFindings(taskId, "widget", { skip: true, summary: "already reviewed" });


### PR DESCRIPTION
## What

`post-review` runs on the harness and built its commentable-line set with a local `git -C \$STATE_DIR/sandboxes/<taskId> diff origin/<base>...HEAD`. That assumes the checkout persists on the harness filesystem — true on the docker/none/gondolin backends, but not on **kubernetes**, where the workspace lives in a per-PR sandbox PVC and only the harvested `.lastlight/` reaches the harness.

With a base ref present, the local git path ran unconditionally. On k8s it failed with `fatal: not a git repository`, dumped the full `git diff` usage block, and logged a false `demoting all findings to the body` on **every** pr-review run — before the existing GitHub-API diff fallback silently rescued the findings. The review still posted correctly; the output was misleading noise.

## Change

- Gate the local git diff on a local checkout actually existing, reusing the `git rev-parse HEAD` probe already taken for the head SHA (`undefined` on k8s). On k8s the handler goes straight to the API diff: no failing subprocess, no misleading log, findings still anchor inline.
- Silence that probe's own stderr, since it now runs on every run.
- Host-checkout backends (docker/none/gondolin) are unchanged — a present checkout yields a head SHA, so the git path runs exactly as before.

## Test

New case in `post-review.test.ts` reproduces the scenario (findings present, no `.git`, `baseBranch: "main"`): it fails against the old code (`gitCommentableDiff` invoked on the non-repo path) and passes now, asserting the local git path is not invoked and the finding still anchors inline via the API diff. Full workflow suites, typecheck, and dependency-boundary checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)