### PR TITLE
fix(dashboard): classify execution outcomes instead of reading `success`

### DIFF
--- a/apps/server/dashboard/src/api.ts
+++ b/apps/server/dashboard/src/api.ts
@@ -516,19 +516,34 @@ export interface HostStats {
   cpuCount: number;
 }
 
+/**
+ * How a finished execution turned out (issue #325). Hand-mirrored from
+ * `ExecutionOutcomeCounts` in `src/state/execution-store.ts`, which is where
+ * the classification is defined and documented.
+ *
+ * `deferred` and `skipped` are NOT failures: both are stored `success = 0` on
+ * purpose (resume re-evaluation and quota requeue respectively), so reading
+ * that column as health painted a wall of red on days when nothing broke.
+ * An in-flight execution is in `executions` and in none of these four.
+ */
+export interface OutcomeCounts {
+  succeeded: number;
+  skipped: number;
+  deferred: number;
+  failed: number;
+}
+
 export interface Stats {
   total_executions: number;
   today_count: number;
-  by_skill: Record<string, { count: number; success: number; fail: number }>;
+  by_skill: Record<string, OutcomeCounts & { count: number }>;
   by_trigger: Record<string, number>;
   running: number;
 }
 
-export interface DailyStat {
+export interface DailyStat extends OutcomeCounts {
   date: string;
   executions: number;
-  successes: number;
-  failures: number;
   totalTokens: number;
   inputTokens: number;
   outputTokens: number;

--- a/apps/server/dashboard/src/components/HomePage.tsx
+++ b/apps/server/dashboard/src/components/HomePage.tsx
@@ -8,6 +8,7 @@ import {
   XAxis,
   YAxis,
   Tooltip,
+  Legend,
   CartesianGrid,
 } from "recharts";
 import { Server, Bot, Box, Network } from "lucide-react";
@@ -27,6 +28,90 @@ type StatRange = "today" | "7d" | "30d";
 // internally for tooltip swatches and gradients. Use literal hex per theme so
 // the chart renders — CHART_DARK matches the daisyUI `lastlight` theme,
 // CHART_LIGHT matches `neaform`. Selected in-component via useTheme().
+/**
+ * Execution outcome — a STATUS palette, not a categorical one (issue #325).
+ *
+ * The four bands are states, not identities, so they take reserved status hues
+ * and are **mode-invariant**: the same steps clear 3:1 on both the light card
+ * (`#ffffff`) and the dark one (`#161b22`), and re-stepping them per theme
+ * would only re-open the separation problem below.
+ *
+ * Only THREE of the four are solid fills. `skipped` is a hatch (see the
+ * `<pattern>` at the chart), because it is the one band that is not an
+ * outcome — and because hue could not carry it: every neutral that read as
+ * "absence" landed too close to the green, and the best of them (ΔE 15.9,
+ * nominally over the floor) was still called out as similar on sight. A floor
+ * is a minimum, not a target. Texture is a different channel, so it separates
+ * unconditionally.
+ *
+ * With `skipped` out of the colour set there are only three solids left, and
+ * that is the whole reason this palette passes every check in both modes —
+ * measured, not eyeballed (OKLab ΔE×100, min of protan/deutan):
+ *
+ *   succeeded ↔ deferred   22.1   (normal 26.0)
+ *   deferred  ↔ failed     14.6   (normal 26.1)
+ *   succeeded ↔ failed      8.7   (normal 37.7)   ← worst CVD
+ *
+ * **The red is a crimson so the green can be a green.** These two move
+ * together: a true green (`#0ca30c`) against a pure red (`#d03b3b`) measures
+ * ΔE 4.1 for deuteranopes — unusable — and every greener green collides the
+ * same way. Cooling the red to `#cc2b5e` buys the room, and only then does
+ * `succeeded` get to look like success rather than a teal compromise. The
+ * earlier emerald was the other end of the same trade.
+ *
+ * **`deferred` is BLUE, not amber, and that is a salience decision.** The
+ * bands are not equally important — succeeded is the signal, skipped is
+ * unremarkable, deferred is an indication of load, failed is bad — so visual
+ * weight has to track that order (Tufte's "smallest effective difference";
+ * Few's rule that saturation is a budget spent only on what needs attention).
+ * A bright amber made the LEAST consequential band the loudest thing on the
+ * chart. Blue also stops it overclaiming: Carbon reserves yellow/orange for
+ * "regular"/"serious warning", and a full sandbox queue is neither — it is
+ * informational, it costs $0, and it clears itself. It fixes the numbers too:
+ * amber was the one step failing contrast on white (1.83:1).
+ *
+ * Two choices carry that, and neither is cosmetic:
+ *
+ * Red/green dichromacy is the binding constraint on the whole palette, and it
+ * cannot be solved by choosing a better red OR a better green in isolation —
+ * only by moving the pair apart. (The dashboard's old dark pastels,
+ * `#86efac`/`#fca5a5`, measured 5.8: below the ΔE 6 floor outright.)
+ *
+ * Two knowingly-accepted validator complaints, both properties of a status
+ * palette rather than defects:
+ *  - `skipped` fails the chroma floor. It is grey ON PURPOSE — grey IS the
+ *    message ("nothing ran"), and a status hue there would imply one did.
+ *  - `deferred` sits outside the categorical lightness band, and is sub-3:1 on
+ *    the light surface (1.83). Both are documented properties of the reference
+ *    `warning` step; the prescribed mitigation is never colour alone — hence
+ *    the `<Legend>`.
+ */
+const OUTCOME = {
+  succeeded: "#0ca30c",
+  skipped: "#6b7280",
+  deferred: "#4a7fb5",
+  failed: "#cc2b5e",
+};
+
+/**
+ * Bottom-to-top stack order, and the single source of it. Declared as data
+ * rather than left implicit in the JSX because the tooltip has to REVERSE it:
+ * a list reads top-down while a stack builds bottom-up, so listing the bands
+ * in stack order puts `succeeded` at the top of the tooltip and `failed` at
+ * the bottom — the mirror image of the bar the reader is pointing at.
+ */
+const OUTCOME_STACK = ["succeeded", "skipped", "deferred", "failed"] as const;
+
+/**
+ * Drop zero bands from the tooltip (issue #325). Most hours have no failures
+ * and no deferrals, and four rows of which two say `0` buries the two that
+ * carry information — the reader has to *read* to find out nothing happened.
+ * Recharts renders nothing for a `null` name.
+ */
+function outcomeTooltipFormatter(value: unknown, name: unknown): [string, string] | null {
+  return Number(value) > 0 ? [String(value), String(name)] : null;
+}
+
 const CHART_DARK = {
   success: "#86efac",
   error: "#fca5a5",
@@ -563,8 +648,13 @@ function StatsChartsSection() {
     // Daily bucket key is `YYYY-MM-DD` → render `MM-DD`.
     date: granularity === "hour" ? `${d.date.slice(11, 13)}:00` : d.date.slice(5),
     executions: d.executions,
-    successes: d.successes,
-    failures: d.failures,
+    succeeded: d.succeeded,
+    deferred: d.deferred,
+    failed: d.failed,
+    // `skipped` is deliberately absent from the stack: a cascade skip is the
+    // CONSEQUENCE of another row's outcome, so stacking it renders one incident
+    // twice. It stays in the tooltip via `executions`.
+    skipped: d.skipped,
     inputTokens: d.inputTokens,
     outputTokens: d.outputTokens,
     cacheTokens: d.cacheReadTokens,
@@ -636,12 +726,82 @@ function StatsChartsSection() {
                   {/* Spacer right-axis so this chart's plot area matches the
                       Token chart, which has a real right axis. */}
                   <YAxis yAxisId="spacer" orientation="right" width={48} tick={false} axisLine={false} tickLine={false} />
+                  {/* Per-band counts plus the TOTAL. The total is the point:
+                      the four bands sum to the "Executions" stat card above,
+                      and showing it here is what lets a reader confirm that
+                      rather than take it on trust. It is also the only place
+                      `skipped` is quantified without squinting at a hatch. */}
                   <Tooltip
                     contentStyle={{ fontSize: 11, background: CHART.tooltipBg, border: `1px solid ${CHART.tooltipBorder}` }}
                     cursor={{ fill: "rgba(255,255,255,0.04)" }}
+                    itemStyle={{ padding: 0 }}
+                    formatter={outcomeTooltipFormatter}
+                    itemSorter={(item) => -OUTCOME_STACK.indexOf(
+                      String(item.dataKey) as (typeof OUTCOME_STACK)[number],
+                    )}
+                    labelFormatter={(label, payload) => {
+                      const total = (payload ?? []).reduce((n, p) => n + (Number(p.value) || 0), 0);
+                      return `${String(label ?? "")} — ${total} execution${total === 1 ? "" : "s"}`;
+                    }}
                   />
-                  <Bar dataKey="successes" stackId="e" fill={CHART.success} name="success" />
-                  <Bar dataKey="failures" stackId="e" fill={CHART.error} name="failure" />
+                  <Legend
+                    verticalAlign="bottom"
+                    height={24}
+                    iconSize={8}
+                    wrapperStyle={{ fontSize: 11, color: CHART.axis }}
+                  />
+                  <defs>
+                    {/* `skipped` is the one band that is not an outcome — the
+                        phase never ran. It is drawn as a HATCH rather than a
+                        fill because hue could not carry it: against the green
+                        it measured ΔE 15.9, technically over the floor and
+                        still visibly similar. Texture is a different channel
+                        entirely, so it separates from all three solids at any
+                        severity of colour blindness, in print, and under
+                        forced-colors — and it reads as "placeholder", which is
+                        what a skip is. */}
+                    <pattern id="ll-skip-hatch" patternUnits="userSpaceOnUse" width={5} height={5}
+                             patternTransform="rotate(45)">
+                      {/* A tinted BODY under the lines, not an outline around
+                          them. An outline would be drawn half outside the rect
+                          — and since the solid bands' strokes are surface-
+                          coloured (their outer half invisible), a visible one
+                          renders this segment ~4px wider than the rest of the
+                          column at the same strokeWidth. The tint gives the
+                          band a definite edge from the inside, so every band
+                          keeps identical geometry. */}
+                      <rect width={5} height={5} fill={CHART.tooltipBg} />
+                      <rect width={5} height={5} fill={OUTCOME.skipped} opacity={0.18} />
+                      <line x1={0} y1={0} x2={0} y2={5} stroke={OUTCOME.skipped} strokeWidth={2.5} />
+                    </pattern>
+                  </defs>
+                  {/* Stack order, bottom to top, is SEMANTIC: nothing wrong →
+                      nothing happened → load → bad. It could not be before —
+                      while `deferred` was amber it had to be held apart from
+                      red (ΔE 2.8) by putting the neutral between them. Blue
+                      dissolved that constraint, and the semantic order is also
+                      the stronger one: the hatch now separates green from blue
+                      by texture, leaving deferred↔failed (ΔE 19.0) as the only
+                      solid-solid boundary, against 13.5 before.
+                      `stroke` is the 2px surface gap between segments. */}
+                  <Bar dataKey="succeeded" stackId="e" fill={OUTCOME.succeeded} name="succeeded"
+                       stroke={CHART.tooltipBg} strokeWidth={2} />
+                  {/* A cascade skip: the phase never ran, because an upstream
+                      one didn't succeed. Kept in the stack so the bar totals to
+                      the "Executions" headline — it is 31% of rows on a busy
+                      day, so hiding it would make the two disagree visibly.
+                      Same surface stroke as every other band; see the pattern
+                      above for why its definition is a tint, not a border. */}
+                  <Bar dataKey="skipped" stackId="e" fill="url(#ll-skip-hatch)" name="skipped"
+                       stroke={CHART.tooltipBg} strokeWidth={2} />
+                  {/* Capacity, not error: the k8s ResourceQuota rejected the
+                      pod and the run requeued. Costs $0 and self-heals — but it
+                      IS the signal that the sandbox namespace is saturated, so
+                      it earns its own band rather than being hidden. */}
+                  <Bar dataKey="deferred" stackId="e" fill={OUTCOME.deferred} name="deferred"
+                       stroke={CHART.tooltipBg} strokeWidth={2} />
+                  <Bar dataKey="failed" stackId="e" fill={OUTCOME.failed} name="failed"
+                       stroke={CHART.tooltipBg} strokeWidth={2} />
                 </BarChart>
               </ResponsiveContainer>
             </div>

--- a/apps/server/dashboard/src/components/HomePage.tsx
+++ b/apps/server/dashboard/src/components/HomePage.tsx
@@ -70,8 +70,6 @@ type StatRange = "today" | "7d" | "30d";
  * informational, it costs $0, and it clears itself. It fixes the numbers too:
  * amber was the one step failing contrast on white (1.83:1).
  *
- * Two choices carry that, and neither is cosmetic:
- *
  * Red/green dichromacy is the binding constraint on the whole palette, and it
  * cannot be solved by choosing a better red OR a better green in isolation —
  * only by moving the pair apart. (The dashboard's old dark pastels,
@@ -94,11 +92,18 @@ const OUTCOME = {
 };
 
 /**
- * Bottom-to-top stack order, and the single source of it. Declared as data
- * rather than left implicit in the JSX because the tooltip has to REVERSE it:
- * a list reads top-down while a stack builds bottom-up, so listing the bands
- * in stack order puts `succeeded` at the top of the tooltip and `failed` at
- * the bottom — the mirror image of the bar the reader is pointing at.
+ * Bottom-to-top stack order — `succeeded` is the bottom band, `failed` the
+ * top — and the single source of it.
+ *
+ * Declared as data rather than left implicit in the JSX because the tooltip
+ * must list the bands in the order the eye meets them going DOWN the bar,
+ * i.e. `failed` first and `succeeded` last. A tooltip is read top-down; a
+ * stack is built bottom-up; so the tooltip needs this array reversed.
+ *
+ * That reversal is the `-` in the `itemSorter` below, and it is load-bearing:
+ * recharts sorts the payload with lodash `sortBy` (ascending), so negating
+ * the index yields failed(-3) → deferred(-2) → skipped(-1) → succeeded(0).
+ * Dropping the `-` produces exactly the mirror image of the bar.
  */
 const OUTCOME_STACK = ["succeeded", "skipped", "deferred", "failed"] as const;
 
@@ -651,9 +656,11 @@ function StatsChartsSection() {
     succeeded: d.succeeded,
     deferred: d.deferred,
     failed: d.failed,
-    // `skipped` is deliberately absent from the stack: a cascade skip is the
-    // CONSEQUENCE of another row's outcome, so stacking it renders one incident
-    // twice. It stays in the tooltip via `executions`.
+    // `skipped` IS in the stack, as a hatch rather than a solid fill — the
+    // phase never ran, so texture carries it instead of hue. Keeping it in is
+    // what makes the bar total to the "Executions" stat card above: it is 31%
+    // of rows on a busy day, so dropping it would make the two disagree by a
+    // third and silently understate the volume.
     skipped: d.skipped,
     inputTokens: d.inputTokens,
     outputTokens: d.outputTokens,

--- a/apps/server/src/state/execution-store.ts
+++ b/apps/server/src/state/execution-store.ts
@@ -176,6 +176,58 @@ function mapExecutionRow(r: Record<string, unknown>): ExecutionRecord {
   };
 }
 
+/** The four ways a finished execution can have turned out (issue #325). */
+export interface ExecutionOutcomeCounts {
+  succeeded: number;
+  skipped: number;
+  deferred: number;
+  failed: number;
+}
+
+/**
+ * The outcome classification, as SQL — the ONE definition every aggregation
+ * selects (issue #325).
+ *
+ * `executions.success` is not a health signal and must not be read as one.
+ * Two paths write `success = 0` deliberately, having failed at nothing:
+ *
+ *  - **`skipped`** — {@link ExecutionStore.recordSkippedPhase}. Stored
+ *    `success = 0` so {@link ExecutionStore.shouldRunPhase} re-evaluates the
+ *    node on resume. The phase never ran.
+ *  - **`error_quota`** — the k8s `ResourceQuota` rejected the pod. The runner
+ *    treats it as an ordinary phase failure precisely so the run REQUEUES
+ *    (`src/workflows/runner.ts`), and it costs $0 and 0 turns.
+ *
+ * So the column correctly answers *"may this phase be skipped on resume?"*,
+ * where skipped / quota-rejected / crashed are one answer. It was never asked
+ * "did something go wrong", and rendering it as though it was painted 251 of a
+ * day's 423 executions red on an instance with zero real failures.
+ *
+ * Held here as a single fragment rather than repeated per query because three
+ * aggregations consume it, and three copies would disagree the first time one
+ * was edited — the same argument `PrState` makes against six sites each
+ * fetching an overlapping subset of the truth.
+ *
+ * `success IS NULL` (still in flight) matches no bucket on purpose: it counts
+ * toward `COUNT(*)` and toward nothing else, so a stacked bar can legitimately
+ * be shorter than the execution total.
+ *
+ * Note `condition_not_met` — a generic-loop `until_bash` check that ran and
+ * came back red — is stored `success = 1` and therefore lands in `succeeded`.
+ * It really executed and really cost tokens; only its per-row rendering is
+ * muted (`execMark`, `packages/cli/src/cli-format.ts`).
+ */
+export const EXECUTION_OUTCOME_COLUMNS = `
+        SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) AS succeeded,
+        SUM(CASE WHEN success = 0 AND stop_reason = 'skipped' THEN 1 ELSE 0 END) AS skipped,
+        SUM(CASE WHEN success = 0 AND stop_reason = 'error_quota' THEN 1 ELSE 0 END) AS deferred,
+        SUM(CASE WHEN success = 0
+                  AND (stop_reason IS NULL OR stop_reason NOT IN ('skipped', 'error_quota'))
+             THEN 1 ELSE 0 END) AS failed`;
+
+/** Zero-fill for a bucket with no executions in it. */
+const NO_OUTCOMES: ExecutionOutcomeCounts = { succeeded: 0, skipped: 0, deferred: 0, failed: 0 };
+
 export class ExecutionStore {
   constructor(private db: Database.Database) {}
 
@@ -786,7 +838,7 @@ export class ExecutionStore {
   executionStats(): {
     total_executions: number;
     today_count: number;
-    by_skill: Record<string, { count: number; success: number; fail: number }>;
+    by_skill: Record<string, ExecutionOutcomeCounts & { count: number }>;
     by_trigger: Record<string, number>;
     running: number;
   } {
@@ -800,14 +852,19 @@ export class ExecutionStore {
 
     const skillRows = this.db.prepare(`
       SELECT skill, COUNT(*) as count,
-        SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) as success,
-        SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) as fail
+        ${EXECUTION_OUTCOME_COLUMNS}
       FROM executions GROUP BY skill
-    `).all() as { skill: string; count: number; success: number; fail: number }[];
+    `).all() as ({ skill: string; count: number } & ExecutionOutcomeCounts)[];
 
-    const by_skill: Record<string, { count: number; success: number; fail: number }> = {};
+    const by_skill: Record<string, ExecutionOutcomeCounts & { count: number }> = {};
     for (const r of skillRows) {
-      by_skill[r.skill] = { count: r.count, success: r.success, fail: r.fail };
+      by_skill[r.skill] = {
+        count: r.count,
+        succeeded: r.succeeded,
+        skipped: r.skipped,
+        deferred: r.deferred,
+        failed: r.failed,
+      };
     }
 
     const triggerRows = this.db.prepare(`
@@ -823,17 +880,15 @@ export class ExecutionStore {
   }
 
   /** Daily aggregated stats for the last N days */
-  dailyStats(days: number): {
+  dailyStats(days: number): (ExecutionOutcomeCounts & {
     date: string;
     executions: number;
-    successes: number;
-    failures: number;
     totalTokens: number;
     inputTokens: number;
     outputTokens: number;
     cacheReadTokens: number;
     costUsd: number;
-  }[] {
+  })[] {
     // Build the inclusive UTC date window: [today - (days-1), today].
     // SQLite's date(started_at) returns a UTC YYYY-MM-DD string, so we
     // generate the same format here to align keys.
@@ -855,8 +910,7 @@ export class ExecutionStore {
       SELECT
         date(started_at) AS date,
         COUNT(*) AS executions,
-        SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) AS successes,
-        SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS failures,
+        ${EXECUTION_OUTCOME_COLUMNS},
         COALESCE(SUM(input_tokens), 0) + COALESCE(SUM(output_tokens), 0) + COALESCE(SUM(cache_read_input_tokens), 0) AS totalTokens,
         COALESCE(SUM(input_tokens), 0) AS inputTokens,
         COALESCE(SUM(output_tokens), 0) AS outputTokens,
@@ -865,24 +919,21 @@ export class ExecutionStore {
       FROM executions
       WHERE date(started_at) >= ?
       GROUP BY date(started_at)
-    `).all(dateKeys[0]) as {
+    `).all(dateKeys[0]) as (ExecutionOutcomeCounts & {
       date: string;
       executions: number;
-      successes: number;
-      failures: number;
       totalTokens: number;
       inputTokens: number;
       outputTokens: number;
       cacheReadTokens: number;
       costUsd: number;
-    }[];
+    })[];
 
     const byDate = new Map(rows.map((r) => [r.date, r]));
     return dateKeys.map((date) => byDate.get(date) ?? {
       date,
       executions: 0,
-      successes: 0,
-      failures: 0,
+      ...NO_OUTCOMES,
       totalTokens: 0,
       inputTokens: 0,
       outputTokens: 0,
@@ -892,17 +943,15 @@ export class ExecutionStore {
   }
 
   /** Hourly aggregated stats for the last N hours (UTC). Bucket key is `YYYY-MM-DDTHH`. */
-  hourlyStats(hours: number): {
+  hourlyStats(hours: number): (ExecutionOutcomeCounts & {
     date: string;
     executions: number;
-    successes: number;
-    failures: number;
     totalTokens: number;
     inputTokens: number;
     outputTokens: number;
     cacheReadTokens: number;
     costUsd: number;
-  }[] {
+  })[] {
     const now = new Date();
     const startUtc = new Date(Date.UTC(
       now.getUTCFullYear(),
@@ -923,8 +972,7 @@ export class ExecutionStore {
       SELECT
         strftime('%Y-%m-%dT%H', started_at) AS date,
         COUNT(*) AS executions,
-        SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) AS successes,
-        SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS failures,
+        ${EXECUTION_OUTCOME_COLUMNS},
         COALESCE(SUM(input_tokens), 0) + COALESCE(SUM(output_tokens), 0) + COALESCE(SUM(cache_read_input_tokens), 0) AS totalTokens,
         COALESCE(SUM(input_tokens), 0) AS inputTokens,
         COALESCE(SUM(output_tokens), 0) AS outputTokens,
@@ -933,24 +981,21 @@ export class ExecutionStore {
       FROM executions
       WHERE strftime('%Y-%m-%dT%H', started_at) >= ?
       GROUP BY strftime('%Y-%m-%dT%H', started_at)
-    `).all(hourKeys[0]) as {
+    `).all(hourKeys[0]) as (ExecutionOutcomeCounts & {
       date: string;
       executions: number;
-      successes: number;
-      failures: number;
       totalTokens: number;
       inputTokens: number;
       outputTokens: number;
       cacheReadTokens: number;
       costUsd: number;
-    }[];
+    })[];
 
     const byHour = new Map(rows.map((r) => [r.date, r]));
     return hourKeys.map((date) => byHour.get(date) ?? {
       date,
       executions: 0,
-      successes: 0,
-      failures: 0,
+      ...NO_OUTCOMES,
       totalTokens: 0,
       inputTokens: 0,
       outputTokens: 0,

--- a/apps/server/tests/state/db.test.ts
+++ b/apps/server/tests/state/db.test.ts
@@ -471,12 +471,12 @@ describe("dailyStats", () => {
     const d2 = rows.find((r) => r.date === day2.key);
     expect(d1).toBeDefined();
     expect(d1!.executions).toBe(2);
-    expect(d1!.successes).toBe(1);
-    expect(d1!.failures).toBe(1);
+    expect(d1!.succeeded).toBe(1);
+    expect(d1!.failed).toBe(1);
     expect(d2).toBeDefined();
     expect(d2!.executions).toBe(1);
-    expect(d2!.successes).toBe(1);
-    expect(d2!.failures).toBe(0);
+    expect(d2!.succeeded).toBe(1);
+    expect(d2!.failed).toBe(0);
   });
 
   it("sums token and cost data correctly", () => {

--- a/apps/server/tests/state/execution-outcome.test.ts
+++ b/apps/server/tests/state/execution-outcome.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { StateDb } from "#src/state/db.js";
+
+/**
+ * The stats aggregations must not read `executions.success` as a health signal
+ * (issue #325).
+ *
+ * `success = 0` is written deliberately by two paths that did not fail:
+ * `recordSkippedPhase` needs it so `shouldRunPhase` re-evaluates the node on
+ * resume, and the runner needs it on a `ResourceQuota` rejection so the run
+ * requeues. The column answers "may this phase be skipped on resume?", for
+ * which skipped, quota-rejected and crashed are all correctly the same answer
+ * — so the aggregations classify on `(success, stop_reason)` instead.
+ */
+describe("execution outcome classification (issue #325)", () => {
+  let db: StateDb;
+
+  /** Write one finished execution with an explicit outcome shape. */
+  function exec(id: string, opts: { success?: boolean; stopReason?: string; skill?: string }) {
+    db.executions.recordStart({
+      id,
+      triggerType: "webhook",
+      triggerId: "owner/repo#1",
+      skill: opts.skill ?? "pr-review:review",
+      owner: "owner",
+      repo: "repo",
+      issueNumber: 1,
+      startedAt: new Date().toISOString(),
+    });
+    if (opts.success !== undefined) {
+      db.executions.recordFinish(id, { success: opts.success, stopReason: opts.stopReason });
+    }
+  }
+
+  /** Today's bucket, which is where every row written by `exec` lands. */
+  function today() {
+    const rows = db.executions.dailyStats(1);
+    expect(rows).toHaveLength(1);
+    return rows[0]!;
+  }
+
+  beforeEach(() => {
+    db = new StateDb(":memory:");
+  });
+
+  it("counts a successful execution as succeeded", () => {
+    exec("e-ok", { success: true, stopReason: "success" });
+
+    expect(today()).toMatchObject({ executions: 1, succeeded: 1, skipped: 0, deferred: 0, failed: 0 });
+  });
+
+  it("counts a cascade-skipped phase as skipped, not failed", () => {
+    db.executions.recordSkippedPhase("pr-review:post-review", "owner/repo#1", "wfr-1", "repo", "owner");
+
+    expect(today()).toMatchObject({ executions: 1, succeeded: 0, skipped: 1, deferred: 0, failed: 0 });
+  });
+
+  it("counts a ResourceQuota rejection as deferred, not failed", () => {
+    exec("e-quota", { success: false, stopReason: "error_quota" });
+
+    expect(today()).toMatchObject({ executions: 1, succeeded: 0, skipped: 0, deferred: 1, failed: 0 });
+  });
+
+  it("counts a real agent error as failed", () => {
+    exec("e-fatal", { success: false, stopReason: "error_fatal" });
+
+    expect(today()).toMatchObject({ executions: 1, succeeded: 0, skipped: 0, deferred: 0, failed: 1 });
+  });
+
+  it("counts a failure with no stop reason as failed", () => {
+    exec("e-null", { success: false });
+
+    expect(today()).toMatchObject({ executions: 1, failed: 1 });
+  });
+
+  it("counts an in-flight execution in the total but in no outcome bucket", () => {
+    exec("e-running", {});
+
+    expect(today()).toMatchObject({ executions: 1, succeeded: 0, skipped: 0, deferred: 0, failed: 0 });
+  });
+
+  it("counts a generic-loop check that came back red as succeeded", () => {
+    // `condition_not_met` is stored `success = 1` because the CHECK ran fine —
+    // the loop simply isn't finished. It cost real tokens and really executed,
+    // so it belongs in the green band; only its per-row rendering is muted
+    // (`execMark` in packages/cli/src/cli-format.ts).
+    exec("e-unmet", { success: true, stopReason: "condition_not_met" });
+
+    expect(today()).toMatchObject({ executions: 1, succeeded: 1, failed: 0 });
+  });
+
+  it("classifies the same way in hourlyStats", () => {
+    exec("e-ok", { success: true });
+    exec("e-quota", { success: false, stopReason: "error_quota" });
+    exec("e-fatal", { success: false, stopReason: "error_fatal" });
+    db.executions.recordSkippedPhase("pr-review:post-review", "owner/repo#1", "wfr-1", "repo", "owner");
+
+    const hour = db.executions.hourlyStats(1);
+    expect(hour).toHaveLength(1);
+    expect(hour[0]).toMatchObject({ executions: 4, succeeded: 1, skipped: 1, deferred: 1, failed: 1 });
+  });
+
+  it("classifies the same way in executionStats().by_skill", () => {
+    exec("e-ok", { success: true, skill: "pr-review:review" });
+    exec("e-quota", { success: false, stopReason: "error_quota", skill: "pr-review:review" });
+    exec("e-fatal", { success: false, stopReason: "error_fatal", skill: "pr-review:review" });
+    db.executions.recordSkippedPhase("pr-review:review", "owner/repo#1", "wfr-1", "repo", "owner");
+
+    const stats = db.executions.executionStats();
+    expect(stats.by_skill["pr-review:review"]).toMatchObject({
+      count: 4,
+      succeeded: 1,
+      skipped: 1,
+      deferred: 1,
+      failed: 1,
+    });
+  });
+
+  it("keeps a skipped phase re-runnable on resume", () => {
+    // The invariant a careless fix breaks: reclassifying must NOT reach for
+    // `success = 1`, because `shouldRunPhase` reads that column to decide
+    // whether a phase is already done.
+    db.executions.recordSkippedPhase("pr-review:post-review", "owner/repo#1", "wfr-1", "repo", "owner");
+
+    expect(db.executions.shouldRunPhase("pr-review:post-review", "owner/repo#1", "wfr-1")).toBe("run");
+    expect(today().skipped).toBe(1);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -824,14 +824,20 @@ async function cmdStats(): Promise<void> {
     const rows = (data.daily as any[]).map((d) => ({
       date: d.date,
       execs: String(d.executions),
-      ok: String(d.successes),
-      fail: String(d.failures),
+      ok: String(d.succeeded),
+      // Neither a pass nor a fail — see `execMark` in cli-format.ts for the
+      // per-row equivalent. `skip` is a cascade skip (the phase never ran),
+      // `defer` is a k8s ResourceQuota rejection that requeued (issue #325).
+      skip: d.skipped ? chalk.dim(String(d.skipped)) : "0",
+      defer: d.deferred ? chalk.yellow(String(d.deferred)) : "0",
+      fail: d.failed ? chalk.red(String(d.failed)) : "0",
       tokens: String(d.totalTokens ?? 0),
       cost: `$${(d.costUsd ?? 0).toFixed(2)}`,
     }));
     console.log(table(rows, [
       { key: "date", header: "DATE" }, { key: "execs", header: "EXECS" },
-      { key: "ok", header: "OK" }, { key: "fail", header: "FAIL" },
+      { key: "ok", header: "OK" }, { key: "skip", header: "SKIP" },
+      { key: "defer", header: "DEFER" }, { key: "fail", header: "FAIL" },
       { key: "tokens", header: "TOKENS" }, { key: "cost", header: "COST" },
     ]));
     return;
@@ -845,14 +851,23 @@ async function cmdStats(): Promise<void> {
   console.log(`${chalk.bold("Total executions")}  ${data.total_executions}`);
   console.log(`${chalk.bold("Today")}             ${data.today_count}`);
   console.log(`${chalk.bold("Running")}           ${data.running}`);
-  const bySkill = data.by_skill as Record<string, { count: number; success: number; fail: number }>;
+  const bySkill = data.by_skill as Record<
+    string,
+    { count: number; succeeded: number; skipped: number; deferred: number; failed: number }
+  >;
   const rows = Object.entries(bySkill).map(([skill, v]) => ({
-    skill, count: String(v.count), ok: chalk.green(String(v.success)), fail: v.fail ? chalk.red(String(v.fail)) : "0",
+    skill,
+    count: String(v.count),
+    ok: chalk.green(String(v.succeeded)),
+    skip: v.skipped ? chalk.dim(String(v.skipped)) : "0",
+    defer: v.deferred ? chalk.yellow(String(v.deferred)) : "0",
+    fail: v.failed ? chalk.red(String(v.failed)) : "0",
   }));
   console.log("");
   console.log(table(rows, [
     { key: "skill", header: "SKILL" }, { key: "count", header: "RUNS" },
-    { key: "ok", header: "OK" }, { key: "fail", header: "FAIL" },
+    { key: "ok", header: "OK" }, { key: "skip", header: "SKIP" },
+    { key: "defer", header: "DEFER" }, { key: "fail", header: "FAIL" },
   ]));
 }
 


### PR DESCRIPTION
Implements #325. Also supersedes the plan doc in #326 — happy to close that in favour of this, or land it first as the record.

## The bug

The stats chart shaded `executions.success = 0` red. Measured on a homelab instance (v0.25.5), 11 Aug 2026:

```
423 executions = 172 green + 251 RED

  stop_reason = 'skipped'       131   $0.000   "skipped: trigger rule not satisfied"
  stop_reason = 'error_quota'   120   $0.000   "pod create rejected by ResourceQuota"
  ────────────────────────────────────────────
  actual failures                 0
```

59% of the bar red on a day nothing failed. They compound: a quota rejection fails `review`, the cascade skips `post-review`, so each retry writes **two** red rows ~15s apart.

## Why the fix is in the reader

Both populations are `success = 0` **deliberately**, and both must stay:

- `recordSkippedPhase` — *"Because it is not `success = 1`, `shouldRunPhase` re-evaluates it on resume"*
- `runner.ts` — *"the engine treats `error_quota` as an ordinary phase failure and requeue"*

`executions.success` correctly answers *"may this phase be skipped on resume?"*, where skipped / quota-rejected / crashed genuinely are one answer. It was never asked about health. A test pins the invariant a careless fix would break — that a `recordSkippedPhase` row classifies as `skipped` **and is still re-run by `shouldRunPhase`**.

## What changed

`EXECUTION_OUTCOME_COLUMNS` derives `succeeded | skipped | deferred | failed` from `(success, stop_reason)` in **one** place, consumed by `dailyStats`, `hourlyStats` and `executionStats().by_skill`. Deriving rather than adding an `outcome` column avoids duplicating state `success` still has to carry; deriving in the store rather than the chart stops the three readers drifting. No migration — history reclassifies at query time.

`lastlight stats --daily` and the by-skill table gain SKIP/DEFER columns alongside OK/FAIL.

## The chart

Rebuilt around the distinction, and every colour decision is measured (OKLab ΔE×100, min of protan/deutan) rather than chosen by eye:

| band | fill |
|---|---|
| succeeded | `#0ca30c` solid |
| skipped | `#6b7280` 45° hatch |
| deferred | `#4a7fb5` solid |
| failed | `#cc2b5e` solid |

- **`skipped` is a hatch, not a colour.** It is the one band that is not an outcome, and hue could not carry it — every neutral that read as "absence" landed too close to the green (best case ΔE 15.9, nominally over the floor and still visibly similar). Texture is a different channel, so it separates under any colour blindness, in greyscale, and under `forced-colors`. Its definition is a tinted body rather than a border: SVG centres a stroke on the edge, so a visible border renders that segment ~4px wider than the rest of the column.
- **The red is a crimson so the green can be a green.** A true green against a pure red is ΔE **4.1** for deuteranopes. The pair has to move together; cooling the red is what buys a green that looks like success rather than a teal compromise.
- **`deferred` is blue, not amber.** It was the least consequential band and the loudest thing on the chart — Tufte's "smallest effective difference" run backwards. Carbon reserves amber for warnings, and a full sandbox queue is informational: $0, self-healing. Blue also fixed the one contrast failure (amber was 1.83:1 on white).
- **Stack order is semantic** (nothing wrong → nothing happened → load → bad). That only became possible once deferred stopped being amber; the hatch now separates green from blue, leaving deferred↔failed (ΔE 19.0) as the only solid-solid boundary, against 13.5 before.

Every solid pair clears the ΔE 8 CVD target and the 15 normal-vision floor, in **both** themes. A legend is always present (never colour alone), and the tooltip lists per-band counts in stack order with zeroes dropped, under a total that reconciles with the Executions stat card.

Worth noting: the published colourblind-safe palettes (Okabe–Ito, Paul Tol bright/muted, ColorBrewer Dark2) were all tested first and all fail these checks, three of them on exactly the neutral-vs-green pair. The resolution isn't a better palette, it's Okabe & Ito's own rule — don't encode in colour alone.

## Verification

- New `tests/state/execution-outcome.test.ts` — the full `(success, stop_reason)` matrix incl. NULL, across `dailyStats` / `hourlyStats` / `executionStats`, plus the resume invariant. Written first and watched fail.
- Full server suite **2966 passed**, 20 skipped, 0 failed.
- CLI suite 112 passed. `lastlight-core`, `@lastlight/dashboard` and `lastlight` all typecheck clean.
- The new classification SQL was run against the live instance DB: 251 red → **0 failed / 120 deferred / 131 skipped**.

Unrelated pre-existing breakage, confirmed on a clean `upstream/main` checkout: `lastlight-shared` fails `tsc` with `Module '"@earendil-works/pi-ai"' has no exported member 'ProviderAuthInteraction'`, which blocks `turbo run typecheck`. Typechecked around it per package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017csqMy58ivRbLTKojhQnpJ
