### PR TITLE
fix(state): one repo-identifier rule — owner + BARE repo everywhere (#279)

### DIFF
--- a/apps/server/dashboard/src/lib/githubLinks.ts
+++ b/apps/server/dashboard/src/lib/githubLinks.ts
@@ -22,11 +22,15 @@ export function repoUrl(repo: string | null | undefined): string | null {
 /**
  * Resolve a run's qualified `owner/repo` for linking, else `null`.
  *
- * Runs store `repo` as a BARE name (`drizzle-cube-help`) and the owner in a
- * separate `owner` column (both in the list + detail payloads), so
- * `repoUrl(run.repo)` alone never links a run — compose owner + repo. Older
- * rows may carry the owner only in `context.owner` (detail) or embedded in the
- * `owner/repo#N` / `owner/repo::workflow` `triggerId`; both are fallbacks.
+ * The client-side twin of `state/repo-ref.ts`'s `qualifyRepo` — hand-mirrored
+ * because the dashboard has no import edge to core, the same way `api.ts`
+ * mirrors the row types. Runs store the pair: a BARE `repo`
+ * (`drizzle-cube-help`) plus a separate `owner` column, in both the list and
+ * detail payloads. So `repoUrl(run.repo)` alone never links a run.
+ *
+ * Two fallbacks, for rows the #279 backfill couldn't reach: the owner may live
+ * only in `context.owner` (detail payload), or embedded in the `owner/repo#N` /
+ * `owner/repo::workflow` `triggerId`.
  */
 export function runRepoPath(run: {
   repo?: string | null;
@@ -35,14 +39,15 @@ export function runRepoPath(run: {
   context?: Record<string, unknown> | null;
 }): string | null {
   const bare = run.repo?.trim();
-  if (bare && OWNER_REPO.test(bare)) return bare;
-  // Explicit `owner` column (+ `context.owner` for pre-migration rows).
   const owner =
     run.owner?.trim() ||
     (typeof run.context?.owner === "string" ? run.context.owner.trim() : "");
   if (bare && owner && !bare.includes("/")) return `${owner}/${bare}`;
-  // Legacy fallback: pull the LEADING `owner/repo` from the trigger id, stopping
-  // at the `#` or `:` suffix so `owner/repo::repo-health` can't slip through.
+  // Legacy: a row written before the backfill put the qualified string in
+  // `repo` itself. Never re-qualify one of those.
+  if (bare && OWNER_REPO.test(bare)) return bare;
+  // Legacy: pull the LEADING `owner/repo` from the trigger id, stopping at the
+  // `#` or `:` suffix so `owner/repo::repo-health` can't slip through.
   const fromTrigger = run.triggerId?.match(/^([^/\s#:]+\/[^/\s#:]+)(?:$|[#:])/)?.[1];
   if (fromTrigger) return fromTrigger;
   return null;

--- a/apps/server/spec/10-state.md
+++ b/apps/server/spec/10-state.md
@@ -39,7 +39,8 @@ CREATE TABLE IF NOT EXISTS executions (
   trigger_type TEXT NOT NULL,           -- "webhook" | "cron" | "chat" | "api"
   trigger_id TEXT NOT NULL,             -- issue URL, Slack thread id, etc.
   skill TEXT NOT NULL,                  -- "workflow-name:phase-name" or "chat"
-  repo TEXT,
+  owner TEXT,                           -- GitHub org/user; composes owner/repo
+  repo TEXT,                            -- BARE repo name (path-safe segment)
   issue_number INTEGER,
   started_at TEXT NOT NULL,
   finished_at TEXT,
@@ -248,13 +249,38 @@ dispatch that did not happen, and it carries the intervention forward, so
 counting it would make the row written to *defer* an ask read as having served
 it.
 
-`owner` + `repo` together identify the target: `repo` is stored **bare**
-(a single path-safe segment — taskIds and workspace/session dirs derive
-from it), so the org/user is kept in its own `owner` column rather than
-inside `context` alone. That lets the runs-list query (which omits the
-heavy `context` blob) compose the qualified `owner/repo` for the Repos-tab
-grouping and the dashboard's GitHub links. Added by an additive migration
-that backfills existing rows from `context.owner`.
+### One repo-identifier rule
+
+`owner` + `repo` together identify the target, on **both** `workflow_runs` and
+`executions` (and on `feedback_anchors` / `feedback_signals`, which always did).
+`repo` is stored **bare** — a single path-safe segment, because taskIds and
+workspace/session dirs derive from it — with the org/user in its own `owner`
+column. That pair is also exactly what Octokit takes, so a row read back needs
+no splitting before it reaches GitHub.
+
+Everything a *user* sees speaks the qualified `owner/repo` instead:
+`getManagedRepos()`, `EventEnvelope.repo`, `PrState.repo`, the artifact-store
+slugs, `/me/repos`, the dashboard. **`src/state/repo-ref.ts` is the only place
+that join is expressed** — `qualifyRepo` for JS, `qualifiedRepoSql` for SQL, and
+`normalizeRepoRef` for the inverse. `createRun` and `recordStart` run every
+write through it, and `deserialize` runs every read back through it.
+
+That convergence is issue #279. Before it, the same column meant two things
+depending on who wrote it: rows predating the `owner` column held the qualified
+string in `repo` itself, and `executions` had no `owner` at all — the dispatcher
+wrote qualified there while the phase executor wrote bare, which is every
+workflow phase row. Six read sites each re-derived "may be bare or qualified"
+and disagreed about which source wins; #278 shipped a filter built on one
+reading, compared `lastlight` against `{nearform/lastlight}`, and a non-null
+non-match **hides** rows rather than showing them.
+
+An idempotent backfill in `migrate()` converges both tables — `workflow_runs`
+first, since the `executions` owner is recovered by joining it. Two arms of
+compatibility survive, both documented as legacy rather than as the rule: the
+`OR repo = ?` branch of `repoMatchClause`, and `normalizeRepoRef` on read-back.
+Rows where the account was never captured anywhere cannot be backfilled and
+keep a null `owner`; a filter treats those as "no repo, always visible" rather
+than hiding them.
 
 The `queued` status is the persisted form of the global concurrency cap
 (see [Workflow Engine](/spec/06-workflow-engine)): when a fresh trigger

--- a/apps/server/src/admin/routes.ts
+++ b/apps/server/src/admin/routes.ts
@@ -1984,19 +1984,11 @@ export function createAdminRoutes(
     const ctx = run.context ?? {};
     const ctxOwner = typeof ctx.owner === "string" ? ctx.owner : undefined;
     const branch = typeof ctx.branch === "string" ? ctx.branch : undefined;
-    const repoField = typeof run.repo === "string" ? run.repo : undefined;
-    let owner: string | undefined;
-    let repo: string | undefined;
-    if (repoField) {
-      if (repoField.includes("/")) {
-        const [maybeOwner, maybeRepo] = repoField.split("/", 2);
-        owner = ctxOwner ?? maybeOwner;
-        repo = maybeRepo;
-      } else {
-        owner = ctxOwner;
-        repo = repoField;
-      }
-    }
+    // The row IS the pair (issue #279) — `owner` plus a bare `repo`, normalized
+    // by the store on the way in and on the way out. `context.owner` stays as
+    // the fallback for a row whose owner column was never captured.
+    const repo = run.repo;
+    const owner = repo ? run.owner ?? ctxOwner : undefined;
     const issueKey = buildAssetIssueKey(run.workflowName, run.issueNumber, run.id);
     return { owner, repo, issueKey, branch };
   }
@@ -2321,13 +2313,12 @@ export function createAdminRoutes(
     } | null = null;
 
     if (approval.artifact && run && run.repo) {
-      // `workflow_runs.repo` is the BARE repo name and `owner` lives in
-      // run.context (set by simple.ts) — except in tests / legacy rows that
-      // may store "owner/repo". Handle both: prefer context.owner, else split.
+      // The row is the (owner, BARE repo) pair (issue #279); `context.owner` is
+      // the fallback for a row whose owner column was never captured.
       const ctx = run.context ?? {};
       const ctxOwner = typeof ctx.owner === "string" ? ctx.owner : undefined;
-      const repo = run.repo.includes("/") ? run.repo.split("/")[1] : run.repo;
-      const owner = ctxOwner ?? (run.repo.includes("/") ? run.repo.split("/")[0] : "");
+      const repo = run.repo;
+      const owner = run.owner ?? ctxOwner ?? "";
       if (owner && repo) {
         const mode: BuildAssetsLocation = config.buildAssets ?? "repo";
         const issueKey = buildAssetIssueKey(run.workflowName, run.issueNumber, run.id);

--- a/apps/server/src/engine/dispatcher.ts
+++ b/apps/server/src/engine/dispatcher.ts
@@ -6,6 +6,7 @@ import type { SessionManager } from "../connectors/index.js";
 // into the dispatcher's module graph.
 import { withThreadTranscript } from "../connectors/messaging/thread-transcript.js";
 import type { StateDb } from "../state/db.js";
+import { qualifyRepo } from "../state/repo-ref.js";
 import type { GitHubClient } from "./github/github.js";
 import type { ChatResult } from "./chat/chat.js";
 import { routeEvent, type Route, type RouterDeps } from "./router.js";
@@ -775,7 +776,11 @@ async function handleBuild(
     triggerType: envelope.type === "message" ? "chat" : "webhook",
     triggerId: String(issueNumber),
     skill: "build-cycle",
-    repo: repoStr,
+    // The pair, not the qualified string this used to write (issue #279) — a
+    // `build-cycle` row has no `workflow_run_id`, so its own columns are the
+    // only place the account can be recovered from.
+    owner,
+    repo,
     issueNumber,
     startedAt: new Date().toISOString(),
     // Actor logging (issue #205): who fired this build.
@@ -951,10 +956,14 @@ async function handleExploreReply(
   const isSlack = run.triggerId.startsWith("slack:");
   const replyChannelId = context.channelId as string | undefined;
   const replyThreadId = context.threadId as string | undefined;
-  // Reconstruct owner/repo from the stored workflow context.
+  // `dispatchWorkflow` speaks the qualified `owner/repo`, so compose it from
+  // the row's pair — through `qualifyRepo`, which is a no-op on a value that
+  // already carries a slash. This used to join unconditionally, so a legacy
+  // qualified `run.repo` produced `acme/acme/widgets`, which the dispatch split
+  // then read as the repo `acme` — a different real repository (issue #279).
   const storedCtx = (run.context || {}) as Record<string, unknown>;
   const storedOwner = storedCtx.owner as string | undefined;
-  const resumeRepo = storedOwner && run.repo ? `${storedOwner}/${run.repo}` : run.repo || undefined;
+  const resumeRepo = qualifyRepo(run.owner ?? storedOwner, run.repo);
   eventLog.info("explore-reply: resuming after reply", { workflowRunId, sender });
   deps.dispatchWorkflow("explore", {
     repo: resumeRepo || (isSlack ? undefined : run.triggerId.split("#")[0]),

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1444,17 +1444,16 @@ async function main() {
           return;
         }
         // Derive owner/repo for the resume dispatch. Prefer the triggerId
-        // (owner/repo#N) but fall back to the stored repo + context.owner so a
-        // run keyed on a non-GitHub triggerId (e.g. a Slack-thread override)
-        // still resumes from the dashboard/focused-approval flow.
+        // (owner/repo#N) but fall back to the row's own (owner, BARE repo) pair
+        // so a run keyed on a non-GitHub triggerId (e.g. a Slack-thread
+        // override) still resumes from the dashboard/focused-approval flow.
         let [owner, repo] = workflowRun.triggerId.includes("/")
           ? workflowRun.triggerId.replace(/#\d+$/, "").split("/")
           : ["", ""];
         if (!owner || !repo) {
           const ctxOwner = (workflowRun.context?.owner as string | undefined) || "";
-          const storedRepo = workflowRun.repo || "";
-          owner = ctxOwner || (storedRepo.includes("/") ? storedRepo.split("/")[0] : "");
-          repo = storedRepo.includes("/") ? storedRepo.split("/")[1] : storedRepo;
+          owner = workflowRun.owner || ctxOwner;
+          repo = workflowRun.repo || "";
         }
         const issueNumber = workflowRun.issueNumber;
         if (!owner || !repo || !issueNumber) {

--- a/apps/server/src/state/execution-store.ts
+++ b/apps/server/src/state/execution-store.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 import { randomUUID } from "crypto";
 import type { TriggerActorType } from "./user-store.js";
+import { normalizeRepoRef, qualifiedRepoSql } from "./repo-ref.js";
 
 export interface ExecutionRecord {
   id: string;
@@ -15,6 +16,13 @@ export interface ExecutionRecord {
   /** Coarse actor category for {@link triggeredBy}. */
   triggerActorType?: TriggerActorType;
   skill: string;
+  /**
+   * GitHub org/user that owns {@link repo}. Its own column since #279, so a
+   * ledger row identifies its target without joining the run that owns it —
+   * which chat and `build-cycle` rows don't have.
+   */
+  owner?: string;
+  /** BARE repo name (no owner). See `state/repo-ref.ts` for the one rule. */
   repo?: string;
   issueNumber?: number;
   startedAt: string;
@@ -72,43 +80,45 @@ export interface ExecutionRecord {
  * scope as the other stores.
  */
 /**
- * `executions.repo`, normalized to a qualified `owner/repo` — or NULL when it
- * can't be (issue #169).
+ * `executions.repo`, composed into the qualified `owner/repo` a user-facing
+ * surface speaks — or NULL when it can't be (issues #169, #279).
  *
- * The column is written in **two shapes**. The dispatcher stores the qualified
- * string (`context.repo`), but the phase executor stores the BARE repo name,
- * because `runSimpleWorkflow` carries `owner` and `repo` as separate fields —
- * so every workflow run's phase rows are bare. There is no `owner` column on
- * `executions` to consult, so the owner comes from the run that owns the
- * execution (`workflow_run_id` → `workflow_runs.owner`).
+ * This used to reach for the owner by joining `workflow_runs` on
+ * `workflow_run_id`, because the column was written in two shapes and
+ * `executions` had no owner of its own. It now has one (#279), so the join is
+ * gone and the answer is on the row.
  *
  * **NULL is the safe answer, and deliberate.** A consumer of this treats null
  * as "no repo, always visible"; returning a bare name instead would produce a
  * value that matches nothing in a qualified allow-list and would therefore
- * HIDE the row. Requires the joined alias to be `e` (executions) and `r`
- * (workflow_runs).
+ * HIDE the row. Requires the alias to be `e` (executions).
  */
-const QUALIFIED_REPO_SQL = `
-  CASE
-    WHEN e.repo IS NULL OR e.repo = '' THEN NULL
-    WHEN instr(e.repo, '/') > 0 THEN e.repo
-    WHEN r.owner IS NOT NULL AND r.owner <> '' THEN r.owner || '/' || e.repo
-    ELSE NULL
-  END`;
+const QUALIFIED_REPO_SQL = qualifiedRepoSql("e.owner", "e.repo", "null");
 
 export class ExecutionStore {
   constructor(private db: Database.Database) {}
 
+  /**
+   * Append a started phase to the ledger.
+   *
+   * Like `createRun`, the (owner, BARE repo) invariant is enforced here rather
+   * than asked of callers (issue #279) — the engine writes the pair off
+   * `GitSandboxAccess`, the dispatcher off a split `context.repo`, and a
+   * qualified value from anywhere else is normalized rather than stored as a
+   * second shape.
+   */
   recordStart(record: Omit<ExecutionRecord, "finishedAt" | "success" | "error" | "turns" | "durationMs">): void {
+    const ref = normalizeRepoRef(record.owner, record.repo);
     this.db.prepare(`
-      INSERT INTO executions (id, trigger_type, trigger_id, skill, repo, issue_number, started_at, workflow_run_id, triggered_by, trigger_actor_type)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO executions (id, trigger_type, trigger_id, skill, owner, repo, issue_number, started_at, workflow_run_id, triggered_by, trigger_actor_type)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       record.id,
       record.triggerType,
       record.triggerId,
       record.skill,
-      record.repo,
+      ref.owner ?? null,
+      ref.repo ?? null,
       record.issueNumber,
       record.startedAt,
       record.workflowRunId ?? null,
@@ -237,19 +247,22 @@ export class ExecutionStore {
     triggerId: string,
     workflowRunId?: string,
     repo?: string,
+    owner?: string,
   ): void {
     const now = new Date().toISOString();
     const m = triggerId.match(/#(\d+)$/);
     const issueNumber = m ? Number(m[1]) : null;
+    const ref = normalizeRepoRef(owner, repo);
     this.db.prepare(`
       INSERT INTO executions
-        (id, trigger_type, trigger_id, skill, repo, issue_number, started_at, finished_at, success, error, stop_reason, workflow_run_id)
-      VALUES (?, 'webhook', ?, ?, ?, ?, ?, ?, 0, 'skipped: trigger rule not satisfied', 'skipped', ?)
+        (id, trigger_type, trigger_id, skill, owner, repo, issue_number, started_at, finished_at, success, error, stop_reason, workflow_run_id)
+      VALUES (?, 'webhook', ?, ?, ?, ?, ?, ?, ?, 0, 'skipped: trigger rule not satisfied', 'skipped', ?)
     `).run(
       randomUUID(),
       triggerId,
       skill,
-      repo ?? null,
+      ref.owner ?? null,
+      ref.repo ?? null,
       issueNumber,
       now,
       now,
@@ -310,7 +323,6 @@ export class ExecutionStore {
         ) AS lastAssistantContent
       FROM executions e
       LEFT JOIN messaging_sessions ms ON ms.id = e.trigger_id
-      LEFT JOIN workflow_runs r ON r.id = e.workflow_run_id
       WHERE e.skill = 'chat'
       GROUP BY e.trigger_id
       ORDER BY lastActivityAt DESC
@@ -352,7 +364,9 @@ export class ExecutionStore {
         e.trigger_id              AS triggerId,
         ms.agent_session_id       AS agentSessionId,
         ms.platform               AS platform,
-        MAX(e.repo)               AS repo,
+        -- Same qualification rule as the list above; it read the raw column
+        -- here and so disagreed with its own list view for one thread.
+        MAX(${QUALIFIED_REPO_SQL}) AS repo,
         MIN(e.started_at)         AS firstStartedAt,
         MAX(COALESCE(e.finished_at, e.started_at)) AS lastActivityAt,
         COUNT(*)                  AS turnCount,
@@ -369,7 +383,6 @@ export class ExecutionStore {
         ) AS lastAssistantContent
       FROM executions e
       LEFT JOIN messaging_sessions ms ON ms.id = e.trigger_id
-      LEFT JOIN workflow_runs r ON r.id = e.workflow_run_id
       WHERE e.skill = 'chat' AND e.trigger_id = ?
       GROUP BY e.trigger_id
     `).get(triggerId) as {
@@ -394,7 +407,7 @@ export class ExecutionStore {
    * ledger by its `session_id` (issue #169).
    *
    * The fs-backed {@link SessionReader} reads jsonl envelopes that carry no
-   * repo of their own, so this is the join that lets the dashboard filter the
+   * repo of their own, so this is the lookup that lets the dashboard filter the
    * session list by the same allowed-repo set as everything else. Returns null
    * for a session we have no execution row for — those stay visible.
    */
@@ -403,7 +416,6 @@ export class ExecutionStore {
       .prepare(
         `SELECT ${QUALIFIED_REPO_SQL} AS repo
            FROM executions e
-           LEFT JOIN workflow_runs r ON r.id = e.workflow_run_id
           WHERE e.session_id = ? AND e.repo IS NOT NULL
           ORDER BY e.started_at DESC
           LIMIT 1`,
@@ -603,6 +615,10 @@ export class ExecutionStore {
    * the `/admin/api/log-search` endpoint and the `lastlight logs search` CLI to
    * find failing/relevant phases without SSHing to the box. Parameterized; the
    * pattern is escaped so user input can't smuggle LIKE wildcards.
+   *
+   * Matches and returns the QUALIFIED repo, because that is what somebody types
+   * (issue #279) — searching `nearform/lastlight` against the bare column found
+   * no phase row at all.
    */
   searchErrors(query: string, limit = 50): Array<{
     id: string;
@@ -618,23 +634,24 @@ export class ExecutionStore {
   }> {
     const escaped = query.replace(/[\\%_]/g, (ch) => `\\${ch}`);
     const pattern = `%${escaped}%`;
+    const qualifiedRepo = qualifiedRepoSql("e.owner", "e.repo", "bare");
     const rows = this.db.prepare(`
       SELECT
-        id,
-        skill,
-        repo,
-        error,
-        success,
-        started_at      AS startedAt,
-        finished_at     AS finishedAt,
-        session_id      AS sessionId,
-        workflow_run_id AS workflowRunId,
-        trigger_id      AS triggerId
-      FROM executions
-      WHERE error LIKE ? ESCAPE '\\'
-         OR skill LIKE ? ESCAPE '\\'
-         OR repo  LIKE ? ESCAPE '\\'
-      ORDER BY started_at DESC
+        e.id,
+        e.skill,
+        ${qualifiedRepo} AS repo,
+        e.error,
+        e.success,
+        e.started_at      AS startedAt,
+        e.finished_at     AS finishedAt,
+        e.session_id      AS sessionId,
+        e.workflow_run_id AS workflowRunId,
+        e.trigger_id      AS triggerId
+      FROM executions e
+      WHERE e.error LIKE ? ESCAPE '\\'
+         OR e.skill LIKE ? ESCAPE '\\'
+         OR ${qualifiedRepo} LIKE ? ESCAPE '\\'
+      ORDER BY e.started_at DESC
       LIMIT ?
     `).all(pattern, pattern, pattern, limit) as Array<Record<string, unknown>>;
     return rows.map((r) => ({

--- a/apps/server/src/state/migrate.ts
+++ b/apps/server/src/state/migrate.ts
@@ -20,6 +20,10 @@ export function migrate(db: Database.Database): void {
       trigger_type TEXT NOT NULL,
       trigger_id TEXT NOT NULL,
       skill TEXT NOT NULL,
+      -- The target repo as (owner, BARE repo) — see state/repo-ref.ts, the one
+      -- place that rule is expressed. The owner column arrives by ALTER below
+      -- on an upgraded DB; it is here too so a fresh DB reaches the same shape.
+      owner TEXT,
       repo TEXT,
       issue_number INTEGER,
       started_at TEXT NOT NULL,
@@ -37,6 +41,8 @@ export function migrate(db: Database.Database): void {
       id TEXT PRIMARY KEY,
       workflow_name TEXT NOT NULL,
       trigger_id TEXT NOT NULL,
+      -- Same (owner, BARE repo) pair as the executions ledger above.
+      owner TEXT,
       repo TEXT,
       issue_number INTEGER,
       current_phase TEXT NOT NULL,
@@ -317,6 +323,86 @@ export function migrate(db: Database.Database): void {
     );
   } catch {
     // Column already exists — ignore
+  }
+
+  // ── One repo-identifier rule: (owner, BARE repo) — issue #279 ──────────────
+  //
+  // The column above fixed the SHAPE for new rows but left two populations
+  // behind, so the same column meant two things depending on who wrote it:
+  // rows predating it hold the qualified `owner/repo` in `repo` itself, and
+  // `executions` never got an `owner` column at all — the dispatcher wrote the
+  // qualified string there while the phase executor wrote the bare name, which
+  // is every workflow phase row.
+  //
+  // Six read sites each re-derived "may be bare or qualified" and disagreed
+  // about which source wins; #278 shipped a filter built on one reading, and a
+  // non-null non-match HIDES rows rather than showing them. So converge the
+  // data instead of teaching the seventh consumer the rule.
+  //
+  // Ordering matters: `workflow_runs` first, because the `executions` owner
+  // backfill reads `workflow_runs.owner` back out. Every statement is a no-op
+  // on a second run — after it, `instr(repo, '/') = 0` — so this is safe to
+  // re-run, which it is, on every boot.
+  try {
+    db.exec(
+      `UPDATE workflow_runs
+          SET owner = CASE WHEN owner IS NULL OR owner = ''
+                           THEN substr(repo, 1, instr(repo, '/') - 1)
+                           ELSE owner END,
+              repo  = substr(repo, instr(repo, '/') + 1)
+        WHERE repo IS NOT NULL AND instr(repo, '/') > 0`,
+    );
+    // A row from before the owner column whose `context.owner` was absent has
+    // one more witness: `trigger_id`, which is built as `owner/repo#N` (or
+    // `owner/repo::workflow`) from the same pair at dispatch. `resume.ts` and
+    // the approval-resume path already PREFER it over the columns, so reading
+    // it here is the existing precedence, not a new guess. Slack-originated
+    // ids (`slack:…`) carry no repo and are excluded.
+    db.exec(
+      `UPDATE workflow_runs
+          SET owner = substr(trigger_id, 1, instr(trigger_id, '/') - 1)
+        WHERE (owner IS NULL OR owner = '')
+          AND repo IS NOT NULL
+          AND trigger_id NOT LIKE 'slack:%'
+          AND instr(trigger_id, '/') > 0`,
+    );
+  } catch {
+    // Best-effort: a run row that won't split is better left alone than
+    // failing boot. The read path still tolerates both shapes.
+  }
+
+  try {
+    db.exec(`ALTER TABLE executions ADD COLUMN owner TEXT`);
+  } catch {
+    // Column already exists — ignore
+  }
+  try {
+    // 1. The account is already in the row, on the dispatcher-written rows that
+    //    stored the qualified string.
+    db.exec(
+      `UPDATE executions
+          SET owner = substr(repo, 1, instr(repo, '/') - 1)
+        WHERE (owner IS NULL OR owner = '')
+          AND repo IS NOT NULL AND instr(repo, '/') > 0`,
+    );
+    // 2. Otherwise it comes from the run that owns the execution. This is the
+    //    bulk: every phase row, written bare from `GitSandboxAccess`.
+    //    `build-cycle` rows are covered by (1) and chat rows carry no repo at
+    //    all, so there is nothing left needing a `trigger_id` parse.
+    db.exec(
+      `UPDATE executions
+          SET owner = (SELECT r.owner FROM workflow_runs r WHERE r.id = executions.workflow_run_id)
+        WHERE (owner IS NULL OR owner = '') AND workflow_run_id IS NOT NULL`,
+    );
+    // 3. Now de-qualify, once the account has been rescued off it.
+    db.exec(
+      `UPDATE executions
+          SET repo = substr(repo, instr(repo, '/') + 1)
+        WHERE repo IS NOT NULL AND instr(repo, '/') > 0`,
+    );
+  } catch {
+    // Same best-effort rule as above — the ledger is append-only history, and
+    // an un-normalized row degrades a dashboard filter, never a run.
   }
 
   // `feedback_anchors.channel` moved from nullable to a '' sentinel (issue

--- a/apps/server/src/state/repo-ref.ts
+++ b/apps/server/src/state/repo-ref.ts
@@ -1,0 +1,113 @@
+/**
+ * The ONE rule for how a repository is identified in the database (issue #279).
+ *
+ * **Storage is `owner` + a BARE `repo`.** Every repo-bearing table follows it —
+ * `workflow_runs`, `executions`, `feedback_anchors`, `feedback_signals` — and so
+ * does `GitSandboxAccess`, so a row read back is directly usable as Octokit's
+ * `(owner, repo)` pair with no splitting anywhere. `repo` stays a single
+ * path-safe segment because `workflowScopedTaskId` and `prNotesRepoDir` derive
+ * filesystem paths from it.
+ *
+ * Everything a *user* sees speaks the qualified `owner/repo` instead —
+ * `getManagedRepos()`, `EventEnvelope.repo`, `PrState.repo`, the artifact-store
+ * slugs, `/me/repos`, the dashboard. That join is the only place the two
+ * vocabularies meet, and this module is the only place it is expressed.
+ *
+ * It used to be expressed in six places that disagreed about which source wins
+ * (`distinctRepos`, `repoMatchClause`, `QUALIFIED_REPO_SQL`, two helpers in
+ * `admin/routes.ts`, and the dashboard's `runRepoPath`). #278 shipped a filter
+ * built on one reading and it compared `lastlight` against `{nearform/lastlight}`
+ * — a non-null non-match, which **hides** rows rather than showing them.
+ *
+ * Pure, dependency-free, and deliberately in `state/` beside the stores that
+ * enforce it.
+ */
+
+/**
+ * Split a possibly-qualified repo into the stored shape.
+ *
+ * The de-qualifier, applied at the write choke points (`createRun`,
+ * `recordStart`) and again on read-back, so a caller that hands us
+ * `"nearform/lastlight"` — a test fixture, an eval harness, a row written by an
+ * older process before the backfill ran — cannot reintroduce the drift this
+ * module exists to end.
+ *
+ * An explicit `owner` wins over the one embedded in `repo`: the column was
+ * populated from `context.owner` by the authoritative dispatch-time split,
+ * while a qualified `repo` is the legacy shape. Empty strings normalize to
+ * `undefined` so callers can use a plain truthiness check.
+ */
+export function normalizeRepoRef(
+  owner: string | null | undefined,
+  repo: string | null | undefined,
+): { owner?: string; repo?: string } {
+  const rawRepo = repo?.trim() || undefined;
+  const rawOwner = owner?.trim() || undefined;
+  if (!rawRepo) return { owner: rawOwner, repo: undefined };
+
+  // First slash, matching the SQL backfill's `instr(repo, '/')`. A GitHub repo
+  // name cannot contain a slash, so anything past the first one is malformed
+  // input rather than a shape we need to support.
+  const slash = rawRepo.indexOf("/");
+  if (slash <= 0) return { owner: rawOwner, repo: rawRepo };
+  return {
+    owner: rawOwner ?? (rawRepo.slice(0, slash) || undefined),
+    repo: rawRepo.slice(slash + 1) || undefined,
+  };
+}
+
+/**
+ * Compose the qualified `owner/repo` a user-facing surface speaks.
+ *
+ * The inverse of {@link normalizeRepoRef}, and the only recomposition in the
+ * codebase. Two degenerate cases, both deliberate:
+ *
+ * - An already-qualified `repo` (a row predating the backfill) is returned
+ *   as-is rather than double-qualified — `dispatcher.ts` used to join
+ *   unconditionally and produced `acme/acme/widgets`, which the dispatch split
+ *   then read as the repo `acme`, a different real repository.
+ * - No owner returns the BARE name. Ambiguous, but it is a name somebody can
+ *   read; for a SQL *filter*, where a bare name would match nothing in a
+ *   qualified allow-list and therefore hide the row, use
+ *   {@link qualifiedRepoSql} with `"null"` instead.
+ */
+export function qualifyRepo(
+  owner: string | null | undefined,
+  repo: string | null | undefined,
+): string | undefined {
+  const rawRepo = repo?.trim() || undefined;
+  if (!rawRepo) return undefined;
+  if (rawRepo.includes("/")) return rawRepo;
+  const rawOwner = owner?.trim() || undefined;
+  return rawOwner ? `${rawOwner}/${rawRepo}` : rawRepo;
+}
+
+/**
+ * {@link qualifyRepo} as a SQL expression, so the two cannot drift.
+ *
+ * `unqualifiable` is what to answer for a row with a repo but no owner — the
+ * only rows the backfill cannot fix, because nothing on them records the
+ * account. **The caller must choose, because the two answers are opposites:**
+ *
+ * - `"bare"` — the repo name alone. For grouping and display (`distinctRepos`),
+ *   where showing an under-specified name beats dropping the row.
+ * - `"null"` — SQL NULL. For anything a consumer treats as "no repo, always
+ *   visible" (the per-repo visibility scope, issue #169). A bare name there
+ *   matches nothing in a qualified allow-list and so silently HIDES the row,
+ *   which is exactly the #278 bug.
+ *
+ * Column names are interpolated, so pass literals — never user input.
+ */
+export function qualifiedRepoSql(
+  ownerCol: string,
+  repoCol: string,
+  unqualifiable: "bare" | "null",
+): string {
+  const fallback = unqualifiable === "bare" ? repoCol : "NULL";
+  return `CASE
+    WHEN ${repoCol} IS NULL OR ${repoCol} = '' THEN NULL
+    WHEN instr(${repoCol}, '/') > 0 THEN ${repoCol}
+    WHEN ${ownerCol} IS NOT NULL AND ${ownerCol} <> '' THEN ${ownerCol} || '/' || ${repoCol}
+    ELSE ${fallback}
+  END`;
+}

--- a/apps/server/src/state/workflow-run-store.ts
+++ b/apps/server/src/state/workflow-run-store.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 import type { ApprovalStore } from "./approval-store.js";
 import type { TriggerActorType } from "./user-store.js";
+import { normalizeRepoRef, qualifiedRepoSql } from "./repo-ref.js";
 import { logger } from "../logging/logger.js";
 
 const log = logger("runs");
@@ -43,7 +44,13 @@ export interface WorkflowRun {
   /** GitHub org/user that owns {@link repo}. Stored as its own column so the
    *  runs list (which omits `context`) can compose the qualified `owner/repo`. */
   owner?: string;
-  /** BARE repo name (no owner) — kept path-safe for taskIds / workspace dirs. */
+  /**
+   * BARE repo name (no owner) — kept path-safe for taskIds / workspace dirs.
+   *
+   * Normalized on the way in AND on the way back out (`state/repo-ref.ts`), so
+   * a consumer can hand `(run.owner, run.repo)` to Octokit unsplit. Reach for
+   * `qualifyRepo` when you need the user-facing `owner/repo`.
+   */
   repo?: string;
   issueNumber?: number;
   /**
@@ -158,15 +165,18 @@ export type TerminalRunObserver = (
 /**
  * Match one `owner/repo` against a `workflow_runs` row, in SQL.
  *
- * Exists because **the column does not hold the value callers filter by.** The
- * dashboard (Repos tab, per-repo visibility) speaks qualified `owner/repo`,
- * while the table stores the BARE repo in `repo` with the account in a separate
- * `owner` column — except for legacy rows written before that split, which put
- * the qualified string in `repo` itself. So both shapes have to be matched, and
- * a plain `repo IN (…)` silently returns nothing for every modern row.
+ * Exists because callers filter by the qualified name while the table stores
+ * the pair — `owner` + a BARE `repo` (see `state/repo-ref.ts`). That is the
+ * rule, and `owner = ? AND repo = ?` is it. A bare filter value has no owner to
+ * split off, so it matches `repo` alone.
  *
- * A bare filter value (no slash) has no owner to split off, so it matches
- * `repo` alone.
+ * The trailing `OR repo = ?` is **legacy-row handling, not the rule** (issue
+ * #279). Rows written before the backfill put the qualified string in `repo`
+ * itself; the migration converges them and both write choke points keep new
+ * ones honest, so this arm should match nothing on a migrated DB. It is kept
+ * because a `SELECT` is not the place to discover that a backfill didn't run,
+ * and because dropping a row from a filter is the failure mode that hides
+ * things silently.
  */
 function repoMatchClause(repo: string): { sql: string; values: string[] } {
   const slash = repo.indexOf("/");
@@ -221,9 +231,17 @@ export class WorkflowRunStore {
 
   // ── Plain single-mutation operations ───────────────────────────
 
-  /** Create a new workflow run record */
+  /**
+   * Create a new workflow run record.
+   *
+   * The (owner, BARE repo) invariant is enforced HERE rather than asked of
+   * callers (issue #279) — a fixture, an eval harness or a future caller
+   * passing `"owner/repo"` is split rather than stored as a third shape. See
+   * `state/repo-ref.ts`.
+   */
   createRun(run: Omit<WorkflowRun, "phaseHistory" | "updatedAt">): void {
     const now = new Date().toISOString();
+    const ref = normalizeRepoRef(run.owner, run.repo);
     this.db.prepare(`
       INSERT INTO workflow_runs (id, workflow_name, trigger_id, owner, repo, issue_number, current_phase, phase_history, status, context, scratch, started_at, updated_at, triggered_by, trigger_actor_type)
       VALUES (?, ?, ?, ?, ?, ?, ?, '[]', ?, ?, ?, ?, ?, ?, ?)
@@ -231,8 +249,8 @@ export class WorkflowRunStore {
       run.id,
       run.workflowName,
       run.triggerId,
-      run.owner ?? null,
-      run.repo ?? null,
+      ref.owner ?? null,
+      ref.repo ?? null,
       run.issueNumber ?? null,
       run.currentPhase,
       run.status,
@@ -636,26 +654,26 @@ export class WorkflowRunStore {
    * which annotates the managed-repo list with recent activity and sorts by it.
    * Ordered newest-activity first.
    *
-   * The `repo` key is the QUALIFIED `owner/repo` (owner-less legacy rows fall
-   * back to the bare name) so it aligns with `getManagedRepos()` and the
-   * artifact-store slugs the `/repos` endpoint unions it against — without this
-   * a repo split into two rows (bare-with-runs vs qualified-managed-with-zero).
+   * The `repo` key is the QUALIFIED `owner/repo` (owner-less rows fall back to
+   * the bare name) so it aligns with `getManagedRepos()` and the artifact-store
+   * slugs the `/repos` endpoint unions it against — without this a repo splits
+   * into two rows (bare-with-runs vs qualified-managed-with-zero).
+   *
+   * That join is the one in `state/repo-ref.ts`, expressed in SQL so it groups
+   * correctly: two rows for the same repo that disagree about shape collapse
+   * into one bucket here rather than after the fact.
    */
   distinctRepos(): { repo: string; runCount: number; lastRunAt: string }[] {
-    const rows = this.db
+    const qualified = qualifiedRepoSql("owner", "repo", "bare");
+    return this.db
       .prepare(
-        `SELECT owner, repo, COUNT(*) AS c, MAX(started_at) AS last
+        `SELECT ${qualified} AS repo, COUNT(*) AS runCount, MAX(started_at) AS lastRunAt
            FROM workflow_runs
           WHERE repo IS NOT NULL AND repo != ''
-          GROUP BY owner, repo
-          ORDER BY last DESC`,
+          GROUP BY ${qualified}
+          ORDER BY lastRunAt DESC`,
       )
-      .all() as { owner: string | null; repo: string; c: number; last: string }[];
-    return rows.map((r) => ({
-      repo: r.owner && !r.repo.includes("/") ? `${r.owner}/${r.repo}` : r.repo,
-      runCount: r.c,
-      lastRunAt: r.last,
-    }));
+      .all() as { repo: string; runCount: number; lastRunAt: string }[];
   }
 
   /**
@@ -813,12 +831,19 @@ export class WorkflowRunStore {
   }
 
   private deserialize(row: Record<string, unknown>): WorkflowRun {
+    // The compatibility shim for the (owner, BARE repo) invariant (issue #279).
+    // The backfill converges stored rows and `createRun` keeps new ones honest,
+    // so this only ever fires for a row written by an older process before the
+    // migration ran — but it fires at the ONE boundary every consumer crosses,
+    // which is what lets `admission.ts` and `feedback-poll.ts` hand
+    // `(run.owner, run.repo)` straight to Octokit with no split of their own.
+    const ref = normalizeRepoRef(row.owner as string | null, row.repo as string | null);
     return {
       id: row.id as string,
       workflowName: row.workflow_name as string,
       triggerId: row.trigger_id as string,
-      owner: (row.owner as string | null) ?? undefined,
-      repo: row.repo as string | undefined,
+      owner: ref.owner,
+      repo: ref.repo,
       issueNumber: row.issue_number as number | undefined,
       triggeredBy: (row.triggered_by as string | null) ?? undefined,
       triggerActorType: (row.trigger_actor_type as TriggerActorType | null) ?? undefined,

--- a/apps/server/src/workflows/resume.ts
+++ b/apps/server/src/workflows/resume.ts
@@ -249,9 +249,12 @@ export async function resumeSimpleRun(run: WorkflowRun, opts: ResumeOptions): Pr
   const stored = (run.context || {}) as Record<string, unknown>;
 
   // Derive owner/repo: GitHub trigger ids encode it as owner/repo#N;
-  // Slack-originated runs store owner in context and repo on the row.
+  // Slack-originated runs fall back to the row's own (owner, BARE repo) pair,
+  // then to context.owner for a row whose owner column was never captured.
+  // Both halves are bare here — `repo` feeds Octokit AND `workflowScopedTaskId`
+  // below, which builds a filesystem path out of it.
   const parsed = parseTriggerId(run.triggerId);
-  const owner = parsed?.owner ?? (stored.owner as string | undefined) ?? "";
+  const owner = parsed?.owner ?? run.owner ?? (stored.owner as string | undefined) ?? "";
   const repo = parsed?.repo ?? run.repo ?? "";
   const issueNumber = run.issueNumber;
   const isSlack = run.triggerId.startsWith("slack:");

--- a/apps/server/tests/admin/dashboard-repo-links.test.ts
+++ b/apps/server/tests/admin/dashboard-repo-links.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The dashboard's client-side copy of the repo-qualification rule, pinned
+ * against the server's.
+ *
+ * `apps/server/dashboard/` has no import edge to core, so `runRepoPath` is a
+ * hand-mirror of `state/repo-ref.ts`'s `qualifyRepo` — the same arrangement as
+ * the config mirror next door. It had no test at all, which is how a rule
+ * expressed in six places ends up with six readings (issue #279).
+ *
+ * Imported rather than read as text: the module is plain TS with no React and
+ * no DOM, so the two implementations can be run against the same table.
+ */
+
+import { describe, it, expect } from "vitest";
+import { runRepoPath } from "../../dashboard/src/lib/githubLinks.js";
+import { qualifyRepo } from "#src/state/repo-ref.js";
+
+describe("runRepoPath mirrors qualifyRepo", () => {
+  const rows: { name: string; owner?: string; repo?: string; expected: string | null }[] = [
+    { name: "the stored pair", owner: "nearform", repo: "lastlight", expected: "nearform/lastlight" },
+    // A row the #279 backfill never reached. Not re-qualified into
+    // `nearform/nearform/lastlight`.
+    { name: "a legacy qualified repo", repo: "nearform/lastlight", expected: "nearform/lastlight" },
+    { name: "a legacy qualified repo with an owner too", owner: "nearform", repo: "nearform/lastlight", expected: "nearform/lastlight" },
+    { name: "no repo", owner: "nearform", expected: null },
+  ];
+
+  for (const row of rows) {
+    it(`agrees on ${row.name}`, () => {
+      expect(runRepoPath({ repo: row.repo, owner: row.owner })).toBe(row.expected);
+      expect(qualifyRepo(row.owner, row.repo) ?? null).toBe(row.expected);
+    });
+  }
+
+  it("differs only where the server has no link to emit", () => {
+    // An owner-less bare name is a repo somebody can read but not a URL, so the
+    // server returns it and the client declines to link. The one deliberate
+    // divergence — asserted so it stays deliberate.
+    expect(qualifyRepo(undefined, "lastlight")).toBe("lastlight");
+    expect(runRepoPath({ repo: "lastlight" })).toBeNull();
+  });
+
+  it("falls back to context.owner, then the trigger id", () => {
+    expect(runRepoPath({ repo: "lastlight", context: { owner: "nearform" } })).toBe(
+      "nearform/lastlight",
+    );
+    expect(runRepoPath({ triggerId: "nearform/lastlight#7" })).toBe("nearform/lastlight");
+    expect(runRepoPath({ triggerId: "nearform/lastlight::repo-health" })).toBe(
+      "nearform/lastlight",
+    );
+  });
+
+  it("prefers the owner column over context.owner", () => {
+    expect(
+      runRepoPath({ owner: "nearform", repo: "lastlight", context: { owner: "stale" } }),
+    ).toBe("nearform/lastlight");
+  });
+});

--- a/apps/server/tests/admin/session-repo.test.ts
+++ b/apps/server/tests/admin/session-repo.test.ts
@@ -63,35 +63,50 @@ describe("ExecutionStore.repoForSessionId", () => {
     expect(db.executions.repoForSessionId("sess-1")).toBe("nearform/lastlight");
   });
 
-  it("qualifies a BARE repo name from the owning run's owner column", () => {
+  it("qualifies a BARE repo name from the row's own owner column", () => {
     // The regression this exists for: `runSimpleWorkflow` carries `owner` and
     // `repo` separately, so EVERY phase execution of a workflow run stores the
     // bare name. Returning `lastlight` here would match nothing in an
     // `owner/repo` allow-list — and a non-null non-match HIDES the row, which
     // is the one outcome per-repo visibility must never produce.
-    db.runs.createRun({
-      id: "run-1",
-      workflowName: "pr-review",
-      triggerId: "nearform/lastlight#7",
-      owner: "nearform",
-      repo: "lastlight",
-      issueNumber: 7,
-      currentPhase: "review",
-      status: "running",
-      startedAt: "2026-08-06T10:00:00.000Z",
-      updatedAt: "2026-08-06T10:00:00.000Z",
-    });
+    //
+    // The account used to be fetched by joining the owning run. Since #279 the
+    // ledger row carries its own `owner`, so this answers without the join —
+    // which is what makes it work for a `build-cycle` or chat row too, neither
+    // of which has a `workflow_run_id` to join through.
     db.executions.recordStart({
       id: "e1",
       triggerType: "webhook",
       triggerId: "nearform/lastlight#7",
       skill: "pr-review:review",
+      owner: "nearform",
       repo: "lastlight",
       issueNumber: 7,
       startedAt: "2026-08-06T10:00:00.000Z",
       workflowRunId: "run-1",
     });
     db.executions.recordSessionId("e1", "sess-1");
+    expect(db.executions.repoForSessionId("sess-1")).toBe("nearform/lastlight");
+  });
+
+  it("splits a qualified repo handed to recordStart rather than storing a second shape", () => {
+    // The write choke point enforces (owner, BARE repo) — issue #279. The
+    // dispatcher used to write the qualified string here.
+    db.executions.recordStart({
+      id: "e1",
+      triggerType: "webhook",
+      triggerId: "3",
+      skill: "build-cycle",
+      repo: "nearform/lastlight",
+      issueNumber: 3,
+      startedAt: "2026-08-06T10:00:00.000Z",
+    });
+    db.executions.recordSessionId("e1", "sess-1");
+
+    const row = db.database
+      .prepare(`SELECT owner, repo FROM executions WHERE id = 'e1'`)
+      .get() as { owner: string; repo: string };
+    expect(row).toEqual({ owner: "nearform", repo: "lastlight" });
     expect(db.executions.repoForSessionId("sess-1")).toBe("nearform/lastlight");
   });
 

--- a/apps/server/tests/cron/feedback-poll.test.ts
+++ b/apps/server/tests/cron/feedback-poll.test.ts
@@ -129,6 +129,34 @@ describe("discoverRunAnchors", () => {
     });
   });
 
+  it("passes Octokit the BARE repo for a legacy qualified row (issue #279)", async () => {
+    // Discovery hangs off the terminal-run observer, so it fires for EVERY
+    // finished run, and it hands `(run.owner, run.repo)` to `listBotComments`
+    // with no split of its own. A qualified value here would not just 404 —
+    // it is persisted onward onto the `feedback_anchors` row, so the anchor URL
+    // stays corrupt long after the run is gone.
+    //
+    // Raw SQL because `createRun` normalizes; the row is then read back through
+    // the store, which is the path the observer actually takes.
+    db.database
+      .prepare(
+        `INSERT INTO workflow_runs (id, workflow_name, trigger_id, owner, repo, issue_number, current_phase, status, started_at, updated_at)
+         VALUES ('run-legacy', 'pr-review', 'nearform/lastlight#255', NULL, 'nearform/lastlight', 255, 'done', 'succeeded', ?, ?)`,
+      )
+      .run("2026-08-01T10:00:00.000Z", "2026-08-01T10:20:00.000Z");
+    const stored = db.runs.getRun("run-legacy")!;
+
+    const listBotComments = vi.fn(async () => [comment()]);
+    await discoverRunAnchors({ db, github: fakeGh({ listBotComments }), botLogin: BOT }, stored);
+
+    expect(listBotComments.mock.calls[0]!.slice(0, 3)).toEqual(["nearform", "lastlight", 255]);
+    // …and the anchor it writes carries the same pair, so `anchorUrl` resolves.
+    const anchors = db.database
+      .prepare(`SELECT owner, repo FROM feedback_anchors`)
+      .all() as { owner: string; repo: string }[];
+    expect(anchors).toEqual([{ owner: "nearform", repo: "lastlight" }]);
+  });
+
   it("asks for review comments only on a PR", async () => {
     const listBotComments = vi.fn(async () => []);
     const issueRun = makeRun({ workflowName: "issue-triage", context: {} });

--- a/apps/server/tests/state/repo-normalization.test.ts
+++ b/apps/server/tests/state/repo-normalization.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { migrate } from "../../src/state/migrate.js";
+
+/**
+ * The #279 backfill: converge both repo-bearing tables on (owner, BARE repo).
+ *
+ * Rows are inserted with raw SQL on purpose — the stores now normalize at their
+ * write choke points, so going through them would seed the shape we are trying
+ * to prove the migration fixes.
+ */
+describe("migrate() — repo normalization (issue #279)", () => {
+  function seed(): Database.Database {
+    const raw = new Database(":memory:");
+    migrate(raw);
+
+    const run = raw.prepare(
+      `INSERT INTO workflow_runs (id, workflow_name, trigger_id, owner, repo, current_phase, status, started_at, updated_at)
+       VALUES (?, 'build', ?, ?, ?, 'phase_0', 'succeeded', '2026-01-01', '2026-01-01')`,
+    );
+    // Legacy: the qualified string in `repo`, no owner column value.
+    run.run("r-legacy", "nearform/lastlight#1", null, "nearform/lastlight");
+    // Legacy + an owner that was already backfilled from context.owner.
+    run.run("r-both", "nearform/lastlight#2", "nearform", "nearform/lastlight");
+    // Already the stored shape.
+    run.run("r-modern", "nearform/lastlight#3", "nearform", "lastlight");
+    // Bare repo, no owner column, no qualified string — but the trigger id
+    // still names the account. This is the whole pre-owner-column population
+    // on the drizby instance (8 rows).
+    run.run("r-from-trigger", "cliftonc/lastlight#19", null, "lastlight");
+    // Genuinely un-backfillable: nothing anywhere records the account.
+    run.run("r-orphan", "42", null, "lastlight");
+    // Slack-originated: the trigger id carries no repo to read.
+    run.run("r-slack", "slack:T1:C1:1.0", null, "lastlight");
+
+    const exec = raw.prepare(
+      `INSERT INTO executions (id, trigger_type, trigger_id, skill, owner, repo, started_at, workflow_run_id)
+       VALUES (?, 'webhook', ?, ?, NULL, ?, '2026-01-01', ?)`,
+    );
+    // Dispatcher-written build-cycle row: qualified repo, no owning run.
+    exec.run("e-qualified", "3", "build-cycle", "nearform/lastlight", null);
+    // Phase row: bare repo, owner recoverable from the owning run.
+    exec.run("e-phase", "nearform/lastlight#3", "build:architect", "lastlight", "r-modern");
+    // Phase row whose run is itself legacy — depends on workflow_runs going first.
+    exec.run("e-legacy-run", "nearform/lastlight#1", "build:architect", "lastlight", "r-legacy");
+    // Un-backfillable: bare repo, no run, no account.
+    exec.run("e-orphan", "42", "build:architect", "lastlight", null);
+    // Chat turn: no repo at all.
+    exec.run("e-chat", "slack:T1:C1:1.0", "chat", null, null);
+
+    return raw;
+  }
+
+  function runs(db: Database.Database) {
+    const rows = db
+      .prepare(`SELECT id, owner, repo FROM workflow_runs ORDER BY id`)
+      .all() as { id: string; owner: string | null; repo: string | null }[];
+    return Object.fromEntries(rows.map((r) => [r.id, [r.owner, r.repo]]));
+  }
+
+  function execs(db: Database.Database) {
+    const rows = db
+      .prepare(`SELECT id, owner, repo FROM executions ORDER BY id`)
+      .all() as { id: string; owner: string | null; repo: string | null }[];
+    return Object.fromEntries(rows.map((r) => [r.id, [r.owner, r.repo]]));
+  }
+
+  it("splits legacy qualified rows and rescues the account first", () => {
+    const db = seed();
+    migrate(db);
+
+    expect(runs(db)).toEqual({
+      "r-legacy": ["nearform", "lastlight"],
+      // An owner already on the row wins; only `repo` is de-qualified.
+      "r-both": ["nearform", "lastlight"],
+      "r-modern": ["nearform", "lastlight"],
+      // Last resort: the trigger id, which is built from the same pair at
+      // dispatch and which the resume paths already prefer over the columns.
+      "r-from-trigger": ["cliftonc", "lastlight"],
+      // Nothing on these rows records the account. Left alone rather than
+      // guessed — a filter reads a null owner as "always visible".
+      "r-orphan": [null, "lastlight"],
+      "r-slack": [null, "lastlight"],
+    });
+
+    expect(execs(db)).toEqual({
+      // Owner off the qualified string it already carried.
+      "e-qualified": ["nearform", "lastlight"],
+      // Owner off the owning run.
+      "e-phase": ["nearform", "lastlight"],
+      // …including a run that only just got its own owner in this same pass,
+      // which is why workflow_runs is normalized first.
+      "e-legacy-run": ["nearform", "lastlight"],
+      "e-orphan": [null, "lastlight"],
+      "e-chat": [null, null],
+    });
+
+    db.close();
+  });
+
+  it("is idempotent — a second and third pass move nothing", () => {
+    const db = seed();
+    migrate(db);
+    const afterFirst = { runs: runs(db), execs: execs(db) };
+
+    migrate(db);
+    migrate(db);
+
+    expect({ runs: runs(db), execs: execs(db) }).toEqual(afterFirst);
+    db.close();
+  });
+
+  it("adds executions.owner to a DB that predates the column", () => {
+    const db = seed();
+    db.exec(`ALTER TABLE executions DROP COLUMN owner`);
+    expect(() => db.prepare(`SELECT owner FROM executions`).all()).toThrow();
+
+    migrate(db);
+
+    expect(execs(db)["e-phase"]).toEqual(["nearform", "lastlight"]);
+    db.close();
+  });
+
+  it("leaves no slash behind in either table", () => {
+    const db = seed();
+    migrate(db);
+
+    const stray = db
+      .prepare(
+        `SELECT COUNT(*) AS c FROM (
+           SELECT repo FROM workflow_runs WHERE instr(repo, '/') > 0
+           UNION ALL
+           SELECT repo FROM executions WHERE instr(repo, '/') > 0
+         )`,
+      )
+      .get() as { c: number };
+    expect(stray.c).toBe(0);
+    db.close();
+  });
+});

--- a/apps/server/tests/state/repo-ref.test.ts
+++ b/apps/server/tests/state/repo-ref.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { normalizeRepoRef, qualifyRepo, qualifiedRepoSql } from "../../src/state/repo-ref.js";
+
+describe("normalizeRepoRef", () => {
+  it("leaves the stored shape alone", () => {
+    expect(normalizeRepoRef("nearform", "lastlight")).toEqual({
+      owner: "nearform",
+      repo: "lastlight",
+    });
+  });
+
+  it("splits a legacy qualified repo", () => {
+    expect(normalizeRepoRef(undefined, "nearform/lastlight")).toEqual({
+      owner: "nearform",
+      repo: "lastlight",
+    });
+  });
+
+  it("prefers an explicit owner over the one embedded in repo", () => {
+    // The column was populated from the authoritative dispatch-time split; a
+    // qualified `repo` is the legacy shape. They should agree, but if they
+    // don't, the column wins.
+    expect(normalizeRepoRef("nearform", "acme/lastlight")).toEqual({
+      owner: "nearform",
+      repo: "lastlight",
+    });
+  });
+
+  it("normalizes empty and whitespace to undefined", () => {
+    expect(normalizeRepoRef("", "")).toEqual({ owner: undefined, repo: undefined });
+    expect(normalizeRepoRef("  ", " lastlight ")).toEqual({
+      owner: undefined,
+      repo: "lastlight",
+    });
+  });
+
+  it("keeps an owner with no repo", () => {
+    expect(normalizeRepoRef("nearform", undefined)).toEqual({
+      owner: "nearform",
+      repo: undefined,
+    });
+  });
+
+  it("is idempotent", () => {
+    const once = normalizeRepoRef(undefined, "nearform/lastlight");
+    expect(normalizeRepoRef(once.owner, once.repo)).toEqual(once);
+  });
+});
+
+describe("qualifyRepo", () => {
+  it("joins the stored pair", () => {
+    expect(qualifyRepo("nearform", "lastlight")).toBe("nearform/lastlight");
+  });
+
+  it("does NOT double-qualify a legacy qualified repo", () => {
+    // dispatcher.ts used to join unconditionally and produce
+    // `acme/acme/widgets`, which the dispatch split then read as the repo
+    // `acme` — a different real repository.
+    expect(qualifyRepo("acme", "acme/widgets")).toBe("acme/widgets");
+  });
+
+  it("falls back to the bare name when there is no owner", () => {
+    expect(qualifyRepo(undefined, "lastlight")).toBe("lastlight");
+    expect(qualifyRepo("", "lastlight")).toBe("lastlight");
+  });
+
+  it("returns undefined with no repo", () => {
+    expect(qualifyRepo("nearform", undefined)).toBeUndefined();
+    expect(qualifyRepo("nearform", "")).toBeUndefined();
+  });
+
+  it("round-trips with normalizeRepoRef", () => {
+    const { owner, repo } = normalizeRepoRef(undefined, "nearform/lastlight");
+    expect(qualifyRepo(owner, repo)).toBe("nearform/lastlight");
+  });
+});
+
+describe("qualifiedRepoSql", () => {
+  // Exercised against real SQLite rather than string-matched, because the whole
+  // point of the helper is that the SQL and the JS agree.
+  const rows = [
+    { id: "a", owner: "nearform", repo: "lastlight" }, // the stored shape
+    { id: "b", owner: null, repo: "nearform/lastlight" }, // legacy qualified
+    { id: "c", owner: null, repo: "orphan" }, // un-backfillable
+    { id: "d", owner: "nearform", repo: null }, // no repo
+    { id: "e", owner: "", repo: "orphan" }, // empty-string owner
+  ];
+
+  function evaluate(unqualifiable: "bare" | "null"): Record<string, string | null> {
+    const db = new Database(":memory:");
+    db.exec(`CREATE TABLE t (id TEXT, owner TEXT, repo TEXT)`);
+    const ins = db.prepare(`INSERT INTO t (id, owner, repo) VALUES (?, ?, ?)`);
+    for (const r of rows) ins.run(r.id, r.owner, r.repo);
+    const out = db
+      .prepare(`SELECT id, ${qualifiedRepoSql("owner", "repo", unqualifiable)} AS repo FROM t`)
+      .all() as { id: string; repo: string | null }[];
+    db.close();
+    return Object.fromEntries(out.map((r) => [r.id, r.repo]));
+  }
+
+  it("agrees with qualifyRepo in `bare` mode", () => {
+    const got = evaluate("bare");
+    for (const r of rows) {
+      expect(got[r.id]).toBe(qualifyRepo(r.owner, r.repo) ?? null);
+    }
+    expect(got).toEqual({
+      a: "nearform/lastlight",
+      b: "nearform/lastlight",
+      c: "orphan",
+      d: null,
+      e: "orphan",
+    });
+  });
+
+  it("answers NULL for an un-qualifiable row in `null` mode", () => {
+    // NULL is "no repo, always visible". A bare name here would match nothing
+    // in a qualified allow-list and so HIDE the row — the #278 bug.
+    expect(evaluate("null")).toEqual({
+      a: "nearform/lastlight",
+      b: "nearform/lastlight",
+      c: null,
+      d: null,
+      e: null,
+    });
+  });
+});

--- a/apps/server/tests/state/workflow-run-store.test.ts
+++ b/apps/server/tests/state/workflow-run-store.test.ts
@@ -648,8 +648,25 @@ describe("listActive includes queued", () => {
   });
 });
 
+/**
+ * Insert a run row with raw SQL, bypassing `createRun`'s normalization — the
+ * only way to produce a shape the store would never write itself (issue #279).
+ */
+function makeLegacyRun(overrides: { owner?: string | null; repo: string }): string {
+  const id = randomUUID();
+  db.database
+    .prepare(
+      `INSERT INTO workflow_runs (id, workflow_name, trigger_id, owner, repo, current_phase, status, started_at, updated_at)
+       VALUES (?, 'explore', ?, ?, ?, 'socratic', 'running', ?, ?)`,
+    )
+    .run(id, `slack:${id}`, overrides.owner ?? null, overrides.repo, new Date().toISOString(), new Date().toISOString());
+  return id;
+}
+
 describe("repo-scoped queries", () => {
   it("list({ repo }) returns only that repo's runs, with the post-filter total", () => {
+    // Passing the qualified form is normalized on the way in (issue #279), so
+    // the rows come back as the (owner, BARE repo) pair regardless.
     makeRun({ repo: "acme/api" });
     makeRun({ repo: "acme/api" });
     makeRun({ repo: "acme/web" });
@@ -658,7 +675,7 @@ describe("repo-scoped queries", () => {
     const { runs, total } = db.runs.list({ repo: "acme/api" });
     expect(total).toBe(2);
     expect(runs).toHaveLength(2);
-    expect(runs.every((r) => r.repo === "acme/api")).toBe(true);
+    expect(runs.every((r) => r.owner === "acme" && r.repo === "api")).toBe(true);
 
     // The filter composes with pagination.
     const page = db.runs.list({ repo: "acme/api", limit: 1 });
@@ -684,11 +701,41 @@ describe("repo-scoped queries", () => {
     // `IN (…)` against the column matches no modern row at all, which would
     // silently show an empty dashboard rather than a filtered one.
     makeRun({ owner: "nearform", repo: "lastlight" });
-    // ...alongside a legacy row that stored the qualified string in `repo`.
-    makeRun({ owner: undefined, repo: "nearform/www" });
+    makeRun({ owner: "nearform", repo: "www" });
 
     const { runs } = db.runs.list({ repos: ["nearform/lastlight", "nearform/www"] });
     expect(runs).toHaveLength(2);
+  });
+
+  it("still matches a legacy row the backfill never reached", () => {
+    // The `OR repo = ?` arm of `repoMatchClause` is compatibility, not the rule
+    // (issue #279): `createRun` normalizes and `migrate()` converges the table,
+    // so only a row written by an older process against an un-migrated DB looks
+    // like this. Kept because dropping a row from a filter is the failure mode
+    // that hides things silently — a SELECT is the wrong place to discover that
+    // a backfill didn't run.
+    makeRun({ owner: "nearform", repo: "lastlight" });
+    const legacy = makeLegacyRun({ owner: null, repo: "nearform/www" });
+
+    const { runs } = db.runs.list({ repos: ["nearform/lastlight", "nearform/www"] });
+    expect(runs).toHaveLength(2);
+    expect(runs.map((r) => r.id)).toContain(legacy);
+
+    // …and it reads back NORMALIZED, because `deserialize` is the shim every
+    // consumer crosses. This is what lets admission.ts hand (owner, repo)
+    // straight to Octokit without a split of its own.
+    const read = db.runs.getRun(legacy)!;
+    expect([read.owner, read.repo]).toEqual(["nearform", "www"]);
+  });
+
+  it("distinctRepos() folds a legacy row in with its normalized twin", () => {
+    // The bare-vs-qualified duplicate the /repos union must never show.
+    makeRun({ owner: "nearform", repo: "www", startedAt: "2026-01-01T00:00:00.000Z" });
+    makeLegacyRun({ owner: null, repo: "nearform/www" });
+
+    const repos = db.runs.distinctRepos();
+    expect(repos.filter((r) => r.repo === "nearform/www")).toHaveLength(1);
+    expect(repos.find((r) => r.repo === "nearform/www")!.runCount).toBe(2);
   });
 
   it("list({ repo }) wins over `repos` — the Repos tab's narrower ask", () => {

--- a/apps/server/tests/workflows/admission.test.ts
+++ b/apps/server/tests/workflows/admission.test.ts
@@ -77,6 +77,30 @@ function makeQueuedRunWithAck(
   db.runs.mergeScratch(id, { queuedAck: { commentId } });
 }
 
+/**
+ * The same run, but written the way a process that predates the #279 backfill
+ * wrote it: the qualified `owner/repo` in the `repo` column. Raw SQL, because
+ * `createRun` now normalizes that shape away — which is the point.
+ *
+ * Octokit takes `(owner, repo)` positionally with no normalization of its own,
+ * so a row like this reaching `deleteComment` unsplit would address
+ * `/repos/acme/acme%2Fwidgets/...`.
+ */
+function makeLegacyQueuedRunWithAck(
+  db: StateDb,
+  id: string,
+  startedAt: string,
+  commentId: number,
+): void {
+  db.database
+    .prepare(
+      `INSERT INTO workflow_runs (id, workflow_name, trigger_id, owner, repo, issue_number, current_phase, status, started_at, updated_at)
+       VALUES (?, 'issue-triage', ?, NULL, 'acme/widgets', 215, 'triage', 'queued', ?, ?)`,
+    )
+    .run(id, `acme/widgets#${id.slice(-2)}`, startedAt, startedAt);
+  db.runs.mergeScratch(id, { queuedAck: { commentId } });
+}
+
 function makeGithubStub() {
   return {
     postComment: vi.fn(async () => 1),
@@ -289,6 +313,46 @@ describe("createAdmissionController", () => {
     expect(github.deleteComment).toHaveBeenCalledWith("acme", "widgets", 5060108290);
     // Retracted, not rewritten — the run's own output is the real answer now.
     expect(github.updateComment).not.toHaveBeenCalled();
+  });
+
+  it("admitNext: passes Octokit the BARE repo even for a legacy qualified row", async () => {
+    // The sharp edge of #279. This code path hands `(run.owner, run.repo)`
+    // straight to Octokit with no split of its own — correct only because the
+    // store normalizes on read-back. Without that shim this would call
+    // `deleteComment("", "acme/widgets", …)`.
+    makeLegacyQueuedRunWithAck(db, "run-legacy", "2024-01-01T00:00:00.000Z", 5060108290);
+    const github = makeGithubStub();
+
+    const ctrl = createAdmissionController({
+      db,
+      resumeOpts: { ...makeResumeOpts(db), github: github as never },
+      maxWorkflows: 4,
+      maxQueueWaitMs: 1_800_000,
+    });
+    await ctrl.admitNext();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(github.deleteComment).toHaveBeenCalledWith("acme", "widgets", 5060108290);
+  });
+
+  it("sweep: rewrites a legacy qualified row's ack against the BARE repo", async () => {
+    // The updateComment twin of the above — the other Octokit call reachable
+    // from a stored repo identifier.
+    const oldTime = new Date(Date.now() - 3_600_000).toISOString();
+    makeLegacyQueuedRunWithAck(db, "gh-legacy-stale", oldTime, 777);
+    const github = makeGithubStub();
+
+    const ctrl = createAdmissionController({
+      db,
+      resumeOpts: { ...makeResumeOpts(db), github: github as never },
+      maxWorkflows: 4,
+      maxQueueWaitMs: 1_800_000,
+    });
+    await ctrl.sweep();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [owner, repo] = github.updateComment.mock.calls[0] as unknown as [string, string];
+    expect([owner, repo]).toEqual(["acme", "widgets"]);
   });
 
   it("admitNext: admits normally when no ack was recorded (Slack / failed post)", async () => {

--- a/apps/server/tests/workflows/generic-loop-check-row.test.ts
+++ b/apps/server/tests/workflows/generic-loop-check-row.test.ts
@@ -301,6 +301,26 @@ describe("generic loop — the until_bash check is an open execution row in flig
     expect(store.executionRows("fix_iter_1_check")[0]!.dedupKey).toBe(`${WF}:fix_iter_1_check`);
   });
 
+  it("stamps every ledger row with the (owner, BARE repo) pair", async () => {
+    // The engine writes what `GitSandboxAccess` already carries — the pair,
+    // never a qualified string (issue #279). It used to write only the bare
+    // half, leaving the account recoverable solely by joining the owning run,
+    // which a `build-cycle` or chat row does not have.
+    //
+    // The in-memory fake dropped both fields entirely until #279, so no
+    // engine-side test could observe this at all.
+    const { store } = await runLoop(defineLoop({ max_iterations: 1, until_bash: GATE_CMD }), {
+      iterations: [agentOk("worked on it")],
+      gates: [gateRed],
+    });
+
+    const rows = store.executionRows();
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect([row.owner, row.repo]).toEqual(["acme", "widgets"]);
+    }
+  });
+
   it("closes the row with a duration once the command returns", async () => {
     const { store } = await runLoop(defineLoop({ max_iterations: 1, until_bash: GATE_CMD }), {
       iterations: [agentOk("worked on it")],

--- a/apps/server/tests/workflows/runner.test.ts
+++ b/apps/server/tests/workflows/runner.test.ts
@@ -611,6 +611,8 @@ describe("runWorkflow — requires_sandbox gate", () => {
       "gated:demo",
       expect.any(String),
       undefined,
+      // The (owner, BARE repo) pair, not a qualified string (issue #279).
+      expect.any(String),
       expect.any(String),
     );
   });
@@ -656,6 +658,8 @@ describe("runWorkflow — requires_sandbox gate", () => {
       "qa:browser",
       expect.any(String),
       undefined,
+      // The (owner, BARE repo) pair, not a qualified string (issue #279).
+      expect.any(String),
       expect.any(String),
     );
   });

--- a/packages/workflow-engine/src/core/phase-executor.ts
+++ b/packages/workflow-engine/src/core/phase-executor.ts
@@ -243,6 +243,21 @@ async function isContainerAlive(liveness: LivenessPort, taskId: string): Promise
   }
 }
 
+/**
+ * The `owner/repo` a TELEMETRY consumer expects to filter traces by.
+ *
+ * The engine carries the pair separately everywhere else — that is the storage
+ * and Octokit shape (see {@link NewExecution}) — and a span attribute is the
+ * one place a whole repository name is more useful than either half. This
+ * package depends only on `zod` and may never reach `lastlight-shared` or
+ * `lastlight-core`, so it cannot import that repo's `state/repo-ref.ts`; the
+ * rule is small enough to restate, and the pair is right here on the row.
+ */
+export function telemetryRepo(access: GitSandboxAccess | undefined): string | undefined {
+  if (!access?.repo) return undefined;
+  return access.owner ? `${access.owner}/${access.repo}` : access.repo;
+}
+
 type RunPhaseResult =
   | { result: ExecutionResult; executionId: string; skipped: false }
   | { result: ExecutionResult; skipped: false }
@@ -267,13 +282,15 @@ async function runPhaseLedger(
     phaseName: string;
     taskId: string;
     triggerId: string;
+    /** BARE repo name + its account — the pair, never a qualified string. */
     repo?: string;
+    owner?: string;
     workflowRunId?: string;
   },
   deps: LedgerDeps,
   run: (onSessionId: (sessionId: string) => void) => Promise<ExecutionResult>,
 ): Promise<RunPhaseResult> {
-  const { dedupKey, phaseName, taskId, triggerId, repo, workflowRunId } = meta;
+  const { dedupKey, phaseName, taskId, triggerId, repo, owner, workflowRunId } = meta;
   const { store: db, liveness, observability } = deps;
   const log = deps.logger ?? noopLogger;
   return observability.withSpan("lastlight.workflow.phase", attrs, async (span) => {
@@ -301,6 +318,7 @@ async function runPhaseLedger(
         triggerType: "webhook",
         triggerId,
         skill: dedupKey,
+        owner,
         repo,
         issueNumber: issueNumberFromTrigger(triggerId),
         startedAt: new Date().toISOString(),
@@ -383,7 +401,7 @@ export async function runPhase(
     "workflow.run_id": workflowRunId,
     "trigger.id": triggerId,
     "task.id": taskId,
-    repo: githubAccess?.repo,
+    repo: telemetryRepo(githubAccess),
     "issue.number": issueNumberFromTrigger(triggerId),
     "sandbox.backend": config.sandbox,
     model: modelOverride || config.model,
@@ -395,7 +413,7 @@ export async function runPhase(
     ...phaseConfigBase,
     telemetry: { workflowName, phaseName, triggerId, workflowRunId },
   };
-  return runPhaseLedger(attrs, { dedupKey, phaseName, taskId, triggerId, repo: githubAccess?.repo, workflowRunId }, deps, (onSessionId) =>
+  return runPhaseLedger(attrs, { dedupKey, phaseName, taskId, triggerId, repo: githubAccess?.repo, owner: githubAccess?.owner, workflowRunId }, deps, (onSessionId) =>
     deps.agent.runAgent(prompt, phaseConfig, { taskId, githubAccess, onSessionId }),
   );
 }
@@ -425,14 +443,14 @@ export async function runCommandPhase(
     "workflow.run_id": workflowRunId,
     "trigger.id": triggerId,
     "task.id": taskId,
-    repo: githubAccess?.repo,
+    repo: telemetryRepo(githubAccess),
     "issue.number": issueNumberFromTrigger(triggerId),
     "sandbox.backend": config.sandbox,
     model: spec.kind,
     [OPENINFERENCE_SPAN_KIND]: OPENINFERENCE_CHAIN,
   };
   const phaseConfig: ExecutorConfig = { ...config, telemetry: { workflowName, phaseName, triggerId, workflowRunId } };
-  return runPhaseLedger(attrs, { dedupKey, phaseName, taskId, triggerId, repo: githubAccess?.repo, workflowRunId }, deps, (onSessionId) =>
+  return runPhaseLedger(attrs, { dedupKey, phaseName, taskId, triggerId, repo: githubAccess?.repo, owner: githubAccess?.owner, workflowRunId }, deps, (onSessionId) =>
     deps.agent.runCommand(spec, phaseConfig, { taskId, githubAccess, onSessionId, timeoutSeconds, sandboxEnv }),
   );
 }
@@ -811,6 +829,7 @@ export class PhaseExecutor {
           triggerType: "webhook",
           triggerId,
           skill: `${definition.name}:${label}`,
+          owner: githubAccess?.owner,
           repo: githubAccess?.repo,
           issueNumber: issueNumberFromTrigger(triggerId),
           startedAt: new Date(startedAt).toISOString(),

--- a/packages/workflow-engine/src/core/scheduler.ts
+++ b/packages/workflow-engine/src/core/scheduler.ts
@@ -4,7 +4,7 @@ import type { TemplateContext } from "./templates.js";
 import { renderTemplate } from "./templates.js";
 import { evalSkipIf } from "./loop-eval.js";
 import { buildDag, getReadyNodes, getNodesToSkip, isComplete } from "./dag.js";
-import { PhaseExecutor, type PhaseRunContext } from "./phase-executor.js";
+import { PhaseExecutor, telemetryRepo, type PhaseRunContext } from "./phase-executor.js";
 import { OPENINFERENCE_CHAIN, OPENINFERENCE_SPAN_KIND } from "./types.js";
 import type {
   EnginePorts,
@@ -76,7 +76,7 @@ export async function runWorkflowCore(
     "workflow.name": definition.name,
     "workflow.run_id": workflowId,
     "trigger.id": triggerId,
-    repo: githubAccess.repo,
+    repo: telemetryRepo(githubAccess),
     "sandbox.backend": config.sandbox,
     [OPENINFERENCE_SPAN_KIND]: OPENINFERENCE_CHAIN,
   };
@@ -137,6 +137,7 @@ export async function runWorkflowCore(
         triggerId,
         workflowId,
         githubAccess.repo,
+        githubAccess.owner,
       );
       await reportStep(node.name, "skipped");
     }
@@ -192,6 +193,7 @@ export async function runWorkflowCore(
           triggerId,
           workflowId,
           githubAccess.repo,
+          githubAccess.owner,
         );
         await reportStep(node.name, "skipped", phaseDef?.messages?.on_skipped_done);
       }

--- a/packages/workflow-engine/src/ports/ports.ts
+++ b/packages/workflow-engine/src/ports/ports.ts
@@ -142,6 +142,17 @@ export interface NewExecution {
   triggerType: "webhook" | "cron" | "chat" | "api";
   triggerId: string;
   skill: string;
+  /**
+   * GitHub org/user that owns {@link repo}. Both come straight off
+   * {@link GitSandboxAccess}, which already carries them separately.
+   */
+  owner?: string;
+  /**
+   * The BARE repo name — a single path-safe segment, NOT `owner/repo`. The two
+   * travel as a pair everywhere the engine touches a repository, so an embedder
+   * can hand them to Octokit without splitting anything (lastlight-core stores
+   * them as two columns for the same reason).
+   */
   repo?: string;
   issueNumber?: number;
   startedAt: string;
@@ -187,7 +198,8 @@ export interface ExecutionLedger {
   recordFinish(id: string, result: ExecutionFinish): void;
   recordSessionId(id: string, sessionId: string): void;
   recordOutputText(id: string, text: string): void;
-  recordSkippedPhase(dedupKey: string, triggerId: string, workflowRunId?: string, repo?: string): void;
+  /** `repo` is the BARE name and `owner` its account — see {@link NewExecution}. */
+  recordSkippedPhase(dedupKey: string, triggerId: string, workflowRunId?: string, repo?: string, owner?: string): void;
   getPhaseOutput(dedupKey: string, triggerId: string, workflowRunId?: string): string | null;
   getExecutionOutput(id: string): string | null;
 }

--- a/packages/workflow-engine/src/test-support/fakes.ts
+++ b/packages/workflow-engine/src/test-support/fakes.ts
@@ -103,6 +103,13 @@ export interface FakeExecutionRow {
   dedupKey: string;
   triggerId: string;
   workflowRunId?: string;
+  /**
+   * The (owner, BARE repo) pair the row was written with. Recorded because it
+   * was silently dropped here, so no engine-side test could observe what the
+   * phase executor actually put on the ledger (issue #279).
+   */
+  owner?: string;
+  repo?: string;
   startedAt: string;
   success?: boolean;
   finished: boolean;
@@ -231,6 +238,8 @@ export class InMemoryStateStore implements WorkflowStateStore {
         dedupKey: rec.skill,
         triggerId: rec.triggerId,
         workflowRunId: rec.workflowRunId,
+        owner: rec.owner,
+        repo: rec.repo,
         startedAt: rec.startedAt,
         finished: false,
       };
@@ -253,12 +262,14 @@ export class InMemoryStateStore implements WorkflowStateStore {
       const row = this.byExecId.get(id);
       if (row) row.output = text;
     },
-    recordSkippedPhase: (dedupKey, triggerId, workflowRunId) => {
+    recordSkippedPhase: (dedupKey, triggerId, workflowRunId, repo, owner) => {
       const row: LedgerRow = {
         id: `skipped:${dedupKey}`,
         dedupKey,
         triggerId,
         workflowRunId,
+        owner,
+        repo,
         startedAt: new Date().toISOString(),
         finished: true,
         success: false,


### PR DESCRIPTION
Closes #279.

## The problem

The same column meant two things depending on who wrote it.

- **`workflow_runs.repo`** is documented BARE with the account in a separate `owner` column, but rows written before that split hold the qualified `owner/repo` in `repo` itself. Both shapes were live.
- **`executions.repo`** had no `owner` column at all. The dispatcher wrote the qualified string; the phase executor wrote the bare name — which is *every workflow phase row*, i.e. the bulk of the table.

Six read sites each re-derived "may be bare or qualified", and they disagreed about which source wins:

| Site | Precedence it used |
|---|---|
| `distinctRepos()` | `owner` column, only if `repo` has no slash |
| `repoMatchClause()` | matched **both** shapes via OR |
| `QUALIFIED_REPO_SQL` | `e.repo` prefix, else JOIN `workflow_runs.owner` |
| `ownerRepoForRun()` / `/approvals/:id` | `context.owner` first, then split `repo` |
| `resume.ts` / `index.ts` | `triggerId` first, then `context.owner` + `repo` |
| `dashboard/githubLinks.ts` | qualified `repo` → `owner` col → `context.owner` → `triggerId` |

#278 shipped a filter built on one of those readings, compared `lastlight` against `{nearform/lastlight}`, and a non-null non-match **hides** rows rather than showing them.

## The direction — and why it inverts the issue

The issue proposed storing the qualified `owner/repo`. This does the opposite: **`owner` + a BARE `repo`, on both tables.**

1. It is the invariant `migrate.ts` already states and that `simple.ts` / `pr-escalation.ts` already write. `repo` stays a single path-safe segment because `workflowScopedTaskId` and `prNotesRepoDir` build filesystem paths out of it.
2. It makes all four repo-bearing tables agree — `feedback_anchors` and `feedback_signals` always carried the pair, and so does `GitSandboxAccess`.
3. The ~35 `GitHubClient` methods take `(owner, repo)` positionally with zero normalization. Storing the pair leaves every one of them correct **by construction**, instead of dependent on remembering to split. That is the sharp edge the issue was most worried about, and this removes it rather than spreading it.

Two acceptance criteria therefore invert: new rows store the **bare** name, and `distinctRepos()`'s recomposition **survives** as the single canonical join. What actually goes away is the four independent copies of the rule and every de-qualifying split on the read side.

## What's here

| Layer | Change |
|---|---|
| `state/repo-ref.ts` (new) | The one rule: `qualifyRepo` (JS), `qualifiedRepoSql` (SQL), `normalizeRepoRef` (inverse). The SQL twin takes an explicit `"bare" \| "null"` for the un-qualifiable case, because those answers are opposites — `null` is "always visible", a bare name matches nothing in a qualified allow-list and so *hides* the row. |
| `state/migrate.ts` | Idempotent backfill of both tables + `executions.owner`. `workflow_runs` first — the executions owner is recovered by joining it. |
| Both stores | The invariant is enforced at the write choke points (`createRun`, `recordStart`) and again on read-back (`deserialize`), so a fixture or a future caller can't reintroduce a third shape. |
| `lastlight-workflow-engine` | `NewExecution.owner` + an optional 5th `recordSkippedPhase` param. Both additive. `GitSandboxAccess` already carried the pair, so nothing new is threaded. |
| Readers | `QUALIFIED_REPO_SQL` no longer needs `LEFT JOIN workflow_runs` — **removed from all three sites**, including the chat-thread list aggregate. `ownerRepoForRun` and the `/approvals/:id` block drop their splits entirely. |

## Three live wrong-repo hazards, each with a test that fails without the fix

- **`admission.ts`** `deleteComment` / `updateComment` on a queued run's ack — the two the issue named.
- **`cron/feedback-poll.ts` `listBotComments`** — *not in the issue*. It hangs off the terminal-run observer, so it fires for **every** finished run, and the bad value is persisted onward onto the `feedback_anchors` row: `anchorUrl` then mints a corrupt permalink that outlives the run.
- **`dispatcher.ts`** explore-reply joined unconditionally, so a qualified `run.repo` produced `acme/acme/widgets` — which `index.ts`'s split then read as the repo `acme`, **a different real repository**, silently.

`review-check.ts` was audited and is safe (its `owner`/`repo` come from `scratch`, written from the canonical dispatch split). `fix-harvest.ts` was already correct.

Two smaller disagreements fixed along the way: the chat **single-thread** read used the raw column while its own **list** view qualified, so they disagreed for one thread; and `searchErrors` matched `repo` against the bare column, so searching `nearform/lastlight` found no phase row at all.

## Verification

Full gate green — 21/21 turbo tasks, 2802 server tests, dashboard typecheck.

**Run against real data, not just fixtures.** I took a snapshot of drizby prod (1507 runs, 2083 executions) and ran the *real* `migrate()` against it:

- row counts unchanged
- **0** stray slashes in either table
- **0** rows left with a repo and no owner
- byte-identical output across three passes (idempotent)

The nearform instance previews the same (575 runs, 794 executions, 0 unresolvable). The snapshot was deleted afterwards.

One thing that check changed: drizby had 8 rows the backfill couldn't reach, all with the account sitting in their `trigger_id`. Since `resume.ts` and the approval-resume path already *prefer* `trigger_id` over the columns, reading it there is the existing precedence rather than a new guess — so the migration does, and those 8 resolve.

The `OR repo = ?` arm of `repoMatchClause` and `normalizeRepoRef`-on-read survive **only** as documented legacy handling, with tests that insert an un-backfillable row via raw SQL to cover them.

**Not verified:** I haven't run the dashboard and looked at the Repos tab or a chat thread's repo badge. Both are typechecked and the SQL is tested against real row shapes, but nothing has been seen rendered.

## Follow-up, not fixed here

`allExecutions` / `runningExecutions` / `recentExecutions` cast raw snake_case rows straight to camelCase `ExecutionRecord`, so `issueNumber`, `startedAt` and `workflowRunId` are always `undefined`. The Slack status report already renders `(started undefined)` and the cancel loop in `routes.ts` never matches a row. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)