### PR TITLE
fix: populate ExecutionRecord reads (#285) + survive a missing statuses:read (#277)

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ If KVM isn't available, fall back to the Docker deploy above with `LASTLIGHT_SAN
    - **Pull Requests**: Read & Write
    - **Contents**: Read & Write
    - **Checks**: Read & Write (post the `last-light/review` check; receive its "Re-run" requests)
+   - **Commit statuses**: Read (classic CI statuses — CircleCI, Jenkins, other external CI. Separate from **Checks**; without it CI is judged on check runs alone)
    - **Metadata**: Read
 4. Subscribe to **events**: `Issues`, `Pull request`, `Issue comment`, `Check run`, `Check suite` (the last two enable the GitHub "Re-run checks" buttons to re-trigger a review)
 5. Click **Create GitHub App**

--- a/apps/server/dashboard/src/api.ts
+++ b/apps/server/dashboard/src/api.ts
@@ -41,19 +41,34 @@ export interface Message {
   [k: string]: unknown;
 }
 
+/**
+ * A row from `GET /admin/api/executions`. Hand-mirrors `ExecutionRecord`
+ * (`apps/server/src/state/execution-store.ts`) — camelCase, because that
+ * endpoint returns the record verbatim.
+ *
+ * It was snake_case until issue #285, matching the raw table rather than the
+ * type the endpoint claimed to return: the query behind it was a `SELECT *`
+ * cast to `ExecutionRecord[]`, so the wire shape really was snake_case and the
+ * server type was the one that lied. Aliasing the query settled it the other
+ * way, and no component reads this yet, so the mirror simply follows.
+ */
 export interface Execution {
   id: string;
-  trigger_type: string;
-  trigger_id: string;
+  triggerType: string;
+  triggerId: string;
+  triggeredBy?: string;
   skill: string;
-  repo: string | null;
-  issue_number: number | null;
-  started_at: string;
-  finished_at: string | null;
-  success: number | null;
-  error: string | null;
-  turns: number | null;
-  duration_ms: number | null;
+  owner?: string;
+  /** BARE repo name — join with `owner` for display. */
+  repo?: string;
+  issueNumber?: number;
+  startedAt: string;
+  finishedAt?: string;
+  success?: boolean;
+  error?: string;
+  turns?: number;
+  durationMs?: number;
+  workflowRunId?: string;
 }
 
 export interface PhaseHistoryEntry {

--- a/apps/server/spec/03-integrations.md
+++ b/apps/server/spec/03-integrations.md
@@ -225,6 +225,16 @@ Grant Actions: read for full CI output.
 
 The notice is suppressed when none of the failed checks is a GitHub Actions job (a CircleCI-only repo has no Actions logs to be missing, so blaming the permission there would be wrong). The same permission backs agentic-pi's `github_list_workflow_runs` / `github_list_workflow_run_jobs` / `github_get_job_logs` tools, which return `{ ok: false, reason }` rather than throwing when it is absent.
 
+### App permission: `Commit statuses: read` (optional, recommended)
+
+The same shape again, one API over: `Checks: read` gets the harness **check runs**. It does *not* get it the **classic commit statuses** a repo's CI may post instead (CircleCI, Jenkins, anything using the legacy statuses API). GitHub exposes the two as separate permissions over separate endpoints, and neither implies the other.
+
+`GitHubClient.getChecksSummary` reads both, because the settle-aware verdict is meant to cover a repo whose CI reports *only* via statuses — exactly the population the live `check_suite` webhook never sees. The status leg is `repos.getCombinedStatusForRef`, which needs `Commit statuses: read`.
+
+**The additive half must not be able to fail the whole read** (issue #277). The two calls were a `Promise.all`, which rejects on the first rejection — so an App holding `checks` but not `statuses` 403'd on the status leg and discarded the check-runs result *it was permitted to read*, losing its entire CI signal rather than the legacy half of it. Nothing surfaced it: `statuses` is requested by no scoped-token profile, so the token still mints (no 422) and the 403 arrives at call time; the run then completes and records `success = true` while every CI gate reads blind. It is now a `Promise.allSettled` — a rejected check-runs leg still throws, a rejected status leg degrades to "no status contexts", and the ref is judged on check runs alone.
+
+That degradation is stated rather than inferred, and stated **once per owner per process**: the grant is per installation and the read runs on every `pr.synchronize` and every check settle, so a line per call buries the finding in tens of identical warnings a day.
+
 ### App permission: organization `Members: read` (optional, opt-in)
 
 Required by, and only by, **per-repo dashboard visibility** (`teamVisibility`,

--- a/apps/server/spec/10-state.md
+++ b/apps/server/spec/10-state.md
@@ -711,6 +711,16 @@ session recreation after timeouts.
   5 s; reading `context` + `scratch` + `node_statuses` for every row
   would dominate the query cost. The list endpoint's projection is
   deliberate.
+- **A read that returns an `ExecutionRecord` aliases every column.** The
+  table is snake_case and the record is camelCase, so `SELECT *` cast to
+  `ExecutionRecord[]` type-checks and silently yields `undefined` for every
+  multi-word field — `issueNumber`, `startedAt`, `workflowRunId` (issue #285).
+  It is not detectable by the compiler and it was not detectable by a test that
+  never read those fields, so three reads had drifted: the Slack status report
+  rendered `(started undefined)` and the admin cancel loop filtered
+  `runningExecutions()` on a `workflowRunId` that matched no row. `ExecutionStore`
+  now holds ONE aliased column list and ONE row mapper, shared by all four
+  record-returning reads, so a new column is added to both or to neither.
 
 ## Current implementation
 

--- a/apps/server/src/engine/dispatcher.ts
+++ b/apps/server/src/engine/dispatcher.ts
@@ -218,9 +218,12 @@ export async function dispatch(
     if (running.length === 0) {
       await envelope.reply("No tasks currently running.");
     } else {
-      const lines = running.map((r) =>
-        `• *${r.skill}*${r.repo ? ` on ${r.repo}` : ""}${r.issueNumber ? ` #${r.issueNumber}` : ""} (started ${r.startedAt})`,
-      );
+      // A status report is a user-facing surface, so it speaks the qualified
+      // `owner/repo` the ledger stores split (issue #279).
+      const lines = running.map((r) => {
+        const repo = qualifyRepo(r.owner, r.repo);
+        return `• *${r.skill}*${repo ? ` on ${repo}` : ""}${r.issueNumber ? ` #${r.issueNumber}` : ""} (started ${r.startedAt})`;
+      });
       await envelope.reply(`Running tasks:\n${lines.join("\n")}`);
     }
     return { kind: "handled", handler };

--- a/apps/server/src/engine/github/github.ts
+++ b/apps/server/src/engine/github/github.ts
@@ -2,6 +2,9 @@ import type { Octokit } from "octokit";
 import { githubAppClient, githubTokenClient } from "./github-app-client.js";
 import { getInstallationDirectory } from "./installations.js";
 import type { InlineComment, ReviewEvent } from "./review-poster.js";
+import { logger } from "../../logging/logger.js";
+
+const log = logger("github");
 
 /** GitHub reaction emoji values accepted by the reactions API. */
 export type ReactionContent =
@@ -1239,7 +1242,9 @@ export class GitHubClient {
    * It combines check_runs (GitHub Actions et al.) with the combined commit
    * status (classic contexts: CircleCI, external CI) so a repo whose CI reports
    * only via statuses — exactly the kind the live `check_suite` webhook never
-   * sees — isn't invisible to the backstop.
+   * sees — isn't invisible to the backstop. The status half is **additive**: an
+   * App without `Commit statuses: read` still gets a verdict from the check
+   * runs (issue #277; see {@link getChecksSummary}).
    *
    *   "none"    — no check_runs AND no status contexts (nothing to judge).
    *   "pending" — a check_run is queued/in_progress, or the combined status is
@@ -1293,10 +1298,28 @@ export class GitHubClient {
     pendingCount: number;
   }> {
     const kit = await this.kit(owner);
-    const [{ data: checks }, { data: status }] = await Promise.all([
+    // `allSettled`, not `all` — the two legs need different permissions and
+    // only one of them is load-bearing (issue #277). `getCombinedStatusForRef`
+    // requires `Commit statuses: read`, which **`Checks: read` does not imply**
+    // and which the setup docs omitted for a long time. Under `Promise.all` a
+    // 403 on that leg discarded the check-runs result too — so an App missing
+    // only `statuses` lost its ENTIRE CI signal, including the half it was
+    // permitted to read, and every `pr.synchronize` / settle event read blind
+    // while the run still recorded success. Check runs alone are a usable
+    // signal, so the status leg degrades to "no status contexts" instead.
+    const [checksRes, statusRes] = await Promise.allSettled([
       kit.rest.checks.listForRef({ owner, repo, ref, filter: "latest" }),
       kit.rest.repos.getCombinedStatusForRef({ owner, repo, ref }),
     ]);
+    if (checksRes.status === "rejected") throw checksRes.reason;
+    const checks = checksRes.value.data;
+    if (statusRes.status === "rejected") noteMissingCombinedStatus(owner, statusRes.reason);
+    // The degraded shape is EMPTY, not green: `statuses: []` makes every use of
+    // `state` below inert (both the pending and the failing test are gated on
+    // there being contexts), so the ref is judged purely on its check runs and
+    // the unreadable half can neither fail it nor pad `settledCount`.
+    const status: { state: string; statuses?: Array<unknown> } =
+      statusRes.status === "fulfilled" ? statusRes.value.data : { state: "success", statuses: [] };
     // Drop OUR OWN check runs when the caller is deciding whether to TRIGGER
     // work — see {@link ChecksQueryOptions.excludeApp} — then collapse each
     // check to the run that survives a re-run ({@link latestPerCheck}), so a
@@ -1779,6 +1802,40 @@ function decodeJobLog(data: unknown): string | null {
     return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("utf8");
   }
   return null;
+}
+
+/**
+ * `<owner>:<cause>` pairs we have already reported a combined-status read
+ * failure for.
+ *
+ * The permission is granted per **installation**, so one owner's answer holds
+ * for every repo and every ref under it — and the read runs on every
+ * `pr.synchronize` and every check settle. Logging each one buried the finding
+ * in ~30 identical warn lines a day (issue #277); the point of the line is to
+ * name a missing grant once, and the grant does not change mid-process.
+ */
+const combinedStatusWarned = new Set<string>();
+
+/**
+ * Report — once per owner per cause — that the combined commit status could not
+ * be read, so {@link GitHubClient.getChecksSummary} is judging the ref on check
+ * runs alone. A 403 means the App lacks `Commit statuses: read`; anything else
+ * is transient, and both degrade the same way, so the line states the status and
+ * lets the reader decide.
+ */
+function noteMissingCombinedStatus(owner: string, err: unknown): void {
+  const status = httpStatus(err);
+  // Keyed on the CAUSE as well as the owner, so a burst of transient 5xx can't
+  // permanently suppress the one line that names a missing grant.
+  const key = `${owner}:${status === 403 ? "forbidden" : "other"}`;
+  if (combinedStatusWarned.has(key)) return;
+  combinedStatusWarned.add(key);
+  log.warn(
+    status === 403
+      ? "Combined commit status is not readable (the App lacks `Commit statuses: read`) — judging checks on check runs alone"
+      : "Combined commit status read failed — judging checks on check runs alone",
+    { owner, status, err },
+  );
 }
 
 /** Classify a failed job-log download — see {@link CiLogUnavailableCause}. */

--- a/apps/server/src/state/execution-store.ts
+++ b/apps/server/src/state/execution-store.ts
@@ -95,6 +95,87 @@ export interface ExecutionRecord {
  */
 const QUALIFIED_REPO_SQL = qualifiedRepoSql("e.owner", "e.repo", "null");
 
+/**
+ * The column list every read that returns an {@link ExecutionRecord} selects.
+ *
+ * The table is snake_case and the record is camelCase, so `SELECT *` does not
+ * produce an `ExecutionRecord` — it produces a row that *looks* like one for
+ * the handful of single-word columns and silently leaves `issueNumber`,
+ * `startedAt` and `workflowRunId` `undefined` (issue #285). Three reads did
+ * exactly that, and the cast to `ExecutionRecord[]` made the compiler agree.
+ * The Slack status report rendered `(started undefined)` and the admin cancel
+ * loop filtered on a `workflowRunId` that never matched a row.
+ *
+ * So the aliasing lives in ONE place rather than being re-typed per query, and
+ * {@link mapExecutionRow} is its other half — a new column is added to both or
+ * to neither. No table alias is used, so this works in any single-table query.
+ */
+const EXECUTION_COLUMNS = `
+  id,
+  trigger_type      AS triggerType,
+  trigger_id        AS triggerId,
+  triggered_by      AS triggeredBy,
+  trigger_actor_type AS triggerActorType,
+  skill,
+  owner,
+  repo,
+  issue_number      AS issueNumber,
+  started_at        AS startedAt,
+  finished_at       AS finishedAt,
+  success,
+  error,
+  turns,
+  duration_ms       AS durationMs,
+  session_id        AS sessionId,
+  cost_usd          AS costUsd,
+  input_tokens      AS inputTokens,
+  cache_creation_input_tokens AS cacheCreationInputTokens,
+  cache_read_input_tokens     AS cacheReadInputTokens,
+  output_tokens     AS outputTokens,
+  api_duration_ms   AS apiDurationMs,
+  stop_reason       AS stopReason,
+  extension_status  AS extensionStatus,
+  skills_status     AS skillsStatus,
+  workflow_run_id   AS workflowRunId
+`;
+
+/**
+ * Turn a row selected with {@link EXECUTION_COLUMNS} into an
+ * {@link ExecutionRecord}: SQLite NULLs become `undefined` (the record's
+ * optional fields) and the `success` integer becomes a boolean.
+ */
+function mapExecutionRow(r: Record<string, unknown>): ExecutionRecord {
+  const nul = <T>(v: unknown): T | undefined => (v === null || v === undefined ? undefined : (v as T));
+  return {
+    id: r.id as string,
+    triggerType: r.triggerType as ExecutionRecord["triggerType"],
+    triggerId: r.triggerId as string,
+    triggeredBy: nul<string>(r.triggeredBy),
+    triggerActorType: nul<TriggerActorType>(r.triggerActorType),
+    skill: r.skill as string,
+    owner: nul<string>(r.owner),
+    repo: nul<string>(r.repo),
+    issueNumber: nul<number>(r.issueNumber),
+    startedAt: r.startedAt as string,
+    finishedAt: nul<string>(r.finishedAt),
+    success: r.success === null || r.success === undefined ? undefined : Boolean(r.success),
+    error: nul<string>(r.error),
+    turns: nul<number>(r.turns),
+    durationMs: nul<number>(r.durationMs),
+    sessionId: nul<string>(r.sessionId),
+    costUsd: nul<number>(r.costUsd),
+    inputTokens: nul<number>(r.inputTokens),
+    cacheCreationInputTokens: nul<number>(r.cacheCreationInputTokens),
+    cacheReadInputTokens: nul<number>(r.cacheReadInputTokens),
+    outputTokens: nul<number>(r.outputTokens),
+    apiDurationMs: nul<number>(r.apiDurationMs),
+    stopReason: nul<string>(r.stopReason),
+    extensionStatus: nul<string>(r.extensionStatus),
+    skillsStatus: nul<string>(r.skillsStatus),
+    workflowRunId: nul<string>(r.workflowRunId),
+  };
+}
+
 export class ExecutionStore {
   constructor(private db: Database.Database) {}
 
@@ -575,12 +656,13 @@ export class ExecutionStore {
 
   /** Get recent executions for a skill */
   recentExecutions(skill: string, limit = 10): ExecutionRecord[] {
-    return this.db.prepare(`
-      SELECT * FROM executions
+    const rows = this.db.prepare(`
+      SELECT ${EXECUTION_COLUMNS} FROM executions
       WHERE skill = ?
       ORDER BY started_at DESC
       LIMIT ?
-    `).all(skill, limit) as ExecutionRecord[];
+    `).all(skill, limit) as Array<Record<string, unknown>>;
+    return rows.map(mapExecutionRow);
   }
 
   /** Count consecutive failures for a skill (for cron failure tracking) */
@@ -602,11 +684,12 @@ export class ExecutionStore {
 
   /** Get all executions with pagination */
   allExecutions(limit = 100, offset = 0): ExecutionRecord[] {
-    return this.db.prepare(`
-      SELECT * FROM executions
+    const rows = this.db.prepare(`
+      SELECT ${EXECUTION_COLUMNS} FROM executions
       ORDER BY started_at DESC
       LIMIT ? OFFSET ?
-    `).all(limit, offset) as ExecutionRecord[];
+    `).all(limit, offset) as Array<Record<string, unknown>>;
+    return rows.map(mapExecutionRow);
   }
 
   /**
@@ -679,70 +762,24 @@ export class ExecutionStore {
   getExecutionsForWorkflowRun(workflowRunId: string, triggerId: string, workflowName?: string): ExecutionRecord[] {
     const skillPattern = workflowName ? `${workflowName}:%` : "%:%";
     const rows = this.db.prepare(`
-      SELECT
-        id,
-        trigger_type    AS triggerType,
-        trigger_id      AS triggerId,
-        skill,
-        repo,
-        issue_number    AS issueNumber,
-        started_at      AS startedAt,
-        finished_at     AS finishedAt,
-        success,
-        error,
-        turns,
-        duration_ms     AS durationMs,
-        session_id      AS sessionId,
-        cost_usd        AS costUsd,
-        input_tokens    AS inputTokens,
-        cache_creation_input_tokens AS cacheCreationInputTokens,
-        cache_read_input_tokens     AS cacheReadInputTokens,
-        output_tokens   AS outputTokens,
-        api_duration_ms AS apiDurationMs,
-        stop_reason     AS stopReason,
-        extension_status AS extensionStatus,
-        skills_status   AS skillsStatus,
-        workflow_run_id AS workflowRunId
+      SELECT ${EXECUTION_COLUMNS}
       FROM executions
       WHERE (workflow_run_id = ? OR (workflow_run_id IS NULL AND trigger_id = ?))
         AND skill LIKE ?
       ORDER BY started_at ASC
     `).all(workflowRunId, triggerId, skillPattern) as Array<Record<string, unknown>>;
 
-    return rows.map((r) => ({
-      id: r.id as string,
-      triggerType: r.triggerType as ExecutionRecord["triggerType"],
-      triggerId: r.triggerId as string,
-      skill: r.skill as string,
-      repo: (r.repo as string | null) ?? undefined,
-      issueNumber: (r.issueNumber as number | null) ?? undefined,
-      startedAt: r.startedAt as string,
-      finishedAt: (r.finishedAt as string | null) ?? undefined,
-      success: r.success === null || r.success === undefined ? undefined : Boolean(r.success),
-      error: (r.error as string | null) ?? undefined,
-      turns: (r.turns as number | null) ?? undefined,
-      durationMs: (r.durationMs as number | null) ?? undefined,
-      sessionId: (r.sessionId as string | null) ?? undefined,
-      costUsd: (r.costUsd as number | null) ?? undefined,
-      inputTokens: (r.inputTokens as number | null) ?? undefined,
-      cacheCreationInputTokens: (r.cacheCreationInputTokens as number | null) ?? undefined,
-      cacheReadInputTokens: (r.cacheReadInputTokens as number | null) ?? undefined,
-      outputTokens: (r.outputTokens as number | null) ?? undefined,
-      apiDurationMs: (r.apiDurationMs as number | null) ?? undefined,
-      stopReason: (r.stopReason as string | null) ?? undefined,
-      extensionStatus: (r.extensionStatus as string | null) ?? undefined,
-      skillsStatus: (r.skillsStatus as string | null) ?? undefined,
-      workflowRunId: (r.workflowRunId as string | null) ?? undefined,
-    }));
+    return rows.map(mapExecutionRow);
   }
 
   /** Get currently running executions (no finished_at) */
   runningExecutions(): ExecutionRecord[] {
-    return this.db.prepare(`
-      SELECT * FROM executions
+    const rows = this.db.prepare(`
+      SELECT ${EXECUTION_COLUMNS} FROM executions
       WHERE finished_at IS NULL
       ORDER BY started_at DESC
-    `).all() as ExecutionRecord[];
+    `).all() as Array<Record<string, unknown>>;
+    return rows.map(mapExecutionRow);
   }
 
   /** Aggregate execution stats */

--- a/apps/server/tests/engine/github/github-checks.test.ts
+++ b/apps/server/tests/engine/github/github-checks.test.ts
@@ -381,6 +381,95 @@ describe("GitHubClient.listOpenPrNumbersForHeadSha", () => {
   });
 });
 
+/**
+ * **The missing `Commit statuses: read` grant** (issue #277).
+ *
+ * The two legs of `getChecksSummary` need two different App permissions, and
+ * `Checks: read` does not imply `Commit statuses: read`. Under `Promise.all` a
+ * 403 on the status leg rejected the whole call, throwing away the check-runs
+ * result the App WAS permitted to read — so an App missing only `statuses` lost
+ * its entire CI signal. Nothing surfaced it: no scoped-token profile requests
+ * `statuses`, so the token mints cleanly and the 403 lands at call time, while
+ * the run still records `success = true`.
+ *
+ * The status half is additive, so it degrades to "no status contexts". The
+ * check-runs half is not, so it still throws.
+ */
+describe("GitHubClient.getChecksSummary — App without `Commit statuses: read`", () => {
+  const forbidden = () => Object.assign(new Error("Resource not accessible by integration"), {
+    status: 403,
+  });
+
+  /** Check runs readable, combined status 403 — the exact production shape. */
+  function octokitWithoutStatuses(runs: Run[], err: () => Error = forbidden) {
+    return {
+      rest: {
+        checks: { listForRef: async () => ({ data: { check_runs: runs } }) },
+        repos: {
+          getCombinedStatusForRef: async () => {
+            throw err();
+          },
+        },
+      },
+    };
+  }
+
+  it("still reports the check runs' verdict when the status leg 403s", async () => {
+    // Under Promise.all this threw, and the caller logged "read failed" and
+    // fell back to a value that could not gate anything.
+    const c = clientWith(octokitWithoutStatuses([run("completed", "failure")]));
+    expect(await c.getChecksConclusion("o-403-failing", "r", "sha")).toBe("failing");
+  });
+
+  it("counts only the check runs toward settledCount", async () => {
+    const c = clientWith(
+      octokitWithoutStatuses([run("completed", "success"), run("completed", "success")]),
+    );
+    expect(await c.getChecksSummary("o-403-passing", "r", "sha")).toEqual({
+      state: "passing",
+      settledCount: 2,
+      pendingCount: 0,
+    });
+  });
+
+  it("reports 'none' rather than inventing a green from the unreadable statuses", async () => {
+    // The degraded status leg must read as "no contexts", never as a passing
+    // one — `dependencies.minSettledChecks` exists to tell "CI approved this"
+    // from "nothing looked at it".
+    const c = clientWith(octokitWithoutStatuses([]));
+    expect(await c.getChecksSummary("o-403-none", "r", "sha")).toEqual({
+      state: "none",
+      settledCount: 0,
+      pendingCount: 0,
+    });
+  });
+
+  it("degrades the same way for a transient status failure, not just a 403", async () => {
+    const c = clientWith(
+      octokitWithoutStatuses([run("completed", "success")], () =>
+        Object.assign(new Error("bad gateway"), { status: 502 }),
+      ),
+    );
+    expect(await c.getChecksConclusion("o-502", "r", "sha")).toBe("passing");
+  });
+
+  it("still throws when the CHECK RUNS leg fails — that half is load-bearing", async () => {
+    const c = clientWith({
+      rest: {
+        checks: {
+          listForRef: async () => {
+            throw forbidden();
+          },
+        },
+        repos: { getCombinedStatusForRef: async () => ({ data: noStatus }) },
+      },
+    });
+    await expect(c.getChecksSummary("o-checks-403", "r", "sha")).rejects.toThrow(
+      "Resource not accessible by integration",
+    );
+  });
+});
+
 describe("GitHubClient.getBaseChecksState", () => {
   it("delegates to getChecksConclusion against the base ref", async () => {
     const c = clientWith(fakeOctokit([run("completed", "failure")], noStatus));

--- a/apps/server/tests/state/execution-store-reads.test.ts
+++ b/apps/server/tests/state/execution-store-reads.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { StateDb } from "#src/state/db.js";
+
+/**
+ * Every read that claims to return an `ExecutionRecord` must actually return
+ * one (issue #285).
+ *
+ * The table is snake_case and the record is camelCase, so a `SELECT *` cast to
+ * `ExecutionRecord[]` type-checks while leaving `issueNumber`, `startedAt` and
+ * `workflowRunId` `undefined` — the compiler cannot see the difference and
+ * neither could any test, because no test read those fields back. Three reads
+ * had drifted that way: the Slack status report rendered `(started undefined)`
+ * and the admin cancel loop filtered `runningExecutions()` on a `workflowRunId`
+ * that matched no row.
+ *
+ * So this asserts the FIELDS, not the SQL: it writes one row through the store
+ * and reads it back through each of the four record-returning paths.
+ */
+describe("ExecutionStore — record-returning reads (issue #285)", () => {
+  let db: StateDb;
+
+  const startedAt = "2026-08-07T09:00:00.000Z";
+  const row = {
+    id: "e-1",
+    triggerType: "webhook" as const,
+    triggerId: "nearform/lastlight#42",
+    triggeredBy: "cliftonc",
+    triggerActorType: "github" as const,
+    skill: "pr-review:review",
+    owner: "nearform",
+    repo: "lastlight",
+    issueNumber: 42,
+    startedAt,
+    workflowRunId: "wfr-1",
+  };
+
+  beforeEach(() => {
+    db = new StateDb(":memory:");
+    db.executions.recordStart(row);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // One assertion set, applied to every path — the point is that none of them
+  // may answer differently.
+  function expectFullRecord(rec: ReturnType<typeof db.executions.allExecutions>[number]) {
+    expect(rec.id).toBe("e-1");
+    expect(rec.triggerType).toBe("webhook");
+    expect(rec.triggerId).toBe("nearform/lastlight#42");
+    expect(rec.triggeredBy).toBe("cliftonc");
+    expect(rec.triggerActorType).toBe("github");
+    expect(rec.skill).toBe("pr-review:review");
+    expect(rec.owner).toBe("nearform");
+    expect(rec.repo).toBe("lastlight");
+    // The three the snake_case cast silently dropped.
+    expect(rec.issueNumber).toBe(42);
+    expect(rec.startedAt).toBe(startedAt);
+    expect(rec.workflowRunId).toBe("wfr-1");
+  }
+
+  it("allExecutions returns a populated record", () => {
+    const [rec] = db.executions.allExecutions();
+    expectFullRecord(rec);
+  });
+
+  it("runningExecutions returns a populated record", () => {
+    const [rec] = db.executions.runningExecutions();
+    expectFullRecord(rec);
+  });
+
+  it("recentExecutions returns a populated record", () => {
+    const [rec] = db.executions.recentExecutions("pr-review:review");
+    expectFullRecord(rec);
+  });
+
+  it("getExecutionsForWorkflowRun returns a populated record", () => {
+    const [rec] = db.executions.getExecutionsForWorkflowRun(
+      "wfr-1",
+      "nearform/lastlight#42",
+      "pr-review",
+    );
+    expectFullRecord(rec);
+  });
+
+  it("maps a finished row's optional columns, with success as a boolean", () => {
+    db.executions.recordFinish("e-1", {
+      success: true,
+      turns: 7,
+      durationMs: 1234,
+      costUsd: 0.5,
+    });
+    const [rec] = db.executions.allExecutions();
+    expect(rec.success).toBe(true);
+    expect(rec.finishedAt).toBeTruthy();
+    expect(rec.turns).toBe(7);
+    expect(rec.durationMs).toBe(1234);
+    expect(rec.costUsd).toBe(0.5);
+  });
+
+  it("reads SQL NULLs back as undefined, not null", () => {
+    // A chat turn: no repo, no issue, no owning run.
+    db.executions.recordStart({
+      id: "e-2",
+      triggerType: "chat",
+      triggerId: "slack:T1:C1:1.0",
+      skill: "chat",
+      startedAt: "2026-08-07T10:00:00.000Z",
+    });
+    const rec = db.executions.allExecutions().find((r) => r.id === "e-2")!;
+    expect(rec.owner).toBeUndefined();
+    expect(rec.repo).toBeUndefined();
+    expect(rec.issueNumber).toBeUndefined();
+    expect(rec.workflowRunId).toBeUndefined();
+    expect(rec.success).toBeUndefined();
+    expect(rec.startedAt).toBe("2026-08-07T10:00:00.000Z");
+  });
+
+  it("returns the BARE repo, so a caller composes owner/repo itself (issue #279)", () => {
+    // The status report and the dashboard qualify at the display boundary; the
+    // ledger keeps the split pair. A read that qualified here would hand a
+    // `repo` back to Octokit's (owner, repo) pair as `nearform/lastlight`.
+    const [rec] = db.executions.runningExecutions();
+    expect(rec.repo).toBe("lastlight");
+    expect(rec.owner).toBe("nearform");
+  });
+});

--- a/apps/www/src/pages/docs/github-app.astro
+++ b/apps/www/src/pages/docs/github-app.astro
@@ -66,6 +66,11 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
 				<td>Merge or push PRs that touch <code>.github/workflows/</code> — GitHub blocks the token otherwise. Needed for dependency PRs that bump GitHub Actions versions (e.g. <code>actions/checkout</code>), which the dependabot-pr-merge flow lands. Omit only if you never want the bot to touch Actions files.</td>
 			</tr>
 			<tr>
+				<td><strong>Commit statuses</strong> <em>(recommended)</em></td>
+				<td>Read</td>
+				<td>Read the classic commit <em>statuses</em> a repo's CI may post (CircleCI, Jenkins, other external CI) alongside check runs, so the auto-merge and fix gating see the full CI picture. Distinct from <strong>Checks</strong> above — GitHub exposes statuses and check runs as two permissions over two APIs, and one does not imply the other. Optional: without it Last Light judges CI on check runs alone and says so once in the log, rather than losing the CI signal entirely.</td>
+			</tr>
+			<tr>
 				<td><strong>Actions</strong> <em>(recommended)</em></td>
 				<td>Read</td>
 				<td>Read GitHub Actions job logs so the fix workflow can see why CI actually failed, rather than only check annotations. Distinct from <strong>Workflows</strong> above, which only governs <em>writing</em> files under <code>.github/workflows/</code>. Optional: without it Last Light still runs, falling back to check-run annotations — and it now says so explicitly in the prompt instead of degrading silently.</td>

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -208,6 +208,7 @@ npm install</code></pre>
 				<li><strong>Contents</strong> — Read & Write</li>
 				<li><strong>Checks</strong> — Read & Write</li>
 				<li><strong>Workflows</strong> — Read & Write (to merge PRs that touch <code>.github/workflows/</code>, e.g. Actions version bumps)</li>
+				<li><strong>Commit statuses</strong> — Read (classic CI statuses; separate from <strong>Checks</strong>)</li>
 				<li><strong>Metadata</strong> — Read</li>
 			</ul>
 			<p>Generate a private key, save the <code>.pem</code> file into the lastlight folder, and install the app on your repos.</p>

--- a/plugins/lastlight/skills/lastlight-server/SKILL.md
+++ b/plugins/lastlight/skills/lastlight-server/SKILL.md
@@ -43,7 +43,10 @@ Ask for each of these (don't guess). Group the questions; explain what each is f
   too — a different permission from workflows: it lets the fix workflow read
   the actual Actions job logs instead of only check annotations. It is optional,
   so an app without it still works; the CI evidence is just weaker, and the
-  prompt says so. They install it on their repos to get the Installation ID.)
+  prompt says so. Recommend **commit statuses** (read) as well — again distinct
+  from checks: it covers the classic statuses external CI posts (CircleCI,
+  Jenkins), and without it CI is judged on check runs alone. They install it on
+  their repos to get the Installation ID.)
 - **Domain** — the public hostname for webhooks/dashboard, e.g.
   `lastlight.example.com`. Ask whether to use the bundled **Caddy** for
   automatic TLS (default yes). The GitHub App webhook URL will be


### PR DESCRIPTION
Two unrelated bugs, both of the same species: a read that quietly returns less than it claims to, while everything downstream reports success.

**Stacked on #284** (`fix/279-normalize-repo-storage`) — the #285 fix needs that branch's `executions.owner` column, `ExecutionRecord.owner` and `qualifyRepo`. Base retargets to `main` automatically when #284 lands. Review this PR's own two commits.

---

## #285 — three `SELECT *` reads dropped `issueNumber` / `startedAt` / `workflowRunId`

The table is snake_case, `ExecutionRecord` is camelCase, and a raw row cast to `ExecutionRecord[]` type-checks anyway. `id` / `skill` / `repo` / `error` / `success` happened to line up; the three multi-word fields never did.

What it broke:
- **The Slack status report** emitted `(started undefined)` and no issue number, on every status request.
- **The admin cancel loop** filtered `runningExecutions()` on a `workflowRunId` that could not match a row — the container kill beside it was doing the work.

The fix is not three more hand-typed alias lists. A fourth read, `getExecutionsForWorkflowRun`, already had the correct one — that is exactly what the other three were supposed to look like. `EXECUTION_COLUMNS` + `mapExecutionRow` now hold it once and all four share them, so a new column is added to both halves or to neither. The mapper also normalizes what the old casts leaked: NULLs become `undefined`, `success` becomes a boolean instead of 1/0.

Two consequences worth flagging for review:
- `getExecutionsForWorkflowRun` now also returns `owner` / `triggeredBy` / `triggerActorType`. Additive; nothing reads them yet.
- With the fields populated, the status report's `repo` is the **bare** name per #279, so it now qualifies through `qualifyRepo` at the display boundary.
- `GET /admin/api/executions` returns the record verbatim, so its **wire shape changes to camelCase**. The dashboard's hand-mirrored `Execution` type followed. No component reads it (only `workflowRunExecutions` is consumed, by the CLI and the run detail panel), so nothing renders differently.

The test asserts **fields, not SQL** — one row written through the store, read back through each of the four paths. That is the test that was missing: the compiler could not see this bug, and neither could a test that never read those fields back. Verified red on the pre-fix store (6 of 7 failing), green after.

## #277 — a missing `statuses:read` blinded the *entire* CI read

`getChecksSummary` reads check runs and the combined commit status together, needing two different permissions — **`Checks: read` does not imply `Commit statuses: read`**. Under `Promise.all`, a 403 on the status leg discarded the check-runs result the App *was* permitted to read.

Nothing surfaced it: no scoped-token profile requests `statuses`, so the token mints cleanly (no 422), the 403 lands at call time, and the run records `success = true` while every CI gate reads blind. The setup docs had never listed the permission, so an App built exactly to the documented table was broken by construction.

- **`Promise.allSettled`.** A rejected check-runs leg still throws — load-bearing. A rejected status leg degrades to `statuses: []`, which is *empty, not green*: both the pending and the failing test are gated on there being contexts, so the unreadable half can neither fail the ref nor pad `settledCount`. Mirrors the existing `Actions: read` handling.
- **Warned once per owner per cause.** The grant is per installation and the read fires on every synchronize and settle — the issue reported ~30 identical lines/day burying the finding. Keying on cause too means transient 5xx cannot permanently suppress the line that names a missing grant.
- **Documented** in every place the App's permissions are listed: setup page, landing page, README, `lastlight-server` skill, and a new spec section beside the `Actions: read` one.

Thanks to @robinbowes — the `github-diag` output in the issue named the missing scope precisely, and is what identified it.

---

Closes #285. Closes #277.

## Verification

`pnpm turbo run typecheck test` — 16/16 tasks, 2814 core tests green. `astro check` — 0 errors across 67 files.

Docs surfaces updated per `docs-sync`: `spec/03-integrations.md` (new permission section), `spec/10-state.md` (the aliasing invariant), plus the four hand-written permission lists.

Prod-facing core, so this needs a release cut before it reaches a deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)