### PR TITLE
fix(dashboard): give the feedback chart one zero, not two

### DIFF
--- a/apps/server/dashboard/src/components/FeedbackPage.tsx
+++ b/apps/server/dashboard/src/components/FeedbackPage.tsx
@@ -5,6 +5,7 @@ import {
   CartesianGrid,
   ComposedChart,
   Line,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -123,6 +124,22 @@ export function FeedbackPage() {
     [daily],
   );
 
+  /**
+   * The count axis is pinned SYMMETRIC around zero, because the plot carries two
+   * Y scales and the reader sees only one horizontal zero.
+   *
+   * Left to recharts, this axis auto-fits the data — one +1 and one -1 gives
+   * `[-1, 3]`, whose zero sits near the bottom of the plot while the score
+   * axis's zero (symmetric `[-2, 2]`) sits in the middle. The bars then rise
+   * correctly from *their* zero and appear, to anyone reading the visible
+   * gridline, to float below it. A symmetric domain makes the two zeros the
+   * same pixel by construction rather than by luck.
+   */
+  const countMax = useMemo(
+    () => Math.max(1, ...(daily ?? []).map((d) => Math.max(d.positive, d.negative))),
+    [daily],
+  );
+
   const totals = useMemo(() => {
     const rows = summary ?? [];
     const positive = rows.reduce((n, r) => n + r.positive, 0);
@@ -212,6 +229,7 @@ export function FeedbackPage() {
                   <YAxis
                     yAxisId="count"
                     width={40}
+                    domain={[-countMax, countMax]}
                     tick={{ fontSize: 10, fill: CHART.axis }}
                     stroke={CHART.axis}
                     allowDecimals={false}
@@ -233,6 +251,8 @@ export function FeedbackPage() {
                     }}
                     cursor={{ fill: "rgba(255,255,255,0.04)" }}
                   />
+                  {/* The one zero both scales share — drawn, not implied. */}
+                  <ReferenceLine yAxisId="count" y={0} stroke={CHART.axis} />
                   <Bar yAxisId="count" dataKey="positive" fill={CHART.positive} name="positive" />
                   <Bar yAxisId="count" dataKey="negative" fill={CHART.negative} name="negative" />
                   <Line


### PR DESCRIPTION
Follow-up to #275 — spotted on the live dashboard: the `+1` and `-2` bars weren't straddling zero.

## Cause

The chart has **two Y scales** — counts on the left, average score on the right — but the reader sees one horizontal zero. The count axis had no explicit `domain`, so recharts auto-fitted it to the data: one `+1` and one `-1` gives `[-1, 3]`, whose zero sits near the *bottom* of the plot, while the score axis's symmetric `[-2, 2]` puts its zero in the *middle*.

So the bars were drawn correctly — rising from *their* zero — but against the visible gridline they looked like they were floating below it.

## Fix

Pin the count axis to a symmetric `[-countMax, countMax]`, which makes the two zeros the same pixel by construction rather than by luck, and draw that shared zero with a `ReferenceLine` instead of leaving it implied.

## Verification

Reproduced and verified by rendering the real `FeedbackPage` against stubbed API data in a browser, rather than reasoning about it — the auto-domain was not obvious from the code.

Before: count axis `[-1, 3]`, bars hanging below the gridline.
After: green `+1` above the line, red `-1` below it, score line dipping to `-0.50`.

Dashboard-only, no server change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)