### PR TITLE
fix(router): triage needs an issue, and needs to be told what was asked (#290)

### DIFF
--- a/apps/server/spec/05-router.md
+++ b/apps/server/spec/05-router.md
@@ -189,6 +189,45 @@ because `demo` is in `WELL_KNOWN_INTENTS` the intent fallback skipped it as
 well, so every demo-classified Slack message fell through to plain chat against
 a configured route.)
 
+### TRIAGE on Slack needs an issue
+
+`issue-triage` triages **one** issue. Repo-wide triage is a real capability but
+it rides on `context.mode = "scan"`, and exactly two things set it: the
+webhooks-off `triage-new-issues` cron, and `lastlight triage <owner/repo>` with
+no `#N`. **The Slack branch sets neither `mode` nor `issueNumber`**, so it used
+to hand a single-issue workflow an empty target — and its clarify text
+(`triage cliftonc/repo`) advertised the repo-wide form it could not deliver.
+
+What that produced, in one real run: a Slack message classified `TRIAGE`,
+dispatched with `issueNumber: 0` and an empty `commentBody`, whereupon the agent
+improvised a `list_issues` sweep, inspected one issue, changed nothing, emitted
+`TRIAGE_COMPLETE` and recorded **succeeded** after 110 s of sandbox. The
+`requires_marker` postcondition cannot catch this: it proves the agent did not
+bail, not that it was asked anything.
+
+Two fixes, and the second is the load-bearing one:
+
+- The branch now **requires an issue** and replies asking for one otherwise —
+  after the managed-repo gate, so a missing issue can never mask an unmanaged
+  target.
+- It forwards **`commentBody: slackText`**, as `demo` and `question` already
+  did. Without it the request never reaches the agent at all: in the run above
+  the word "overdue" appears nowhere in the 775-line transcript.
+
+**The classification block is what stops the misroute happening at all.** It was
+one line, defined the intent purely by *subject matter* ("scan/triage issues on a
+repo"), and carried no deliverable and no counter-examples — while every peer
+block states what comes out ("the deliverable is an ANSWER", "make code changes
+NOW", "a short screen-recorded mp4"). So any sentence pairing "issues" with a
+repo matched it, and *"are there any issues in cliftonc/drizzle-cube that are
+overdue?"* — a question, whose deliverable is an answer — matched it best of all.
+It now states its deliverable (labels), requires one issue, and makes the CHAT
+downgrade explicit, with the real misroute as a counter-example. `QUESTION`
+already carried the same downgrade; TRIAGE simply never yielded to it, and chat
+reads issues and their comments from GitHub directly. Pinned by
+`tests/workflows/issue-triage.test.ts`, which asserts the *shape* — a deliverable,
+the downgrade, counter-examples resolving to CHAT — rather than the wording.
+
 **The prompt is composed, forkable, and workflow-driven (issue #164).** The
 system prompt is assembled at runtime by `buildClassifierPrompt()`, not
 hardcoded:

--- a/apps/server/src/engine/router.ts
+++ b/apps/server/src/engine/router.ts
@@ -1017,13 +1017,37 @@ export async function routeEvent(
         case "triage": {
           const gate = requireManagedRepo(
             classifiedRepo,
-            "Which repo should I triage? e.g. `triage cliftonc/repo`",
+            "Which issue should I triage? e.g. `triage cliftonc/repo#42`",
           );
           if (!gate.ok) return gate.route;
+          // `issue-triage` triages ONE issue. Repo-wide scanning exists only as
+          // the webhooks-off cron fallback, which sets `mode: scan` — nothing on
+          // this path does, so a dispatch with no issue hands a single-issue
+          // workflow an empty target. That is not hypothetical: it burned a
+          // sandbox for 110s, improvised a `list_issues` sweep, changed nothing,
+          // emitted TRIAGE_COMPLETE and recorded SUCCEEDED. The marker
+          // postcondition cannot catch it — it proves the agent didn't bail, not
+          // that we asked it anything.
+          if (!classifiedIssue) {
+            return {
+              action: "reply",
+              message: `Which issue in ${gate.repo}? Triage works on one issue — e.g. \`triage ${gate.repo}#42\`. To ask *about* a repo's issues, just ask me directly and I'll look them up.`,
+            };
+          }
           return {
             action: "handler",
             handler: slack.triage || "issue-triage",
-            context: { repo: gate.repo, sender: envelope.sender, source: envelope.source },
+            context: {
+              repo: gate.repo,
+              issueNumber: classifiedIssue,
+              sender: envelope.sender,
+              // Forward what was actually said, as `demo`/`question` do. Without
+              // it the agent never sees the request that reached it: the run
+              // above rendered an empty `commentBody`, so the word "overdue"
+              // appeared nowhere in its 775-line transcript.
+              commentBody: slackText,
+              source: envelope.source,
+            },
           };
         }
 

--- a/apps/server/tests/engine/chat.test.ts
+++ b/apps/server/tests/engine/chat.test.ts
@@ -66,8 +66,8 @@ describe("chatSystemSuffix — composed from the packaged workflows", () => {
 
   it("renders a deflect bullet with its quoted phrasings and reply", () => {
     expect(prompt()).toContain(
-      '- "triage" / "scan issues" / "go through open issues on <repo>"\n' +
-        '  → reply: "tell me `triage owner/repo`"',
+      '- "triage this issue" / "triage <repo>#<n>" / "label this issue"\n' +
+        '  → reply: "tell me `triage owner/repo#N`"',
     );
   });
 

--- a/apps/server/tests/engine/router.test.ts
+++ b/apps/server/tests/engine/router.test.ts
@@ -892,13 +892,49 @@ describe('routeEvent — message events (classifier-driven)', () => {
     }
   });
 
-  it('routes triage intent with managed repo to issue-triage', async () => {
-    mockClassifyComment.mockResolvedValue({ intent: 'triage', repo: 'cliftonc/drizby' });
-    const result = await routeEvent(makeEnvelope({ type: 'message', body: 'triage cliftonc/drizby' }));
+  it('routes triage intent with a managed repo AND an issue to issue-triage', async () => {
+    mockClassifyComment.mockResolvedValue({
+      intent: 'triage',
+      repo: 'cliftonc/drizby',
+      issueNumber: 42,
+    });
+    const result = await routeEvent(
+      makeEnvelope({ type: 'message', body: 'triage cliftonc/drizby#42' }),
+    );
     expect(result.action).toBe('handler');
     if (result.action === 'handler') {
       expect(result.handler).toBe('issue-triage');
+      // The branch used to build its context from the repo alone, so both of
+      // these were dropped on the floor.
+      expect(result.context.issueNumber).toBe(42);
+      expect(result.context.commentBody).toBe('triage cliftonc/drizby#42');
     }
+  });
+
+  it('asks which issue rather than dispatching triage with no target', async () => {
+    // The regression. `issue-triage` triages ONE issue; repo-wide scanning is
+    // the webhooks-off cron's `mode: scan`, which this path never sets. This
+    // used to dispatch anyway with issueNumber 0 — the agent improvised a
+    // `list_issues` sweep, changed nothing, emitted TRIAGE_COMPLETE and the run
+    // recorded SUCCEEDED after 110s of sandbox.
+    mockClassifyComment.mockResolvedValue({ intent: 'triage', repo: 'cliftonc/drizby' });
+    const result = await routeEvent(makeEnvelope({ type: 'message', body: 'triage cliftonc/drizby' }));
+    expect(result.action).toBe('reply');
+    if (result.action === 'reply') {
+      expect(result.message).toContain('cliftonc/drizby#42');
+      // Points at the thing that DOES answer questions about issues, so the
+      // reply is a redirect rather than a refusal.
+      expect(result.message).toMatch(/ask me directly/i);
+    }
+  });
+
+  it('still refuses an unmanaged repo before asking for an issue', async () => {
+    // Order matters: the managed-repo gate is the security-relevant one, so a
+    // missing issue must not be able to mask an unmanaged target.
+    mockClassifyComment.mockResolvedValue({ intent: 'triage', repo: 'unknown/repo' });
+    const result = await routeEvent(makeEnvelope({ type: 'message', body: 'triage unknown/repo' }));
+    expect(result.action).toBe('reply');
+    if (result.action === 'reply') expect(result.message).toContain('unknown/repo');
   });
 
   it('routes review intent with managed repo to pr-review', async () => {

--- a/apps/server/tests/workflows/issue-triage.test.ts
+++ b/apps/server/tests/workflows/issue-triage.test.ts
@@ -27,6 +27,51 @@ describe("issue-triage — built-in workflow", () => {
     expect(getWorkflowByIntent("triage")?.name).toBe("issue-triage");
   });
 
+
+  /**
+   * The classification block is the ONLY thing standing between a question
+   * about issues and a sandbox (issue: the Slack message "Are there any issues
+   * in cliftonc/drizzle-cube that are overdue?" classified TRIAGE).
+   *
+   * It was one line long and defined the intent purely by SUBJECT MATTER —
+   * "scan/triage issues on a repo" — with no deliverable and no
+   * counter-examples, while every peer block states what comes out ("the
+   * deliverable is an ANSWER", "make code changes NOW", "a short screen-recorded
+   * mp4"). So any sentence pairing "issues" with a repo matched it.
+   *
+   * These assertions are deliberately about the SHAPE of the prompt rather than
+   * its wording: the block must state that it needs one issue, must name the
+   * CHAT downgrade, and must carry counter-examples that resolve to CHAT.
+   * Without them the classifier has nothing to discriminate on, however the
+   * sentences are phrased.
+   */
+  it("scopes the triage intent to ONE issue, not a repo-wide sweep", () => {
+    const def = getWorkflow("issue-triage");
+    const text = def.classification?.description ?? "";
+    expect(text).toMatch(/one\b|single/i);
+    // The old block advertised exactly this, which the Slack path cannot do —
+    // repo-wide triage is the cron's `mode: scan` and nothing else sets it.
+    expect(text).not.toMatch(/scan\/triage issues on a repo/i);
+  });
+
+  it("tells the classifier that a question ABOUT issues is CHAT", () => {
+    const def = getWorkflow("issue-triage");
+    const text = def.classification?.description ?? "";
+    expect(text).toMatch(/CHAT/);
+    expect(text).toMatch(/overdue|stale|unassigned/i);
+  });
+
+  it("carries counter-examples that resolve to CHAT, including the real misroute", () => {
+    const def = getWorkflow("issue-triage");
+    const examples = def.classification?.examples ?? [];
+    const chat = examples.filter((e) => /INTENT: CHAT/.test(e));
+    expect(chat.length).toBeGreaterThanOrEqual(3);
+    // The exact sentence that burned 110s of sandbox and answered nothing.
+    expect(chat.some((e) => /overdue/i.test(e))).toBe(true);
+    // And the positive case still has to name an issue.
+    expect(examples.some((e) => /INTENT: TRIAGE/.test(e) && /ISSUE: \d+/.test(e))).toBe(true);
+  });
+
   it("is dispatched by the triage-new-issues cron, so the marker covers cron runs too", () => {
     // The every-15-min scan (webhooks-disabled backstop) is exactly the
     // batch/cron path that produced the false-green bail this marker fixes. If

--- a/apps/server/tests/workflows/triggers.test.ts
+++ b/apps/server/tests/workflows/triggers.test.ts
@@ -34,7 +34,7 @@ describe("getWorkflowTriggers — Slack rows", () => {
   it("describes a workflow by its chat trigger phrase", () => {
     configureWorkflowAssets();
     const triage = getWorkflowTriggers("issue-triage").find((t) => t.kind === "slack");
-    expect(triage).toMatchObject({ description: "Slack: `triage owner/repo`" });
+    expect(triage).toMatchObject({ description: "Slack: `triage owner/repo#N`" });
   });
 
   it("falls back to the summary for a workflow with no phrase to type", () => {

--- a/apps/server/workflows/issue-triage.yaml
+++ b/apps/server/workflows/issue-triage.yaml
@@ -3,16 +3,27 @@ name: issue-triage
 classification:
   intent: triage
   description: |
-    TRIAGE — The user wants to scan/triage issues on a repo: "triage cliftonc/repo", "scan for new issues", "can you triage <repo>?".
+    TRIAGE — The user is ASKING YOU to classify and LABEL one specific GitHub issue: "triage cliftonc/repo#42", "can you triage this?" on an issue, "re-triage this now that I've added detail". The deliverable is LABELS AND LABEL-DRIVEN ACTIONS on that issue — never an answer, a summary, or a list.
+    TRIAGE NEEDS ONE ISSUE. It is not a repo-wide sweep: it acts on the issue named in the message, or the issue the comment is on. A request naming only a repo has no target, so it is not TRIAGE.
+    A QUESTION ABOUT ISSUES IS CHAT, NOT TRIAGE. "which issues are overdue / stale / unassigned / oldest?", "how many open bugs are there?", "what's in the backlog?" all ask for an ANSWER, and chat reads issues and their comments from GitHub directly. Mentioning "issues" and a repo in one sentence is not a triage request — wanting labels changed is. This is the same downgrade QUESTION makes, and it is the one that matters here, because a question about issues is lexically almost identical to a request to triage them.
   examples:
-    - '"could you triage https://github.com/foo/bar?" → INTENT: TRIAGE, REPO: foo/bar, ISSUE: NONE, REASON: NONE'
+    - '"triage cliftonc/drizzle-cube#42" → INTENT: TRIAGE, REPO: cliftonc/drizzle-cube, ISSUE: 42, REASON: NONE'
+    - '"could you triage this?" with ISSUE TITLE "Crash on empty CSV" → INTENT: TRIAGE, REPO: NONE, ISSUE: NONE, REASON: NONE'
+    # Counter-examples: questions ABOUT issues. Each names a repo and the word
+    # "issues", and none of them wants a label changed — chat answers all three
+    # from its own GitHub reads. The first is the real misroute this guards
+    # against: it dispatched a single-issue workflow with no issue, which
+    # improvised a repo sweep, changed nothing, and reported success.
+    - '"Are there any issues in cliftonc/drizzle-cube that are overdue?" → INTENT: CHAT, REPO: cliftonc/drizzle-cube, ISSUE: NONE, REASON: NONE'
+    - '"how many open bugs does cliftonc/drizzle-cube have?" → INTENT: CHAT, REPO: cliftonc/drizzle-cube, ISSUE: NONE, REASON: NONE'
+    - '"whats the oldest untriaged issue in cliftonc/drizzle-cube?" → INTENT: CHAT, REPO: cliftonc/drizzle-cube, ISSUE: NONE, REASON: NONE'
 chat:
-  trigger: triage owner/repo
-  summary: Triage open issues on a repo
+  trigger: triage owner/repo#N
+  summary: Triage one issue — classify and label it
   deflect:
-    - triage
-    - scan issues
-    - go through open issues on <repo>
+    - triage this issue
+    - triage <repo>#<n>
+    - label this issue
 description: |
   Triage a GitHub issue: read it, classify it, label it, and act on stale or
   incomplete reports. Single agent invocation, no PR creation.


### PR DESCRIPTION
Closes #290.

Your Slack message — *"Are there any issues in cliftonc/drizzle-cube that are overdue?"* — classified `TRIAGE`, dispatched `issue-triage` with **`issueNumber: 0`** and an **empty `commentBody`**, and the agent improvised a `list_issues` sweep, changed nothing, emitted `TRIAGE_COMPLETE` and recorded **succeeded** after 110s of sandbox.

The word "overdue" appears nowhere in that run's 775-line transcript. **The question never reached the agent.**

`requires_marker: TRIAGE_COMPLETE` can't catch this — it proves the agent didn't bail, not that we asked it anything.

## Three defects

**1. The classification block matched on subject matter, not deliverable.** It was one line:

> TRIAGE — The user wants to scan/triage issues on a repo…

No deliverable, no counter-examples — while every peer block leads with what comes out (`QUESTION`: "the deliverable is an ANSWER"; `BUILD`: "make code changes NOW"; `DEMO`: "a short screen-recorded mp4"). So any sentence pairing "issues" with a repo matched. A question *about* issues is lexically almost identical to a request to triage them, and TRIAGE was the one intent that never told the classifier to yield — even though `QUESTION` already carries exactly the right downgrade ("chat reads issues and their comments directly").

**2. The Slack branch dropped your text.** `demo` and `question` forward `slackText` as `commentBody`. Triage never did.

**3. The Slack branch dispatched a single-issue workflow with no issue,** and its clarify text advertised the repo-wide form it can't deliver. The workflow file said both things three lines apart:

| line | says |
|---|---|
| `classification.description` | "scan/triage **issues** on a repo" |
| `chat.summary` | "Triage open **issues** on a repo" |
| `description` | "Triage **a** GitHub issue… **Single agent invocation**" |

## Scope

Repo-wide triage is real — it rides on `context.mode = "scan"`, set by the webhooks-off cron and by `lastlight triage <owner/repo>` (`cli.ts:1136`). **Both are untouched and still work.** Only the classifier path becomes single-issue, which is what the `chat:` block now advertises.

The issue gate sits **after** the managed-repo gate, so a missing issue can never mask an unmanaged target. There's a test for that ordering.

## Testing

The contract test asserts the **shape** of the classification block — states a deliverable, requires one issue, names the CHAT downgrade, carries counter-examples resolving to CHAT — rather than its wording, so a rewrite that drops the discriminators fails even if it reads well.

`router.test.ts`'s existing *"routes triage intent with managed repo to issue-triage"* was **pinning the bug** (a repo, no issue, dispatched happily). It now asserts the reply, alongside a with-an-issue case checking `issueNumber` and `commentBody` both survive.

Two fixtures in `chat.test.ts` / `triggers.test.ts` used `issue-triage`'s `chat:` block as their example; updated to the new strings, mechanism unchanged.

Full gate 16/16, `astro check` 0 errors.

⚠️ Needs a release to reach prod (harness code + workflow YAML both ship in the image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)