### PR TITLE
fix(checks): let a re-run clear the failure, and settle on either colour

### DIFF
--- a/apps/server/spec/03-integrations.md
+++ b/apps/server/spec/03-integrations.md
@@ -59,14 +59,68 @@ session management, allowlist enforcement, and message chunking.
 | **Event types** | `issue.opened`, `issue.reopened`, `issue.closed`, `pr.opened`, `pr.synchronize`, `pr.reopened`, `pr.closed`, `pr.merged`, `pr.checks_failed`, `pr.checks_passed`, `pr.checks_settled`, `pr.labeled`, `pr.review_requested`, `comment.created`, `pr_review.submitted`, `pr_review_comment.created` |
 | **Review signals** | Three `pull_request` actions carry the `review.trigger` machinery. `ready_for_review` normalizes to **`pr.opened` semantics** — a draft becoming ready is the moment the PR first asks to be looked at, and it is the event that un-defers a review `review.skipDraft` held back. `labeled` normalizes to `pr.labeled` carrying `addedLabel`, so `review.requestLabel` works; every other label is hard-ignored by the router, so the widening costs a `normalize()` call rather than a dispatch. `review_requested` normalizes to `pr.review_requested` carrying `requested_reviewer.login` (or `team/<slug>`) — **opportunistic only**: GitHub App bot users are not selectable in the reviewer picker, so `on-request` mode must not depend on it, and the label + comment + Re-run paths are the real mechanism. All three inherit the self-review guard: a PR the bot authored is dropped. |
 | **Re-run checks** | `check_run.rerequested` / `check_suite.rerequested` (the GitHub "Re-run" / "Re-run all checks" buttons) normalize to `pr.synchronize` for the PR in the event's `pull_requests[]`, re-triggering pr-review against the current head. **Exception:** a re-run of *our own* `last-light/review` check normalizes to `pr.review_requested` instead — it is a human asking for a review, not "the code changed", and `pr.synchronize` is a PR-attention event that `after-checks` / `on-request` would defer, which would make the check's own button a no-op. Requires the App to subscribe to the **Check run** / **Check suite** events (App permission: Checks: read). |
-| **Failed checks** | `check_suite.completed` with a `failure` / `timed_out` conclusion normalizes to `pr.checks_failed` for two populations: a **dependency-update PR** (head commit author `dependabot[bot]` / `renovate[bot]`, or a `dependabot/` / `renovate/` head branch — commit author *or* branch, so a squashed or proxied bot commit still matches), **and** a PR whose head commit **we** pushed (`head_commit.author.name === botLogin`, which is exactly what `git-auth.ts` stamps on the agent's own commits). The second is the CI feedback loop `pr-fix` never had: it could push a fix and never learn whether the build went green, because this event only ever fired for dependency PRs. It stays bounded — it cannot fire on a human PR the bot has not touched — but it is the one gate here that can raise run volume on non-dependency PRs. **Settle-aware:** the connector emits only once the head SHA's checks have *fully settled red* (`getChecksConclusion === "failing"` — nothing pending), so a repo with several check-reporting apps fires one event per SHA, not one per suite. The dependency discriminator is **carried on the envelope** as `isDependencyPr` rather than discarded, so the router routes on it deterministically (dependency → `dependabot-ci-fix`, otherwise → `pr-fix`) instead of paying a classifier call to re-guess it — see [Router](/spec/05-router). Requires the **Check suite** subscription (Checks: read); reading the *reason* it failed additionally wants **Actions: read** — see below. |
-| **Settled checks** | Under `review.trigger: after-checks` — and only then, since emitting is what costs event volume — a settled `check_suite.completed` on a PR that **neither** check-outcome route below claimed normalizes to `pr.checks_settled`, either colour. This is the `after-checks` trigger. It is a separate event type rather than a broadening of `pr.checks_failed` because `normalize()` returns **one envelope per delivery** and `route()` returns one handler: a fan-out into both a fix and a review is not expressible, so **fix outranks review** by construction. The gap that leaves — a fix chain that ends without pushing, so no further `check_suite` ever fires — is released by the `check-prs-awaiting-review` sweep. |
-| **Passed checks** | `check_suite.completed` with a `success` conclusion normalizes to `pr.checks_passed`, but **only for dependency-update PRs** — the connector pre-filters on the head commit author (`dependabot[bot]` / `renovate[bot]`) or the suite's head branch (`dependabot/` / `renovate/`) so an ordinary green PR fires nothing. **Settle-aware:** it emits only when the head SHA has *fully settled green* (`getChecksConclusion === "passing"`); an earlier suite going green while siblings are still running sees `"pending"` and is dropped, so exactly one event fires per SHA — the last suite to settle. The router routes it deterministically (no classifier call) to the workflow claiming the `dependabot-pr-merge` intent; unclaimed → ignored. Same **Check suite** subscription (Checks: read). |
+| **Failed checks** | A `check_suite.completed` whose head SHA has **settled red in aggregate** normalizes to `pr.checks_failed` for two populations: a **dependency-update PR** (head commit author `dependabot[bot]` / `renovate[bot]`, or a `dependabot/` / `renovate/` head branch — commit author *or* branch, so a squashed or proxied bot commit still matches), **and** a PR whose head commit **we** pushed (`head_commit.author.name === botLogin`, which is exactly what `git-auth.ts` stamps on the agent's own commits). The second is the CI feedback loop `pr-fix` never had: it could push a fix and never learn whether the build went green, because this event only ever fired for dependency PRs. It stays bounded — it cannot fire on a human PR the bot has not touched — but it is the one gate here that can raise run volume on non-dependency PRs. **Settle-aware:** the connector emits only once the head SHA's checks have *fully settled red* (`getChecksConclusion === "failing"` — nothing pending), so a repo with several check-reporting apps fires one event per SHA, not one per suite. **The delivering suite's own conclusion is not the discriminator** — see "Which event a settle becomes" below. The dependency discriminator is **carried on the envelope** as `isDependencyPr` rather than discarded, so the router routes on it deterministically (dependency → `dependabot-ci-fix`, otherwise → `pr-fix`) instead of paying a classifier call to re-guess it — see [Router](/spec/05-router). Requires the **Check suite** subscription (Checks: read); reading the *reason* it failed additionally wants **Actions: read** — see below. |
+| **Settled checks** | Under `review.trigger: after-checks` — and only then, since emitting is what costs event volume — a settled `check_suite.completed` on a PR that **neither** check-outcome route below claimed normalizes to `pr.checks_settled`, either colour — **including a red aggregate observed through a green suite**, which is the ordinary shape of a PR with one failing job whose sibling suite finishes last. This is the `after-checks` trigger. It is a separate event type rather than a broadening of `pr.checks_failed` because `normalize()` returns **one envelope per delivery** and `route()` returns one handler: a fan-out into both a fix and a review is not expressible, so **fix outranks review** by construction. The gap that leaves — a fix chain that ends without pushing, so no further `check_suite` ever fires — is released by the `check-prs-awaiting-review` sweep. |
+| **Passed checks** | A `check_suite.completed` whose head SHA has **settled green in aggregate** normalizes to `pr.checks_passed`, but **only for dependency-update PRs** — the connector pre-filters on the head commit author (`dependabot[bot]` / `renovate[bot]`) or the suite's head branch (`dependabot/` / `renovate/`) so an ordinary green PR fires nothing. **Settle-aware:** it emits only when the head SHA has *fully settled green* (`getChecksConclusion === "passing"`); an earlier suite going green while siblings are still running sees `"pending"` and is dropped, so exactly one event fires per SHA — the last suite to settle. Again the aggregate decides, not this suite's conclusion. The router routes it deterministically (no classifier call) to the workflow claiming the `dependabot-pr-merge` intent; unclaimed → ignored. Same **Check suite** subscription (Checks: read). |
 | **Filtered out** | `IGNORED_ACTIONS`: `edited`, `unlabeled`, `assigned`, `closed` (except for the explicit close types above), `pinned`, `transferred`, and friends. `labeled` left the set when `review.requestLabel` landed. Bot self-events are dropped unless the bot opened/synchronised a PR **or** it's a `check_suite.completed` (the failing-CI signal is always bot-sent); a PR **authored** by the bot is dropped from pr-review entirely (self-review guard). |
 | **Reply** | Posts a comment via `replyFn(owner, repo, issueNumber, msg)` (line 237). Returns `Promise<void>`; no useful return value. No-op if `replyFn` or issue context is missing. |
 
 If `WEBHOOK_SECRET` is empty (allowed but warned during boot), signature
 verification is disabled. Production deployments must set it.
+
+### Which event a settle becomes
+
+A `check_suite.completed` delivery carries a conclusion of its own, and it is
+**not** what picks the event. The suite's colour says only which
+check-reporting app happened to finish last; the decision reads the
+**aggregate** state of the head SHA. So one `completed` branch resolves all
+three outcomes, in this order:
+
+| Aggregate | Population | Event |
+|---|---|---|
+| `failing` | dependency PR, or a head **we** pushed | `pr.checks_failed` |
+| `passing` | dependency PR | `pr.checks_passed` |
+| `failing` or `passing` | anything left, under `after-checks` | `pr.checks_settled` |
+| `pending` / `none` | — | nothing (CI is still moving) |
+
+The order is **fix outranks review** (09 → S2): `normalize()` returns one
+envelope per delivery, so the precedence is the shape of the pipeline rather
+than a policy bolted on later. Deliveries with a `cancelled` / `neutral` /
+`skipped` / `stale` conclusion are dropped without an aggregate read at all —
+nothing happened, and the round trip would buy nothing.
+
+Reading the delivering suite's colour instead was a live deadlock
+(nearform/skillspro#1646). The red and green cases were separate branches, each
+with its own aggregate test, and the green one demanded `passing`. A PR with one
+failing job whose *sibling* suite finished green afterwards landed in the green
+branch, computed `failing`, and was dropped — while the failing suite, which the
+red branch would have taken, had completed while the sibling was still running
+and read `pending`. No event ever fired; under `review.postsCheck` the `queued`
+placeholder sat on the PR until it was merged hours later. Nothing about the PR
+was unusual: the outcome depended purely on the order CI settled in.
+
+### Superseded check re-runs
+
+`checks.listForRef?filter=latest` de-dupes per check **suite**, not per check
+**name**. Re-running a failed job creates a new suite, so its green result comes
+back *alongside* the red attempt it replaced — and both keep coming back for the
+life of the SHA. Every aggregate read therefore collapses the list to the most
+recent run of each `(app, name)` before judging it, so a re-run that goes green
+actually clears the failure. Without that collapse `some(conclusion ===
+"failure")` pins the SHA at `failing` permanently and no re-run can ever move it
+— the other half of #1646, and the reason its aggregate could no longer reach a
+state any emit branch accepted.
+
+Latest-wins is also what gates the merge: branch protection satisfies a required
+check from its most recent run, so reading the SHA any other way puts the
+harness at odds with the gate it exists to feed. Two *different* apps posting the
+same check name are not collapsed (the key is `(app, name)`), and a run carrying
+no name is passed through untouched — de-duping is an identity claim, and
+keeping both can only ever report a SHA redder than it is.
+
+The same collapse applies to `getCiFailureReport`, so the fix agent is never
+handed a red job that has since been re-run green: discovery and the fix prompt
+have to agree on what "red" means.
 
 ### Multi-installation GitHub Apps
 

--- a/apps/server/spec/05-router.md
+++ b/apps/server/spec/05-router.md
@@ -874,6 +874,12 @@ gate, the router's dependency-comment enrichment, and both dependency
 sweeps. Commit statuses carry no app and we never post one, so nothing is
 excluded on that side, and excluding ours can never turn red into green.
 
+The same aggregate has a second way to jam: a check re-run in a fresh suite
+comes back *alongside* the attempt it replaced, so a job re-run green kept
+reporting red forever. Every settle query collapses the list to the latest run
+of each `(app, name)` first — see
+[Integrations → Superseded check re-runs](/spec/03-integrations).
+
 ### Escalation — the skips that are not silent
 
 Three of `resolveFixDisposition`'s skips are **terminal for the current

--- a/apps/server/src/connectors/github-webhook.ts
+++ b/apps/server/src/connectors/github-webhook.ts
@@ -529,134 +529,116 @@ export class GitHubWebhookConnector extends EventEmitter implements Connector {
           prNumber = payload.check_suite?.pull_requests?.[0]?.number;
           issueNumber = prNumber;
           if (prNumber) type = "pr.synchronize";
-        } else if (
-          action === "completed" &&
-          (payload.check_suite?.conclusion === "failure" ||
-            payload.check_suite?.conclusion === "timed_out")
-        ) {
-          // A PR's CI has gone red. Emit a dedicated event so a workflow can
-          // react (e.g. fix a failing Dependabot PR). We use check_suite
-          // (aggregate — ~one event per push) rather than per-check_run.completed
-          // to avoid a burst of duplicates. `pull_requests[]` is populated for
-          // same-repo PRs (fork PRs carry an empty array and are dropped below).
-          const pr = payload.check_suite?.pull_requests?.[0];
-          const sha: string | undefined = payload.check_suite?.head_sha;
-          // The check_suite `pull_requests[]` entry is minimal (number/refs
-          // only — no title or author). The head commit carries the useful
-          // classifier signal instead: for a Dependabot PR the commit message
-          // is the bump description ("Bump lodash from …") and the commit
-          // author name is "dependabot[bot]". The router feeds these to the
-          // classifier; the dispatcher later fetches the full PR for the fix.
-          const headCommit = payload.check_suite?.head_commit;
-          const commitAuthor: string = headCommit?.author?.name || "";
-          const headBranch: string = payload.check_suite?.head_branch || "";
-          // GATE: which red PRs may kick off the fix path at all. Commit author
-          // OR branch prefix for the dependency case, so a squashed/proxied bot
-          // commit still matches via its branch.
-          const isDependency =
-            /^(dependabot|renovate)\[bot\]$/.test(commitAuthor) ||
-            /^(dependabot|renovate)\//.test(headBranch);
-          // ...plus a head commit WE pushed. `git-auth.ts` stamps
-          // `user.name = <botName>[bot]` on the agent's own commits and the
-          // check_suite payload carries the same field, so this is precisely
-          // "did my fix work?" — the CI feedback loop `pr-fix` has never had
-          // (it could push a fix and never learn whether the build went green,
-          // because this event only ever fired for dependency PRs). It stays
-          // bounded: it cannot fire for an ordinary human PR the bot has not
-          // touched. It is nonetheless the one change here that can increase
-          // run volume on non-dependency PRs — watch it after rollout.
-          const isOurOwnPush = !!this.config.botLogin && commitAuthor === this.config.botLogin;
-          // Only fire once the PR's checks have FULLY SETTLED red — a repo with
-          // several check-reporting apps completes one suite at a time, and a
-          // failure in one while another is still running should not kick off a
-          // fix mid-flight. `getChecksConclusion` returns "failing" only when
-          // nothing is pending and ≥1 check concluded red, so exactly one event
-          // fires per SHA (the last suite to settle). Absent a wired client
-          // (standalone tests) we keep the legacy per-suite behaviour. Gated
-          // behind the emit check so an untouched human PR never makes the call.
-          if (pr?.number && (isDependency || isOurOwnPush)) {
-            const settled = await this.settledConclusion(repoFullName, sha, "failing");
-            if (settled === "failing") {
-              prNumber = pr.number;
-              issueNumber = prNumber;
-              headSha = sha;
-              type = "pr.checks_failed";
-              title = (headCommit?.message || "").split("\n")[0] || title;
-              issueAuthor = commitAuthor || issueAuthor;
-              // The router routes on THIS, deterministically: dependency →
-              // `dependabot-ci-fix`, everything else → `pr-fix`. Without it a
-              // human's red PR would run a dependency-bump prompt, the
-              // `dependency-*` label vocabulary and a `requires-human`
-              // preflight it was never designed for.
-              isDependencyPr = isDependency;
-            }
-          } else if (pr?.number && this.afterChecks()) {
-            // FIX OUTRANKS REVIEW (09 → S2). A settled-red PR the fix family can
-            // act on has already been claimed above; only what is LEFT becomes a
-            // review settle. One envelope per delivery is all `normalize()` can
-            // return, so this precedence is not a policy choice bolted on later
-            // — it is the shape of the pipeline.
-            const settled = await this.settledConclusion(repoFullName, sha, "failing");
-            if (settled === "failing" || settled === "passing") {
-              prNumber = pr.number;
-              issueNumber = prNumber;
-              headSha = sha;
-              type = "pr.checks_settled";
-              title = (headCommit?.message || "").split("\n")[0] || title;
-              isDependencyPr = isDependency;
-            }
-          }
-        } else if (
-          action === "completed" &&
-          payload.check_suite?.conclusion === "success"
-        ) {
-          // A PR's CI has gone fully green. Emit a dedicated event ONLY for
-          // dependency-update PRs (Dependabot / Renovate) so a workflow can
-          // enable auto-merge on the trivial ones — we deliberately do NOT fire
-          // on every green PR (that would flood the router with events for
-          // unrelated work). The dependency signal comes cheaply from the head
-          // commit author + the suite's head branch, with no extra PR fetch.
-          const pr = payload.check_suite?.pull_requests?.[0];
-          const sha: string | undefined = payload.check_suite?.head_sha;
-          const headCommit = payload.check_suite?.head_commit;
-          const commitAuthor: string = headCommit?.author?.name || "";
-          const headBranch: string = payload.check_suite?.head_branch || "";
-          const isDependency =
-            /^(dependabot|renovate)\[bot\]$/.test(commitAuthor) ||
-            /^(dependabot|renovate)\//.test(headBranch);
-          // Fire ONLY when the head SHA's checks have fully settled green. A
-          // suite going green while sibling suites are still running reports
-          // "pending" here and is dropped; the last suite to settle flips the
-          // aggregate to "passing", so exactly one `pr.checks_passed` fires per
-          // SHA instead of one per check-reporting app. (Legacy per-suite
-          // behaviour is preserved when no client is wired — standalone tests.)
-          if (pr?.number && isDependency) {
-            const settled = await this.settledConclusion(repoFullName, sha, "passing");
-            if (settled === "passing") {
-              prNumber = pr.number;
-              issueNumber = prNumber;
-              headSha = sha;
-              type = "pr.checks_passed";
-              title = (headCommit?.message || "").split("\n")[0] || title;
-              issueAuthor = commitAuthor || issueAuthor;
-              // Always true on this branch (the green route is dependency-only),
-              // set for symmetry so the envelope's discriminator is never
-              // undefined on a check-outcome event.
-              isDependencyPr = true;
-            }
-          } else if (pr?.number && this.afterChecks()) {
-            // The green half of the same broadening. A non-dependency PR whose
-            // CI has fully settled green is the canonical `after-checks` review:
-            // nothing is going to change about this head, and the review can now
-            // say so.
-            const settled = await this.settledConclusion(repoFullName, sha, "passing");
-            if (settled === "passing") {
-              prNumber = pr.number;
-              issueNumber = prNumber;
-              headSha = sha;
-              type = "pr.checks_settled";
-              title = (headCommit?.message || "").split("\n")[0] || title;
-              isDependencyPr = isDependency;
+        } else if (action === "completed") {
+          // A PR's checks have moved. WHICH event that becomes is decided by
+          // the AGGREGATE state of the head SHA — never by this suite's own
+          // colour, which says only which check-reporting app happened to
+          // finish last. A repo with several of them completes one suite at a
+          // time, so the suite colour is the order CI settled in, and the three
+          // routes below all care about the PR.
+          //
+          // That was the #1646 bug: the two arms were separate `else if`s on
+          // the SUITE, each with its own aggregate test, and the green one
+          // demanded `passing`. A PR with one failing job whose sibling suite
+          // finished last landed in the green arm, computed `failing`, and was
+          // dropped — while the failing suite, which the red arm would have
+          // taken, had completed while the sibling was still running and read
+          // `pending`. Nothing ever emitted; the `queued` review check sat
+          // there until the PR was merged six hours later.
+          //
+          // We still look only at settled colours: `cancelled` / `neutral` /
+          // `skipped` / `stale` say nothing happened and carry no aggregate
+          // worth paying a round trip for.
+          const suiteConclusion = payload.check_suite?.conclusion;
+          const suiteRed = suiteConclusion === "failure" || suiteConclusion === "timed_out";
+          const suiteGreen = suiteConclusion === "success";
+          if (suiteRed || suiteGreen) {
+            // `pull_requests[]` is populated for same-repo PRs (fork PRs carry
+            // an empty array and are dropped below).
+            const pr = payload.check_suite?.pull_requests?.[0];
+            const sha: string | undefined = payload.check_suite?.head_sha;
+            // The check_suite `pull_requests[]` entry is minimal (number/refs
+            // only — no title or author). The head commit carries the useful
+            // classifier signal instead: for a Dependabot PR the commit message
+            // is the bump description ("Bump lodash from …") and the commit
+            // author name is "dependabot[bot]". The router feeds these to the
+            // classifier; the dispatcher later fetches the full PR for the fix.
+            const headCommit = payload.check_suite?.head_commit;
+            const commitAuthor: string = headCommit?.author?.name || "";
+            const headBranch: string = payload.check_suite?.head_branch || "";
+            // GATE: which red PRs may kick off the fix path at all. Commit
+            // author OR branch prefix for the dependency case, so a
+            // squashed/proxied bot commit still matches via its branch.
+            const isDependency =
+              /^(dependabot|renovate)\[bot\]$/.test(commitAuthor) ||
+              /^(dependabot|renovate)\//.test(headBranch);
+            // ...plus a head commit WE pushed. `git-auth.ts` stamps
+            // `user.name = <botName>[bot]` on the agent's own commits and the
+            // check_suite payload carries the same field, so this is precisely
+            // "did my fix work?" — the CI feedback loop `pr-fix` has never had
+            // (it could push a fix and never learn whether the build went green,
+            // because this event only ever fired for dependency PRs). It stays
+            // bounded: it cannot fire for an ordinary human PR the bot has not
+            // touched. It is nonetheless the one change here that can increase
+            // run volume on non-dependency PRs — watch it after rollout.
+            const isOurOwnPush = !!this.config.botLogin && commitAuthor === this.config.botLogin;
+            // Nobody downstream wants this delivery — don't pay for the
+            // aggregate read. An ordinary human PR under a mode with no
+            // consumer for a settle event never makes the call.
+            const wanted = isDependency || isOurOwnPush || this.afterChecks();
+            if (pr?.number && wanted) {
+              // Fire only once the head SHA has FULLY SETTLED, so a repo with
+              // several check-reporting apps produces exactly one event per SHA
+              // — the last suite to settle — rather than one per app. Absent a
+              // wired client (standalone tests) the fallback keeps the legacy
+              // per-suite behaviour, which is this suite's own colour.
+              const settled = await this.settledConclusion(
+                repoFullName,
+                sha,
+                suiteRed ? "failing" : "passing",
+              );
+              const title0 = (headCommit?.message || "").split("\n")[0];
+              // FIX OUTRANKS REVIEW (09 → S2), and one envelope per delivery is
+              // all `normalize()` can return — so the precedence below is not a
+              // policy choice bolted on later, it is the shape of the pipeline.
+              if (settled === "failing" && (isDependency || isOurOwnPush)) {
+                prNumber = pr.number;
+                issueNumber = prNumber;
+                headSha = sha;
+                type = "pr.checks_failed";
+                title = title0 || title;
+                issueAuthor = commitAuthor || issueAuthor;
+                // The router routes on THIS, deterministically: dependency →
+                // `dependabot-ci-fix`, everything else → `pr-fix`. Without it a
+                // human's red PR would run a dependency-bump prompt, the
+                // `dependency-*` label vocabulary and a `requires-human`
+                // preflight it was never designed for.
+                isDependencyPr = isDependency;
+              } else if (settled === "passing" && isDependency) {
+                // A green dependency PR goes to the MERGE route, not a review.
+                // We deliberately do NOT fire this for every green PR — that
+                // would flood the router with events for unrelated work.
+                prNumber = pr.number;
+                issueNumber = prNumber;
+                headSha = sha;
+                type = "pr.checks_passed";
+                title = title0 || title;
+                issueAuthor = commitAuthor || issueAuthor;
+                isDependencyPr = true;
+              } else if ((settled === "failing" || settled === "passing") && this.afterChecks()) {
+                // Whatever the fix family did not claim, under `after-checks`,
+                // is the canonical review settle: nothing is going to change
+                // about this head, and the review can now say so. EITHER
+                // COLOUR — "on settle, either colour" is the documented
+                // contract (09 → S2, locked decision 14), a red result is
+                // useful review input, and a PR we gave up on never goes green.
+                prNumber = pr.number;
+                issueNumber = prNumber;
+                headSha = sha;
+                type = "pr.checks_settled";
+                title = title0 || title;
+                isDependencyPr = isDependency;
+              }
             }
           }
         }

--- a/apps/server/src/engine/github/github.ts
+++ b/apps/server/src/engine/github/github.ts
@@ -194,6 +194,73 @@ function excludingApp<T extends { app?: { slug?: string | null } | null }>(
   return opts.excludeApp ? runs.filter((r) => r.app?.slug !== opts.excludeApp) : runs;
 }
 
+/** A check run, as much of it as the de-dupe below needs. */
+type IdentifiableRun = {
+  name?: string | null;
+  app?: { slug?: string | null } | null;
+  started_at?: string | null;
+  id?: number;
+};
+
+/**
+ * Keep only the MOST RECENT run of each check, discarding the ones a re-run has
+ * superseded.
+ *
+ * `checks.listForRef?filter=latest` does NOT mean "one run per check name" —
+ * it de-dupes per check SUITE. Re-running a failed workflow from the Actions UI
+ * (or re-triggering it, as a `pull_request_target` workflow does when the PR
+ * body is edited) creates a NEW suite, so its green result arrives ALONGSIDE
+ * the old red one and both come back from the API forever:
+ *
+ *     Check linked issues  failure  suite 84337326378  10:11:39
+ *     Check linked issues  success  suite 84339674693  10:23:51   ← the re-run
+ *
+ * Without this, `some(conclusion === "failure")` pins the aggregate at
+ * `failing` for the life of the SHA and nothing a re-run does can clear it —
+ * nearform/skillspro#1646, where the review deferred on `after-checks` and its
+ * `queued` check never concluded, because the settle event fires only on a
+ * state the aggregate could no longer reach.
+ *
+ * Latest-wins is also what actually gates the merge: branch protection
+ * satisfies a required check from its most recent run. Reading the SHA any
+ * other way puts us at odds with the gate we exist to feed.
+ *
+ * Keyed on `app.slug` + `name`, never `name` alone: two apps may legitimately
+ * post the same check name, and collapsing those would let one app's green
+ * hide another's red. Ordered by `started_at` (ISO-8601 UTC, so lexicographic
+ * IS chronological) with the check-run id as a tiebreak.
+ *
+ * A run with NO name is passed through untouched rather than sharing an empty
+ * key with every other nameless run. De-duping is an identity claim — "these
+ * two are the same check, so the later one replaces the earlier" — and without
+ * a name there is no identity to claim. Keeping both is the fail-safe answer:
+ * it can only ever report a SHA redder than it is.
+ */
+function latestPerCheck<T extends IdentifiableRun>(runs: T[]): T[] {
+  const newest = new Map<string, T>();
+  const unidentified: T[] = [];
+  for (const run of runs) {
+    if (!run.name) {
+      unidentified.push(run);
+      continue;
+    }
+    // A check NAME may contain anything, spaces included; a NUL separator
+    // cannot occur in either half, so the composite key is unambiguous.
+    const key = `${run.app?.slug ?? ""}\u0000${run.name}`;
+    const seen = newest.get(key);
+    if (!seen || supersedes(run, seen)) newest.set(key, run);
+  }
+  return [...newest.values(), ...unidentified];
+}
+
+/** Is `a` the later run of the two? See {@link latestPerCheck}. */
+function supersedes(a: IdentifiableRun, b: IdentifiableRun): boolean {
+  const at = a.started_at ?? "";
+  const bt = b.started_at ?? "";
+  if (at !== bt) return at > bt;
+  return (a.id ?? 0) > (b.id ?? 0);
+}
+
 /**
  * Raised when a harness-side call targets an account the GitHub App is not
  * installed on. Distinct from a 404 so callers can say the actionable thing
@@ -1019,6 +1086,12 @@ export class GitHubClient {
    * A check run counts as settled when it has left queued/in_progress —
    * whatever it concluded. Status contexts are settled unless the combined
    * state is `pending`.
+   *
+   * The count is per CHECK, not per run: a check that has been re-run counts
+   * once, because {@link latestPerCheck} has already discarded the superseded
+   * attempts. That is the reading `dependencies.minSettledChecks` wants — it
+   * asks how many distinct things looked at this SHA, and four re-runs of one
+   * reviewer bot were never four independent opinions.
    */
   async getChecksSummary(
     owner: string,
@@ -1036,8 +1109,10 @@ export class GitHubClient {
       kit.rest.repos.getCombinedStatusForRef({ owner, repo, ref }),
     ]);
     // Drop OUR OWN check runs when the caller is deciding whether to TRIGGER
-    // work — see {@link ChecksQueryOptions.excludeApp}.
-    const runs = excludingApp(checks.check_runs, opts);
+    // work — see {@link ChecksQueryOptions.excludeApp} — then collapse each
+    // check to the run that survives a re-run ({@link latestPerCheck}), so a
+    // job that was re-run green stops reporting the SHA red forever.
+    const runs = latestPerCheck(excludingApp(checks.check_runs, opts));
     const statuses = status.statuses ?? [];
 
     const runPendingCount = runs.filter(
@@ -1141,7 +1216,12 @@ export class GitHubClient {
       filter: "latest",
     });
 
-    const failed = excludingApp(data.check_runs, opts).filter(
+    // Superseded attempts are dropped BEFORE the failure filter, or the report
+    // hands the fix agent a red job that has since been re-run green — a real
+    // log, a real error, and nothing left to fix. Same reason `getChecksSummary`
+    // de-dupes: the two must agree on what "red" means, or discovery fires a fix
+    // for evidence the prompt then can't reproduce.
+    const failed = latestPerCheck(excludingApp(data.check_runs, opts)).filter(
       (r) => r.conclusion === "failure" || r.conclusion === "timed_out"
     );
     if (failed.length === 0) return { jobs: [], logsAvailable: false };

--- a/apps/server/tests/connectors/github-webhook.test.ts
+++ b/apps/server/tests/connectors/github-webhook.test.ts
@@ -529,6 +529,27 @@ describe("GitHubWebhookConnector — settle-aware emit gate", () => {
     expect(emitted.headSha).toBe("beef0001");
   });
 
+  it("emits pr.checks_settled when a GREEN suite settles a red aggregate", async () => {
+    // nearform/skillspro#1646. Which suite finishes last is an accident of
+    // scheduling, not a fact about the PR: here one job failed and a SIBLING
+    // suite completed green afterwards, so the aggregate is `failing` but the
+    // delivery that observes it is a success. Requiring `passing` on this
+    // branch dropped it — and the failing suite, which the red branch would
+    // have taken, had completed while the sibling was still running and read
+    // `pending`. Nothing emitted, and the `queued` review check never concluded.
+    const { conn } = connectorWithChecks("failing", "after-checks");
+    const { emitted } = await postCheckSuiteCompleted(conn, {
+      conclusion: "success",
+      prNumber: 7,
+      commitAuthor: "Ada Lovelace",
+      commitMessage: "feat: something human",
+      headBranch: "feature/whatever",
+      headSha: "beef0002",
+    });
+    expect(emitted?.type).toBe("pr.checks_settled");
+    expect(emitted.headSha).toBe("beef0002");
+  });
+
   it("emits pr.checks_settled for a settled-RED human PR too — either colour", async () => {
     // 09 locked decision 14: the `passing` variant was deleted. A red result is
     // useful review input, and a PR we gave up on never goes green.
@@ -541,6 +562,33 @@ describe("GitHubWebhookConnector — settle-aware emit gate", () => {
       headBranch: "feature/whatever",
     });
     expect(emitted?.type).toBe("pr.checks_settled");
+  });
+
+  it("routes a red aggregate to the FIX path even when the last suite was green", async () => {
+    // The aggregate decides, so the fix family's claim can't be lost to the
+    // order CI settled in: this dependency PR is red, and a sibling suite
+    // finishing green afterwards must not demote it to a review. Before the
+    // arms were merged this emitted nothing at all.
+    const { conn } = connectorWithChecks("failing", "after-checks");
+    const { emitted } = await postCheckSuiteCompleted(conn, {
+      conclusion: "success",
+      prNumber: 190,
+      commitAuthor: "dependabot[bot]",
+    });
+    expect(emitted?.type).toBe("pr.checks_failed");
+  });
+
+  it("does the same for a head WE pushed — the fix loop's CI feedback", async () => {
+    const { conn } = connectorWithChecks("failing", "after-checks");
+    const { emitted } = await postCheckSuiteCompleted(conn, {
+      conclusion: "success",
+      prNumber: 207,
+      commitAuthor: BOT_LOGIN,
+      commitMessage: "fix: address review",
+      headBranch: "lastlight/205-user-identity",
+    });
+    expect(emitted?.type).toBe("pr.checks_failed");
+    expect(emitted.isDependencyPr).toBe(false);
   });
 
   it("FIX OUTRANKS REVIEW — a red dependency PR stays pr.checks_failed under after-checks", async () => {

--- a/apps/server/tests/engine/github/github-checks.test.ts
+++ b/apps/server/tests/engine/github/github-checks.test.ts
@@ -7,7 +7,14 @@ import { GitHubClient } from "#src/engine/github/github.js";
  * getFailedChecks). We swap in a fake Octokit returning canned check_runs +
  * combined-status payloads and assert the derived verdict.
  */
-type Run = { status: string; conclusion: string | null; app?: { slug: string } };
+type Run = {
+  status: string;
+  conclusion: string | null;
+  app?: { slug: string };
+  name?: string;
+  started_at?: string;
+  id?: number;
+};
 type Combined = { state: string; statuses: unknown[] };
 
 function fakeOctokit(runs: Run[], combined: Combined) {
@@ -149,6 +156,169 @@ describe("GitHubClient.getChecksSummary — excludeApp (the self-gating deadlock
     expect(await c.getChecksConclusion("o", "r", "sha", { excludeApp: "last-light" })).toBe(
       "failing",
     );
+  });
+});
+
+/**
+ * **The superseded re-run** — nearform/skillspro#1646.
+ *
+ * `filter: "latest"` de-dupes per check SUITE, not per check NAME, so a job
+ * re-run in a fresh suite comes back ALONGSIDE the attempt it replaced. Reading
+ * every run equally pinned that SHA at `failing` forever: the review deferred
+ * on `after-checks`, posted its `queued` placeholder, and then no settle event
+ * could ever fire because the aggregate could no longer reach a state either
+ * emit branch accepted. The PR was merged six hours later with the check still
+ * queued.
+ */
+describe("GitHubClient.getChecksSummary — superseded re-runs", () => {
+  const attempt = (
+    name: string,
+    conclusion: string | null,
+    startedAt: string,
+    extra: Partial<Run> = {},
+  ): Run => ({
+    name,
+    status: conclusion === null ? "in_progress" : "completed",
+    conclusion,
+    app: { slug: "github-actions" },
+    started_at: startedAt,
+    ...extra,
+  });
+
+  it("lets a GREEN re-run clear the failure it replaced", async () => {
+    // The exact shape #1646 was stuck in.
+    const c = clientWith(
+      fakeOctokit(
+        [
+          attempt("Check linked issues", "failure", "2026-08-06T10:11:33Z"),
+          attempt("Check linked issues", "success", "2026-08-06T10:23:46Z"),
+          attempt("Lint and test", "success", "2026-08-06T10:11:40Z"),
+        ],
+        noStatus,
+      ),
+    );
+    expect(await c.getChecksConclusion("o", "r", "sha")).toBe("passing");
+  });
+
+  it("lets a RED re-run resurrect a failure — latest wins in BOTH directions", async () => {
+    // Not "prefer green": the newest attempt is the answer, whatever it says.
+    // A flake re-run that fails for real must still read red.
+    const c = clientWith(
+      fakeOctokit(
+        [
+          attempt("Lint and test", "success", "2026-08-06T10:11:33Z"),
+          attempt("Lint and test", "failure", "2026-08-06T10:23:46Z"),
+        ],
+        noStatus,
+      ),
+    );
+    expect(await c.getChecksConclusion("o", "r", "sha")).toBe("failing");
+  });
+
+  it("reports 'pending' while the re-run of a settled check is still going", async () => {
+    // The re-run is the latest attempt, so the check is back in flight — firing
+    // a review or a merge off the stale result would assess a moving target.
+    const c = clientWith(
+      fakeOctokit(
+        [
+          attempt("Lint and test", "failure", "2026-08-06T10:11:33Z"),
+          attempt("Lint and test", null, "2026-08-06T10:23:46Z"),
+        ],
+        noStatus,
+      ),
+    );
+    expect(await c.getChecksConclusion("o", "r", "sha")).toBe("pending");
+  });
+
+  it("never lets one app's green hide ANOTHER app's red of the same name", async () => {
+    // Two CI apps may both post a check called "build". They are different
+    // checks, so the key is (app, name) and neither supersedes the other.
+    const c = clientWith(
+      fakeOctokit(
+        [
+          attempt("build", "failure", "2026-08-06T10:11:33Z", { app: { slug: "circleci" } }),
+          attempt("build", "success", "2026-08-06T10:23:46Z", { app: { slug: "github-actions" } }),
+        ],
+        noStatus,
+      ),
+    );
+    expect(await c.getChecksConclusion("o", "r", "sha")).toBe("failing");
+  });
+
+  it("falls back to the check-run id when two attempts share a start time", async () => {
+    const c = clientWith(
+      fakeOctokit(
+        [
+          attempt("Lint and test", "success", "2026-08-06T10:11:33Z", { id: 2 }),
+          attempt("Lint and test", "failure", "2026-08-06T10:11:33Z", { id: 1 }),
+        ],
+        noStatus,
+      ),
+    );
+    expect(await c.getChecksConclusion("o", "r", "sha")).toBe("passing");
+  });
+
+  it("counts CHECKS, not attempts, in settledCount", async () => {
+    // `dependencies.minSettledChecks` asks how many distinct things looked at
+    // this SHA. Four re-runs of one reviewer bot were never four opinions.
+    const c = clientWith(
+      fakeOctokit(
+        [
+          attempt("copilot-pull-request-reviewer", "success", "2026-08-06T10:11:53Z"),
+          attempt("copilot-pull-request-reviewer", "success", "2026-08-06T10:25:41Z"),
+          attempt("copilot-pull-request-reviewer", "success", "2026-08-06T10:36:57Z"),
+          attempt("Lint and test", "success", "2026-08-06T10:11:40Z"),
+        ],
+        noStatus,
+      ),
+    );
+    expect(await c.getChecksSummary("o", "r", "sha")).toEqual({
+      state: "passing",
+      settledCount: 2,
+      pendingCount: 0,
+    });
+  });
+
+  it("does NOT collapse runs that carry no name — no identity, no de-dupe", async () => {
+    // Fail safe: without a name there is no claim that two runs are the same
+    // check, and keeping both can only ever report the SHA redder than it is.
+    const c = clientWith(
+      fakeOctokit([run("completed", "success"), run("completed", "failure")], noStatus),
+    );
+    expect(await c.getChecksConclusion("o", "r", "sha")).toBe("failing");
+  });
+});
+
+describe("GitHubClient.getCiFailureReport — superseded re-runs", () => {
+  it("does not hand the fix agent a failure that has since been re-run green", async () => {
+    // The report and the aggregate must agree on what "red" means, or discovery
+    // fires a fix for evidence the prompt then cannot reproduce. No logs are
+    // fetched at all here: nothing is failing once the stale attempt is dropped.
+    const c = clientWith(
+      fakeOctokit(
+        [
+          {
+            name: "Lint and test",
+            status: "completed",
+            conclusion: "failure",
+            app: { slug: "github-actions" },
+            started_at: "2026-08-06T10:11:33Z",
+          },
+          {
+            name: "Lint and test",
+            status: "completed",
+            conclusion: "success",
+            app: { slug: "github-actions" },
+            started_at: "2026-08-06T10:23:46Z",
+          },
+        ],
+        noStatus,
+      ),
+    );
+    expect(await c.getCiFailureReport("o", "r", "sha")).toEqual({
+      jobs: [],
+      logsAvailable: false,
+    });
   });
 });
 

--- a/apps/server/tests/engine/github/github-failed-checks.test.ts
+++ b/apps/server/tests/engine/github/github-failed-checks.test.ts
@@ -735,7 +735,14 @@ describe("GitHubClient.getCiFailureReport — log-unavailable cause", () => {
             data: {
               check_runs: [
                 failingCheck(1),
-                { ...failingCheck(2), details_url: `${ACTIONS_URL.slice(0, -3)}457` },
+                // A DIFFERENT job, so a different check name — same-name runs
+                // on one SHA are re-runs and the later one supersedes the
+                // earlier (see `latestPerCheck`), which would leave one job here.
+                {
+                  ...failingCheck(2),
+                  name: "CI / test",
+                  details_url: `${ACTIONS_URL.slice(0, -3)}457`,
+                },
               ],
             },
           }),


### PR DESCRIPTION
[nearform/skillspro#1646](https://github.com/nearform/skillspro/pull/1646) opened, deferred its review under `review.trigger: after-checks`, posted the `queued` `last-light/review` placeholder — and was merged six hours later with that check still queued. No `pr-review` run was ever created for it.

CI had finished. One check failed and was re-run green. That was enough, twice over: there are two independent defects here, and either one alone strands the PR.

## 1. A re-run never clears the failure it replaced

`checks.listForRef?filter=latest` de-dupes per check **suite**, not per check **name**. Re-running a failed job creates a *new* suite, so its green result comes back alongside the red attempt it replaced — and both keep coming back for the life of the SHA. Live, from the API today:

```
Check linked issues  failure  suite 84337326378  10:11:39
Check linked issues  success  suite 84339674693  10:23:51   <- the re-run
```

`getChecksSummary` does `runs.some(r => r.conclusion === "failure")`, so from 10:15 onward that SHA read `failing` permanently and nothing a re-run did could move it.

Both check-run reads now collapse the list to the latest run of each `(app, name)` before judging it. Latest-wins is what gates the merge anyway — branch protection satisfies a required check from its most recent run — so reading the SHA any other way put us at odds with the gate we exist to feed.

- Keyed on `(app, name)`, never name alone: two apps posting `build` are two checks, and collapsing them would let one's green hide the other's red.
- Latest wins in **both** directions — a green run later re-run red still reads red, and a re-run still in flight reads `pending`.
- A run with no name is passed through untouched. De-duping is an identity claim; without a name there is none to make, and keeping both can only report a SHA redder than it is.
- `getCiFailureReport` gets the same collapse, or the fix agent is handed a red job that has since gone green — discovery and the fix prompt have to agree on what "red" means.
- `settledCount` now counts checks rather than attempts, which is what `dependencies.minSettledChecks` actually wants.

## 2. The settle event depended on which suite finished last

The red and green `check_suite.completed` branches each ran their own aggregate test, and the green one demanded `passing`. A PR with one failing job whose **sibling** suite finished green afterwards landed in the green branch, computed `failing`, and was dropped — while the failing suite, which the red branch would have accepted, had completed while the sibling was still running and read `pending`. Nothing ever emitted.

Nothing about the PR was unusual. The outcome depended purely on the order CI settled in.

The two branches are now one. The suite's own conclusion decides only whether an aggregate read is worth paying for; the **aggregate** picks the event:

| Aggregate | Population | Event |
|---|---|---|
| `failing` | dependency PR, or a head we pushed | `pr.checks_failed` |
| `passing` | dependency PR | `pr.checks_passed` |
| either | anything left, under `after-checks` | `pr.checks_settled` |
| `pending` / `none` | — | nothing |

Merging them is what keeps **fix outranks review** intact. Just accepting `failing` on the old green branch would have demoted a fix-eligible red PR to a review whenever its last suite happened to be green — two cases that previously emitted nothing now correctly route to `pr.checks_failed`, both pinned by tests.

## Not covered

A suite concluding `cancelled` / `neutral` / `skipped` / `stale` still emits nothing, so the same last-to-settle accident survives one conclusion set over. `cancelled` is common with Actions concurrency groups. Closing it means paying an aggregate read on deliveries that usually mean nothing happened — a volume trade-off worth deciding separately. Called out in the spec.

## Testing

- 10 new tests. Verified that 4 of the de-dupe tests fail against the unfixed helper — they are not vacuous.
- One existing fixture in `github-failed-checks.test.ts` modelled two distinct failing jobs as two runs of *one* check name, which real GitHub never produces (the rest of that file already uses `CI / build` vs `CI / test`). Named the second job distinctly.
- `pnpm turbo run typecheck test build` green — 21/21 tasks, 2760 tests. `astro check` clean.

Spec updated in `03-integrations.md` (the three check-event rows, plus new "Which event a settle becomes" and "Superseded check re-runs" sections) and cross-referenced from `05-router.md`.

## Deploying

This is prod-facing, so it needs a release tag and a `deploy.version` bump in each overlay to reach an instance.

Separately worth knowing: on the nearform instance the `check-prs-awaiting-review` sweep — the documented release mechanism for exactly this class of stuck review — is currently disabled, so it did not catch #1646 either. Left as-is deliberately; not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
