### PR TITLE
fix(webhook): find the PR behind a fork PR's checks

### DIFF
--- a/apps/server/spec/03-integrations.md
+++ b/apps/server/spec/03-integrations.md
@@ -99,6 +99,41 @@ and read `pending`. No event ever fired; under `review.postsCheck` the `queued`
 placeholder sat on the PR until it was merged hours later. Nothing about the PR
 was unusual: the outcome depended purely on the order CI settled in.
 
+### Fork PRs and the check payloads
+
+GitHub populates `check_suite.pull_requests[]` / `check_run.pull_requests[]`
+**only when the head branch lives on the base repo**. A PR opened from a fork
+carries an empty array, so every route keyed on it — the settle emit and both
+Re-run buttons — used to drop the delivery outright.
+
+That was invisible until `after-checks` became the packaged default. Under
+`eager` the review fires from `pr.opened`, a `pull_request` event that always
+carries the PR object, so forks never touched the check path at all. Under
+`after-checks` a fork PR defers on `pr.opened`, posts its `queued` placeholder,
+and then no settle event can ever conclude it — the check sits there for the
+life of the PR, and on a repo that made it required the PR is unmergeable
+(nearform/lastlight#282).
+
+So an empty array falls back to asking the **base** repo which open PR this
+commit heads (`listPullRequestsAssociatedWithCommit`). The base repo is the one
+the App is installed on, so this needs no access to the fork. Two filters make
+it a safe substitute for the payload's own array: `head.sha` must equal the
+commit (the endpoint also returns PRs that merely *contain* it), and the PR must
+be **open**. Results are sorted ascending so the rare commit heading two open
+PRs resolves deterministically.
+
+The lookup is resolved **after** the "does anyone consume this?" test, so a
+delivery no route wants still costs nothing, and a same-repo PR never reaches it
+at all.
+
+**The maintainer-approval gate comes for free.** GitHub withholds Actions runs on
+a fork PR from a first-time contributor until a maintainer approves them. No
+approval means no checks, which means the aggregate is `none` and never settles,
+which means no review. Gating on "CI settled" inherits GitHub's own gate exactly,
+with no permission logic on our side — and it is why reviewing fork PRs is safe
+to do by default: the same human decision that lets fork code run in Actions is
+the one that lets it reach the review sandbox.
+
 ### Superseded check re-runs
 
 `checks.listForRef?filter=latest` de-dupes per check **suite**, not per check

--- a/apps/server/src/connectors/github-webhook.ts
+++ b/apps/server/src/connectors/github-webhook.ts
@@ -47,6 +47,23 @@ export interface GitHubWebhookConfig {
     ref: string,
   ) => Promise<"passing" | "failing" | "pending" | "none">;
   /**
+   * The open PR(s) whose HEAD is this commit (delegates to
+   * `GitHubClient.listOpenPrNumbersForHeadSha`) — the FORK-PR fallback for
+   * `check_suite` / `check_run` payloads, whose own `pull_requests[]` is empty
+   * unless the PR's head branch lives on the base repo.
+   *
+   * Without it every check-driven route is same-repo-only, which under
+   * `review.trigger: after-checks` means a fork PR defers on `pr.opened`,
+   * posts the `queued` placeholder, and never gets the settle event that would
+   * conclude it. When unset (standalone unit tests) the connector keeps the
+   * payload-only behaviour.
+   */
+  listOpenPrNumbersForHeadSha?: (
+    owner: string,
+    repo: string,
+    sha: string,
+  ) => Promise<number[]>;
+  /**
    * The OPERATOR's `review.trigger`, read live.
    *
    * `check_suite.completed` is broadened past dependency PRs — to
@@ -353,6 +370,53 @@ export class GitHubWebhookConnector extends EventEmitter implements Connector {
   }
 
   /**
+   * The PR a `check_suite` / `check_run` delivery is about.
+   *
+   * The payload's own `pull_requests[]` is authoritative and free — but GitHub
+   * fills it only when the head branch lives on the base repo. A FORK PR gets
+   * an empty array, and every check-driven route keyed on it (the settle emit,
+   * the Re-run buttons) then drops the delivery entirely.
+   *
+   * So when the array is empty we ask the base repo which open PR this commit
+   * heads. One extra call, only on that path, and only when a head SHA is
+   * present — a same-repo PR never reaches it.
+   *
+   * Returns `undefined` rather than throwing on any failure: a PR we cannot
+   * identify is exactly the situation before this fallback existed, and a
+   * transient lookup error must not be louder than the event it was resolving.
+   */
+  private async prNumberForCheckPayload(
+    payloadPrs: Array<{ number?: number }> | undefined,
+    repoFullName: string | undefined,
+    sha: string | undefined,
+  ): Promise<number | undefined> {
+    const fromPayload = payloadPrs?.[0]?.number;
+    if (fromPayload) return fromPayload;
+    if (!this.config.listOpenPrNumbersForHeadSha || !repoFullName || !sha) return undefined;
+    const [owner, repo] = repoFullName.split("/");
+    try {
+      const numbers = await this.config.listOpenPrNumbersForHeadSha(owner, repo, sha);
+      const found = numbers[0];
+      if (found) {
+        log.debug("Resolved a fork PR from its head SHA", {
+          repoFullName,
+          sha: sha.slice(0, 7),
+          prNumber: found,
+          ...(numbers.length > 1 ? { alsoHeads: numbers.slice(1) } : {}),
+        });
+      }
+      return found;
+    } catch (err) {
+      log.warn("listOpenPrNumbersForHeadSha failed", {
+        repoFullName,
+        sha: sha.slice(0, 7),
+        err,
+      });
+      return undefined;
+    }
+  }
+
+  /**
    * Is the operator running `review.trigger: after-checks`? Only then does a
    * settled check suite on a PR neither check-outcome route claimed become a
    * `pr.checks_settled` event; every other mode has no consumer for it.
@@ -498,14 +562,21 @@ export class GitHubWebhookConnector extends EventEmitter implements Connector {
       // check_run.rerequested (one check) or check_suite.rerequested (all) to
       // the App that owns the check. Map either to pr.synchronize so the runner
       // re-reviews the PR's current head — the same path a fresh push takes.
-      // The associated PR comes from the event's `pull_requests[]` (populated
-      // for same-repo PRs). Other check_run/check_suite actions (created /
-      // completed / requested, fired on every check) leave `type` null and are
-      // ignored. NOTE: requires the GitHub App to be subscribed to the "Check
+      // The associated PR comes from the event's `pull_requests[]`, falling back
+      // to a head-SHA lookup for a fork PR, whose array is always empty — see
+      // {@link prNumberForCheckPayload}. Without that fallback the Re-run button
+      // on `last-light/review`, which is the documented manual escape hatch for
+      // a stuck review, did nothing at all on exactly the PRs most likely to be
+      // stuck. Other check_run/check_suite actions (created / completed /
+      // requested, fired on every check) leave `type` null and are ignored. NOTE: requires the GitHub App to be subscribed to the "Check
       // run" / "Check suite" events — without that GitHub never delivers these.
       case "check_run":
         if (action === "rerequested" || action === "requested_action") {
-          prNumber = payload.check_run?.pull_requests?.[0]?.number;
+          prNumber = await this.prNumberForCheckPayload(
+            payload.check_run?.pull_requests,
+            repoFullName,
+            payload.check_run?.head_sha,
+          );
           issueNumber = prNumber;
           if (prNumber) {
             // Re-running OUR OWN review check is an explicit review request,
@@ -526,7 +597,11 @@ export class GitHubWebhookConnector extends EventEmitter implements Connector {
 
       case "check_suite":
         if (action === "rerequested") {
-          prNumber = payload.check_suite?.pull_requests?.[0]?.number;
+          prNumber = await this.prNumberForCheckPayload(
+            payload.check_suite?.pull_requests,
+            repoFullName,
+            payload.check_suite?.head_sha,
+          );
           issueNumber = prNumber;
           if (prNumber) type = "pr.synchronize";
         } else if (action === "completed") {
@@ -553,9 +628,6 @@ export class GitHubWebhookConnector extends EventEmitter implements Connector {
           const suiteRed = suiteConclusion === "failure" || suiteConclusion === "timed_out";
           const suiteGreen = suiteConclusion === "success";
           if (suiteRed || suiteGreen) {
-            // `pull_requests[]` is populated for same-repo PRs (fork PRs carry
-            // an empty array and are dropped below).
-            const pr = payload.check_suite?.pull_requests?.[0];
             const sha: string | undefined = payload.check_suite?.head_sha;
             // The check_suite `pull_requests[]` entry is minimal (number/refs
             // only — no title or author). The head commit carries the useful
@@ -586,7 +658,17 @@ export class GitHubWebhookConnector extends EventEmitter implements Connector {
             // aggregate read. An ordinary human PR under a mode with no
             // consumer for a settle event never makes the call.
             const wanted = isDependency || isOurOwnPush || this.afterChecks();
-            if (pr?.number && wanted) {
+            // Resolved AFTER `wanted`, because for a fork PR this costs an API
+            // call (`pull_requests[]` is empty unless the head branch is on the
+            // base repo) and a delivery nobody consumes should cost nothing.
+            const suitePr = wanted
+              ? await this.prNumberForCheckPayload(
+                  payload.check_suite?.pull_requests,
+                  repoFullName,
+                  sha,
+                )
+              : undefined;
+            if (suitePr) {
               // Fire only once the head SHA has FULLY SETTLED, so a repo with
               // several check-reporting apps produces exactly one event per SHA
               // — the last suite to settle — rather than one per app. Absent a
@@ -602,7 +684,7 @@ export class GitHubWebhookConnector extends EventEmitter implements Connector {
               // all `normalize()` can return — so the precedence below is not a
               // policy choice bolted on later, it is the shape of the pipeline.
               if (settled === "failing" && (isDependency || isOurOwnPush)) {
-                prNumber = pr.number;
+                prNumber = suitePr;
                 issueNumber = prNumber;
                 headSha = sha;
                 type = "pr.checks_failed";
@@ -618,7 +700,7 @@ export class GitHubWebhookConnector extends EventEmitter implements Connector {
                 // A green dependency PR goes to the MERGE route, not a review.
                 // We deliberately do NOT fire this for every green PR — that
                 // would flood the router with events for unrelated work.
-                prNumber = pr.number;
+                prNumber = suitePr;
                 issueNumber = prNumber;
                 headSha = sha;
                 type = "pr.checks_passed";
@@ -632,7 +714,7 @@ export class GitHubWebhookConnector extends EventEmitter implements Connector {
                 // COLOUR — "on settle, either colour" is the documented
                 // contract (09 → S2, locked decision 14), a red result is
                 // useful review input, and a PR we gave up on never goes green.
-                prNumber = pr.number;
+                prNumber = suitePr;
                 issueNumber = prNumber;
                 headSha = sha;
                 type = "pr.checks_settled";

--- a/apps/server/src/engine/github/github.ts
+++ b/apps/server/src/engine/github/github.ts
@@ -612,6 +612,52 @@ export class GitHubClient {
   }
 
   /**
+   * The OPEN pull request whose HEAD is this commit — the fork-PR answer to a
+   * question `check_suite` / `check_run` payloads cannot answer themselves.
+   *
+   * GitHub populates `pull_requests[]` on those payloads only for a **same-repo**
+   * PR. A PR opened from a fork carries an empty array, so every route keyed on
+   * it drops the delivery: under `review.trigger: after-checks` the review
+   * defers on `pr.opened` (a `pull_request` event, which DOES carry the PR),
+   * posts its `queued` placeholder, and then no settle event can ever fire —
+   * the check sits queued for the life of the PR. That is a regression of the
+   * trigger change, not a property of forks: under `eager` the review fired
+   * from `pr.opened` and forks were never involved in the check path at all.
+   *
+   * `listPullRequestsAssociatedWithCommit` answers it from the BASE repo, which
+   * is the repo the App is installed on — no access to the fork required.
+   *
+   * Two filters make it a safe substitute for the payload's own array:
+   *
+   * - **`head.sha === sha`.** The endpoint returns every PR the commit is
+   *   associated with, including ones that merely CONTAIN it. Acting on those
+   *   would review a PR whose head is somewhere else entirely.
+   * - **open only.** A settled check on a commit that also sits in a closed PR
+   *   is not a reason to do anything to the closed PR.
+   *
+   * Returns the numbers, ascending, so a caller taking `[0]` gets the oldest —
+   * a stable choice on the rare commit that heads two open PRs, rather than
+   * whichever order GitHub happened to answer in.
+   */
+  async listOpenPrNumbersForHeadSha(
+    owner: string,
+    repo: string,
+    sha: string,
+  ): Promise<number[]> {
+    const kit = await this.kit(owner);
+    const { data } = await kit.rest.repos.listPullRequestsAssociatedWithCommit({
+      owner,
+      repo,
+      commit_sha: sha,
+      per_page: 100,
+    });
+    return data
+      .filter((pr) => pr.state === "open" && pr.head?.sha === sha)
+      .map((pr) => pr.number)
+      .sort((a, b) => a - b);
+  }
+
+  /**
    * List a repo's open pull requests as light records (number / title / draft /
    * author login / labels / head ref + sha). Deterministic discovery for the
    * dependency-merge and dependency-ci-fix crons: they filter these by author +

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1124,6 +1124,16 @@ async function main() {
         ? (owner, repo, ref) =>
             github.getChecksConclusion(owner, repo, ref, { excludeApp: config.botName })
         : undefined,
+      // The FORK-PR fallback. `check_suite` / `check_run` payloads carry
+      // `pull_requests[]` only for a same-repo PR, so without this every
+      // check-driven route is same-repo-only — and under the packaged
+      // `review.trigger: after-checks` a fork PR defers on `pr.opened`, posts
+      // the `queued` placeholder, and never receives the settle event that
+      // would conclude it. Asked of the BASE repo, which is the one the App is
+      // installed on, so it needs no access to the fork.
+      listOpenPrNumbersForHeadSha: github
+        ? (owner, repo, sha) => github.listOpenPrNumbersForHeadSha(owner, repo, sha)
+        : undefined,
       // Only broaden `check_suite.completed` beyond dependency PRs when the
       // operator's mode actually consumes a settle event. Deliberately the
       // OPERATOR's value, not a repo's: emitting is what costs event volume,

--- a/apps/server/tests/connectors/github-webhook.test.ts
+++ b/apps/server/tests/connectors/github-webhook.test.ts
@@ -202,6 +202,23 @@ describe("GitHubWebhookConnector — re-run checks", () => {
     expect(json.filtered).toBe(true);
     expect(emitted).toBeNull();
   });
+
+  it("resolves a FORK PR for the Re-run button, which is otherwise fork-blind", async () => {
+    // The Re-run button on `last-light/review` is the documented manual
+    // affordance for a stuck review — and it read the same empty
+    // `pull_requests[]`, so on a fork PR it did nothing at all.
+    const conn = new GitHubWebhookConnector({
+      port: 0,
+      webhookSecret: SECRET,
+      botLogin: BOT_LOGIN,
+      listOpenPrNumbersForHeadSha: async () => [282],
+    });
+    const { emitted } = await postCheckEvent(conn, "check_run", {
+      action: "rerequested",
+    });
+    expect(emitted?.type).toBe("pr.synchronize");
+    expect(emitted?.prNumber).toBe(282);
+  });
 });
 
 /** POST a signed `check_suite` webhook (with conclusion + head_commit). */
@@ -418,6 +435,11 @@ describe("GitHubWebhookConnector — settle-aware emit gate", () => {
   function connectorWithChecks(
     conclusion: "passing" | "failing" | "pending" | "none",
     trigger: "eager" | "after-checks" | "on-request" = "eager",
+    /**
+     * The fork-PR fallback. Wired only when a test opts in, so every existing
+     * case still proves the payload-only path on its own.
+     */
+    forkLookup?: { prs: number[]; calls: Array<[string, string, string]> },
   ): { conn: GitHubWebhookConnector; calls: Array<[string, string, string]> } {
     const calls: Array<[string, string, string]> = [];
     const conn = new GitHubWebhookConnector({
@@ -428,6 +450,14 @@ describe("GitHubWebhookConnector — settle-aware emit gate", () => {
         calls.push([owner, repo, ref]);
         return conclusion;
       },
+      ...(forkLookup
+        ? {
+            listOpenPrNumbersForHeadSha: async (owner: string, repo: string, sha: string) => {
+              forkLookup.calls.push([owner, repo, sha]);
+              return forkLookup.prs;
+            },
+          }
+        : {}),
       reviewTrigger: () => trigger,
     });
     return { conn, calls };
@@ -562,6 +592,102 @@ describe("GitHubWebhookConnector — settle-aware emit gate", () => {
       headBranch: "feature/whatever",
     });
     expect(emitted?.type).toBe("pr.checks_settled");
+  });
+
+  // ── Fork PRs ────────────────────────────────────────────────────────────
+  //
+  // GitHub fills `check_suite.pull_requests[]` only when the head branch lives
+  // on the BASE repo. A PR opened from a fork carries an empty array, so every
+  // check-driven route keyed on it dropped the delivery outright.
+  //
+  // That was invisible until `review.trigger: after-checks` became the packaged
+  // default: under `eager` the review fired from `pr.opened` (a `pull_request`
+  // event, which always carries the PR) and forks never touched the check path.
+  // Afterwards a fork PR defers on `pr.opened`, posts its `queued` placeholder,
+  // and no settle event can ever conclude it — nearform/lastlight#282.
+
+  it("resolves a FORK PR from the head SHA when pull_requests[] is empty", async () => {
+    const fork = { prs: [282], calls: [] as Array<[string, string, string]> };
+    const { conn } = connectorWithChecks("passing", "after-checks", fork);
+    const { emitted } = await postCheckSuiteCompleted(conn, {
+      conclusion: "success",
+      // no prNumber -> the payload carries `pull_requests: []`, as a fork does
+      commitAuthor: "Robin",
+      commitMessage: "feat(cron): make sandbox-sweep observable",
+      headBranch: "feat/cron-sweep-observability",
+      headSha: "969b6986",
+    });
+    expect(emitted?.type).toBe("pr.checks_settled");
+    expect(emitted.prNumber).toBe(282);
+    expect(emitted.headSha).toBe("969b6986");
+    expect(fork.calls).toEqual([["acme", "widgets", "969b6986"]]);
+  });
+
+  it("prefers the payload's own PR — a same-repo PR costs no extra call", async () => {
+    const fork = { prs: [999], calls: [] as Array<[string, string, string]> };
+    const { conn } = connectorWithChecks("passing", "after-checks", fork);
+    const { emitted } = await postCheckSuiteCompleted(conn, {
+      conclusion: "success",
+      prNumber: 7,
+      commitAuthor: "Ada Lovelace",
+      commitMessage: "feat: something human",
+      headBranch: "feature/whatever",
+    });
+    expect(emitted?.prNumber).toBe(7);
+    expect(fork.calls).toEqual([]);
+  });
+
+  it("does not pay for the lookup when nobody consumes the delivery", async () => {
+    // A human fork PR under `eager`: no fix route claims it and no settle
+    // consumer exists, so the delivery must cost nothing at all.
+    const fork = { prs: [282], calls: [] as Array<[string, string, string]> };
+    const { conn, calls } = connectorWithChecks("passing", "eager", fork);
+    const { json, emitted } = await postCheckSuiteCompleted(conn, {
+      conclusion: "success",
+      commitAuthor: "Robin",
+      commitMessage: "feat: something",
+      headBranch: "feat/whatever",
+    });
+    expect(json.filtered).toBe(true);
+    expect(emitted).toBeNull();
+    expect(fork.calls).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  it("drops the delivery when the SHA heads no open PR", async () => {
+    // A push to a branch with no PR still produces check suites. Resolving
+    // nothing must stay a silent no-op, exactly as an empty array always was.
+    const fork = { prs: [], calls: [] as Array<[string, string, string]> };
+    const { conn } = connectorWithChecks("passing", "after-checks", fork);
+    const { json, emitted } = await postCheckSuiteCompleted(conn, {
+      conclusion: "success",
+      commitAuthor: "Robin",
+      commitMessage: "chore: direct push",
+      headBranch: "some-branch",
+    });
+    expect(json.filtered).toBe(true);
+    expect(emitted).toBeNull();
+  });
+
+  it("survives a failed lookup without dropping louder than before", async () => {
+    const conn = new GitHubWebhookConnector({
+      port: 0,
+      webhookSecret: SECRET,
+      botLogin: BOT_LOGIN,
+      getChecksConclusion: async () => "passing" as const,
+      listOpenPrNumbersForHeadSha: async () => {
+        throw new Error("502 from GitHub");
+      },
+      reviewTrigger: () => "after-checks" as const,
+    });
+    const { json, emitted } = await postCheckSuiteCompleted(conn, {
+      conclusion: "success",
+      commitAuthor: "Robin",
+      commitMessage: "feat: something",
+      headBranch: "feat/whatever",
+    });
+    expect(json.filtered).toBe(true);
+    expect(emitted).toBeNull();
   });
 
   it("routes a red aggregate to the FIX path even when the last suite was green", async () => {

--- a/apps/server/tests/engine/github/github-checks.test.ts
+++ b/apps/server/tests/engine/github/github-checks.test.ts
@@ -322,6 +322,65 @@ describe("GitHubClient.getCiFailureReport — superseded re-runs", () => {
   });
 });
 
+/**
+ * The FORK-PR lookup (nearform/lastlight#282). `check_suite` / `check_run`
+ * payloads carry `pull_requests[]` only for a same-repo PR, so this is how a
+ * fork PR's checks find their PR at all. Its two filters are the whole safety
+ * argument — the endpoint answers a looser question than we are asking.
+ */
+describe("GitHubClient.listOpenPrNumbersForHeadSha", () => {
+  const pr = (number: number, state: string, headSha: string) => ({
+    number,
+    state,
+    head: { sha: headSha },
+  });
+
+  function octokitWith(prs: unknown[]) {
+    return {
+      rest: {
+        repos: {
+          listPullRequestsAssociatedWithCommit: async () => ({ data: prs }),
+        },
+      },
+    };
+  }
+
+  it("returns the open PR this commit HEADS", async () => {
+    const c = clientWith(octokitWith([pr(282, "open", "969b698")]));
+    expect(await c.listOpenPrNumbersForHeadSha("o", "r", "969b698")).toEqual([282]);
+  });
+
+  it("ignores a PR that merely CONTAINS the commit", async () => {
+    // The endpoint returns every associated PR. A commit sitting in the middle
+    // of another PR's branch must never point a review at that PR.
+    const c = clientWith(
+      octokitWith([pr(282, "open", "969b698"), pr(300, "open", "deadbee")]),
+    );
+    expect(await c.listOpenPrNumbersForHeadSha("o", "r", "969b698")).toEqual([282]);
+  });
+
+  it("ignores a CLOSED PR with the same head", async () => {
+    // A settled check on a commit that also heads a closed PR is not a reason
+    // to do anything to the closed PR.
+    const c = clientWith(octokitWith([pr(199, "closed", "969b698")]));
+    expect(await c.listOpenPrNumbersForHeadSha("o", "r", "969b698")).toEqual([]);
+  });
+
+  it("returns nothing when the commit heads no open PR", async () => {
+    const c = clientWith(octokitWith([]));
+    expect(await c.listOpenPrNumbersForHeadSha("o", "r", "969b698")).toEqual([]);
+  });
+
+  it("sorts ascending, so a caller taking [0] is deterministic", async () => {
+    // One commit can head two open PRs (the same branch targeted at two bases).
+    // Whichever we pick must not depend on GitHub's response order.
+    const c = clientWith(
+      octokitWith([pr(310, "open", "969b698"), pr(282, "open", "969b698")]),
+    );
+    expect(await c.listOpenPrNumbersForHeadSha("o", "r", "969b698")).toEqual([282, 310]);
+  });
+});
+
 describe("GitHubClient.getBaseChecksState", () => {
   it("delegates to getChecksConclusion against the base ref", async () => {
     const c = clientWith(fakeOctokit([run("completed", "failure")], noStatus));


### PR DESCRIPTION
[#282](https://github.com/nearform/lastlight/pull/282) has sat with a `queued` `last-light/review` check since it opened, with no workflow run ever created. It's a fork PR, and that's the whole cause.

## What broke

GitHub fills `check_suite.pull_requests[]` / `check_run.pull_requests[]` **only when the head branch lives on the base repo**. A PR opened from a fork carries an empty array, so every route keyed on it drops the delivery.

Decisive A/B — two open PRs in this repo, same moment:

| PR | Type | `check_suite.pull_requests[]` |
|---|---|---|
| #278 | same-repo | `[278]` on every suite |
| #282 | fork (`yo61/lastlight`) | `[]` on every suite |

## Why it only started now

This is a regression of the review-trigger change, not a property of forks.

Under `eager` the review fires from `pr.opened` — a `pull_request` event, which always carries the PR object — so forks never touched the check path. Fork PRs #249, #258, #260 and #263 were each reviewed **within five seconds of opening**, as the run history shows.

`after-checks` became the packaged default in 4e045d1 (Jul 31) and reached the nearform instance with v0.24.4 on Aug 6. Since then a fork PR defers on `pr.opened`, posts its `queued` placeholder, and no settle event can ever conclude it. On a repo that made the check required, that PR is unmergeable.

## The fix

An empty array falls back to asking the **base** repo which open PR this commit heads (`listPullRequestsAssociatedWithCommit`). The base repo is the one the App is installed on, so this needs no access to the fork.

Two filters make it a safe substitute for the payload's own array:

- **`head.sha` must equal the commit.** The endpoint returns every PR the commit is *associated* with, including ones that merely contain it — acting on those would review a PR whose head is somewhere else.
- **open only.** A settled check on a commit that also heads a closed PR is not a reason to touch the closed PR.

Sorted ascending, so the rare commit heading two open PRs resolves deterministically rather than by GitHub's response order.

The lookup is resolved **after** the "does anyone consume this?" test, so a delivery no route wants still costs nothing, and a same-repo PR never reaches it. A failed lookup returns `undefined` — exactly the situation before the fallback existed.

**Both Re-run buttons get it too.** `check_run.rerequested` on `last-light/review` is the documented manual escape hatch for a stuck review, and it read the same empty array — so it did nothing on precisely the PRs most likely to be stuck.

## Not new policy

Reviewing fork PRs is what the harness already did under `eager`, and `resolveReviewTrigger` has never had a fork guard — only the FIX family does, since it needs a branch to push to.

The maintainer-approval gate comes for free: GitHub withholds Actions runs on a first-time contributor's fork PR until a maintainer approves them. No approval means no checks, so the aggregate is `none`, never settles, and no review fires. Gating on "CI settled" inherits GitHub's own gate with no permission logic on our side — and it's why this is safe on by default. The same human decision that lets fork code run in Actions is the one that lets it reach the review sandbox.

## Testing

- 6 new connector tests (fork resolution, payload preference, no-cost-when-unwanted, no matching PR, lookup failure, fork Re-run) and 5 for the client method's filters.
- `pnpm turbo run typecheck test build` green — 21/21 tasks. `astro check` clean.

Spec: new "Fork PRs and the check payloads" section in `03-integrations.md`, plus corrections to the stale "fork PRs are dropped" claims.

## Related

Independent of #280 — skillspro#1646 was a same-repo PR with a different pair of causes. This is a third distinct way a review can strand at `queued`.

Worth noting: the `check-prs-awaiting-review` sweep *would* have caught this (it lists all open PRs, forks included, and the sweep route is exempt from the pending deferral). It's currently disabled on the nearform instance, which is why neither this nor #1646 was rescued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
