### PR TITLE
docs(core): correct stale repo-config clamp directions

### DIFF
--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -550,9 +550,9 @@ dashboard/              React+Vite admin SPA, served from /admin at runtime.
     review modes are equally *safe* but not equally *expensive* — `eager`
     buys a full agent review per push on the operator's budget — and the
     audit comment is the record of a major this deployment auto-merged,
-    whose only silenceable party is the one being audited.) Three leaves
-    are **operator-only** and answer
-    `key-not-allowed` instead: `fix.escalateModelAfterAttempt` (spend),
+    whose only silenceable party is the one being audited.) Three leaves are
+    **operator-only** and answer `key-not-allowed` instead:
+    `fix.escalateModelAfterAttempt` (spend),
     `fix.gateTimeoutSeconds` (shared resource), and
     `dependencies.minSettledChecks` — where a `max(repo, operator)` clamp would
     weld the escape hatch shut for a repo with no CI at all. `fix` +

--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -542,9 +542,16 @@ dashboard/              React+Vite admin SPA, served from /admin at runtime.
     back to it). Per-key directions live with the sanitizers in
     `packages/shared/src/repo-config-schema.ts` — `min()` for the fix budgets,
     subset-only for `retryableClasses`, the lower tier for
-    `autoMergeMaxImpact`, add-only `true` for `requireSettledChecks` /
-    `postsCheck` / `skipDraft`, free for `auditComment` / `trigger` /
-    `requestLabel`. Three leaves are **operator-only** and answer
+    `autoMergeMaxImpact` and `review.trigger`
+    (`on-request < after-checks < eager`), union-only for
+    `review.generatedPaths`, add-only `true` for `requireSettledChecks` /
+    `postsCheck` / `skipDraft` / `auditComment`, free for `requestLabel`
+    alone. (`trigger` and `auditComment` were free until #256: the three
+    review modes are equally *safe* but not equally *expensive* — `eager`
+    buys a full agent review per push on the operator's budget — and the
+    audit comment is the record of a major this deployment auto-merged,
+    whose only silenceable party is the one being audited.) Three leaves
+    are **operator-only** and answer
     `key-not-allowed` instead: `fix.escalateModelAfterAttempt` (spend),
     `fix.gateTimeoutSeconds` (shared resource), and
     `dependencies.minSettledChecks` — where a `max(repo, operator)` clamp would


### PR DESCRIPTION
Corrects three stale entries in the per-key clamp list in `apps/server/CLAUDE.md`. Documentation only — no behaviour change.

The dev guide lists `trigger` and `auditComment` as **free** leaves a repo may set in either direction. #256 clamped both, and the line was never updated:

| leaf | guide said | sanitizer actually does |
|---|---|---|
| `review.trigger` | free | lower tier on `on-request < after-checks < eager` (`repo-config-schema.ts:1068`) |
| `dependencies.auditComment` | free | add-only `true` (`:1000`) |
| `review.generatedPaths` | *absent* | union-only (`:1130`) |

`requestLabel` is the only free leaf left, which is what the line now says.

The reasoning is already in the sanitizers, and worth keeping visible because both were deliberate reversals rather than drive-by tightening:

> *"This was `free` on the reasoning that all three modes are equally 'safe'. They are not equally EXPENSIVE (#256): a repo committing `eager` against an `on-request` deployment buys itself a full agent run per push, on the operator's budget."*

> *"This was `free` on the reasoning that the comment is cosmetic. It is not: it is the AUDIT RECORD of a major version this deployment auto-merged into that repo, and the party it silences is the party being audited."*

`spec/02-configuration.md:305-306` already documents all three correctly, so this aligns the dev guide with the spec and the code rather than introducing a new claim. Found while reading the `review` block to work out whether a repo could opt down to `on-request` — it can, but the guide implied it could also opt *up* to `eager`, which the sanitizer drops with a `policy-downgrade` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017csqMy58ivRbLTKojhQnpJ
