### PR TITLE
fix(dashboard): share one status palette, repairing the feedback CVD pair

### DIFF
--- a/apps/server/dashboard/src/components/FeedbackPage.tsx
+++ b/apps/server/dashboard/src/components/FeedbackPage.tsx
@@ -18,6 +18,7 @@ import {
   type FeedbackSummaryRow,
 } from "../api";
 import { useTheme } from "../hooks/useTheme";
+import { STATUS } from "../lib/status-colors";
 
 /**
  * Feedback signals (issue #255) — 👍/👎 people left on what Last Light wrote,
@@ -30,11 +31,16 @@ import { useTheme } from "../hooks/useTheme";
  */
 
 // Recharts parses fill strings internally and can't resolve `hsl(var(--p))`,
-// so the palettes are literal hex per theme. Same constraint (and the same
-// values) as HomePage's charts.
+// so what remains here is literal hex per theme: `score` is a CATEGORICAL line
+// colour and stays local.
+//
+// `positive` / `negative` are NOT themed and are NOT this page's to pick — a
+// 👍 is the same `good` as a succeeded run, so both come from the shared
+// STATUS palette (issue #329). They used to be per-theme literals here, which
+// drifted from the Home page's and, worse, made the dark pair `#86efac` /
+// `#fca5a5` — ΔE 5.8 for deuteranopes, below the floor, on the two bars in
+// this view that most need telling apart.
 const CHART_DARK = {
-  positive: "#86efac",
-  negative: "#fca5a5",
   score: "#7dd3fc",
   grid: "#21262d",
   axis: "rgba(230, 237, 243, 0.45)",
@@ -43,8 +49,6 @@ const CHART_DARK = {
 };
 
 const CHART_LIGHT = {
-  positive: "#07a06f",
-  negative: "#dc2626",
   score: "#0b3b63",
   grid: "#e2e6ea",
   axis: "rgba(27, 35, 48, 0.55)",
@@ -253,8 +257,8 @@ export function FeedbackPage() {
                   />
                   {/* The one zero both scales share — drawn, not implied. */}
                   <ReferenceLine yAxisId="count" y={0} stroke={CHART.axis} />
-                  <Bar yAxisId="count" dataKey="positive" fill={CHART.positive} name="positive" />
-                  <Bar yAxisId="count" dataKey="negative" fill={CHART.negative} name="negative" />
+                  <Bar yAxisId="count" dataKey="positive" fill={STATUS.good} name="positive" />
+                  <Bar yAxisId="count" dataKey="negative" fill={STATUS.bad} name="negative" />
                   <Line
                     yAxisId="score"
                     type="monotone"

--- a/apps/server/dashboard/src/components/HomePage.tsx
+++ b/apps/server/dashboard/src/components/HomePage.tsx
@@ -16,6 +16,7 @@ import type { LucideIcon } from "lucide-react";
 import { api, type WorkflowRun, type ContainerStats, type ContainerKind, type HostStats } from "../api";
 import { useStatsSeries } from "../hooks/useDailyStats";
 import { useTheme } from "../hooks/useTheme";
+import { STATUS } from "../lib/status-colors";
 import { repoUrl, issueUrl, runRepoPath } from "../lib/githubLinks";
 import { useVisibleRepos, repoScopeParam } from "../hooks/useVisibleRepos";
 import { GhLink } from "./GhLink";
@@ -29,66 +30,19 @@ type StatRange = "today" | "7d" | "30d";
 // the chart renders — CHART_DARK matches the daisyUI `lastlight` theme,
 // CHART_LIGHT matches `neaform`. Selected in-component via useTheme().
 /**
- * Execution outcome — a STATUS palette, not a categorical one (issue #325).
+ * Execution outcome, mapped onto the shared STATUS palette (issues #325, #329).
  *
- * The four bands are states, not identities, so they take reserved status hues
- * and are **mode-invariant**: the same steps clear 3:1 on both the light card
- * (`#ffffff`) and the dark one (`#161b22`), and re-stepping them per theme
- * would only re-open the separation problem below.
- *
- * Only THREE of the four are solid fills. `skipped` is a hatch (see the
- * `<pattern>` at the chart), because it is the one band that is not an
- * outcome — and because hue could not carry it: every neutral that read as
- * "absence" landed too close to the green, and the best of them (ΔE 15.9,
- * nominally over the floor) was still called out as similar on sight. A floor
- * is a minimum, not a target. Texture is a different channel, so it separates
- * unconditionally.
- *
- * With `skipped` out of the colour set there are only three solids left, and
- * that is the whole reason this palette passes every check in both modes —
- * measured, not eyeballed (OKLab ΔE×100, min of protan/deutan):
- *
- *   succeeded ↔ deferred   22.1   (normal 26.0)
- *   deferred  ↔ failed     14.6   (normal 26.1)
- *   succeeded ↔ failed      8.7   (normal 37.7)   ← worst CVD
- *
- * **The red is a crimson so the green can be a green.** These two move
- * together: a true green (`#0ca30c`) against a pure red (`#d03b3b`) measures
- * ΔE 4.1 for deuteranopes — unusable — and every greener green collides the
- * same way. Cooling the red to `#cc2b5e` buys the room, and only then does
- * `succeeded` get to look like success rather than a teal compromise. The
- * earlier emerald was the other end of the same trade.
- *
- * **`deferred` is BLUE, not amber, and that is a salience decision.** The
- * bands are not equally important — succeeded is the signal, skipped is
- * unremarkable, deferred is an indication of load, failed is bad — so visual
- * weight has to track that order (Tufte's "smallest effective difference";
- * Few's rule that saturation is a budget spent only on what needs attention).
- * A bright amber made the LEAST consequential band the loudest thing on the
- * chart. Blue also stops it overclaiming: Carbon reserves yellow/orange for
- * "regular"/"serious warning", and a full sandbox queue is neither — it is
- * informational, it costs $0, and it clears itself. It fixes the numbers too:
- * amber was the one step failing contrast on white (1.83:1).
- *
- * Red/green dichromacy is the binding constraint on the whole palette, and it
- * cannot be solved by choosing a better red OR a better green in isolation —
- * only by moving the pair apart. (The dashboard's old dark pastels,
- * `#86efac`/`#fca5a5`, measured 5.8: below the ΔE 6 floor outright.)
- *
- * Two knowingly-accepted validator complaints, both properties of a status
- * palette rather than defects:
- *  - `skipped` fails the chroma floor. It is grey ON PURPOSE — grey IS the
- *    message ("nothing ran"), and a status hue there would imply one did.
- *  - `deferred` sits outside the categorical lightness band, and is sub-3:1 on
- *    the light surface (1.83). Both are documented properties of the reference
- *    `warning` step; the prescribed mitigation is never colour alone — hence
- *    the `<Legend>`.
+ * The colours, and every measurement justifying them, live in
+ * `lib/status-colors.ts` — they are not this chart's to choose, because
+ * "good" has to mean the same green here as on the feedback page. What IS
+ * local to this chart is how the four are rendered: see the `<Bar>` stack for
+ * the hatch, the stack order and the gap.
  */
 const OUTCOME = {
-  succeeded: "#0ca30c",
-  skipped: "#6b7280",
-  deferred: "#4a7fb5",
-  failed: "#cc2b5e",
+  succeeded: STATUS.good,
+  skipped: STATUS.neutral,
+  deferred: STATUS.info,
+  failed: STATUS.bad,
 };
 
 /**
@@ -118,8 +72,6 @@ function outcomeTooltipFormatter(value: unknown, name: unknown): [string, string
 }
 
 const CHART_DARK = {
-  success: "#86efac",
-  error: "#fca5a5",
   primary: "#7dd3fc",
   secondary: "#c4b5fd",
   accent: "#fcd34d",
@@ -131,8 +83,6 @@ const CHART_DARK = {
 };
 
 const CHART_LIGHT = {
-  success: "#07a06f",
-  error: "#dc2626",
   primary: "#0b3b63",
   secondary: "#7c3aed",
   accent: "#b45309",

--- a/apps/server/dashboard/src/lib/status-colors.ts
+++ b/apps/server/dashboard/src/lib/status-colors.ts
@@ -1,0 +1,64 @@
+/**
+ * The reserved STATUS palette — the one place in the SPA that names a colour
+ * meaning "good", "bad", "informational" or "nothing happened" (issue #329).
+ *
+ * Status colours are a different job from categorical ones. A categorical hue
+ * answers *which series is this?* and may be themed freely; a status hue
+ * answers *how bad is this?* and must mean the same thing on every page. A run
+ * that succeeded and a 👍 are both `good`, so they are the same green — they
+ * were not, and the two pages drifted ΔE 9.3 (green) and 7.3 (red) apart:
+ * near enough to read as one idea, far enough to look like a bug.
+ *
+ * **Mode-invariant on purpose.** The same four steps clear 3:1 on the light
+ * card (`#ffffff`) and the dark one (`#161b22`), and re-stepping them per
+ * theme would re-open the separation problem below for no gain.
+ *
+ * ## Measured, not eyeballed
+ *
+ * OKLab ΔE×100, min of protan/deutan. Every pair clears the ΔE 8 CVD target
+ * and the 15 normal-vision floor, in both themes:
+ *
+ *   good ↔ info    22.1   (normal 26.0)
+ *   info ↔ bad     14.6   (normal 26.1)
+ *   good ↔ bad      8.7   (normal 37.7)   ← worst, and the one that binds
+ *
+ * **`bad` is a crimson so `good` can be a green.** These two move together:
+ * red/green dichromacy cannot be fixed by choosing a better red OR a better
+ * green in isolation. A true green against a pure red (`#0ca30c` / `#d03b3b`)
+ * measures ΔE **4.1** for deuteranopes — unusable — and every greener green
+ * collides the same way. Cooling the red buys the room. The pastels this
+ * replaced (`#86efac` / `#fca5a5`) measured **5.8**, below the ΔE 6 floor
+ * outright, on the two quantities in the feedback view most needing to be
+ * told apart.
+ *
+ * **`info` is blue rather than amber** because it is the least consequential
+ * band and amber made it the loudest thing on the chart — visual weight has to
+ * track importance (Tufte's "smallest effective difference"). Amber also
+ * overclaims: reserved vocabularies put yellow/orange at "warning", and a
+ * queued run is informational, costs nothing and clears itself. It failed
+ * contrast on white (1.83:1) into the bargain.
+ *
+ * **`neutral` is grey ON PURPOSE** — grey *is* the message ("nothing ran"),
+ * and a status hue there would imply something did. It is deliberately below
+ * the chroma floor, which is why it is never asked to carry a band by itself:
+ * on the executions chart it is the line colour of a hatch, not a fill.
+ *
+ * Two knowingly-accepted validator complaints, both properties of a status
+ * palette rather than defects: `neutral` fails the chroma floor (above), and
+ * nothing here may be used as a categorical series colour — a status colour
+ * must never impersonate a series.
+ *
+ * Never colour alone: every consumer pairs these with a legend or a label.
+ */
+export const STATUS = {
+  /** Succeeded · positive feedback. */
+  good: "#0ca30c",
+  /** Nothing happened — skipped, absent, not applicable. */
+  neutral: "#6b7280",
+  /** Informational: real, worth seeing, not a problem. */
+  info: "#4a7fb5",
+  /** Failed · negative feedback. */
+  bad: "#cc2b5e",
+} as const;
+
+export type StatusKey = keyof typeof STATUS;

--- a/apps/server/tests/admin/dashboard-status-palette.test.ts
+++ b/apps/server/tests/admin/dashboard-status-palette.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The status palette is defined ONCE for the whole SPA (issue #329).
+ *
+ * `good` and `bad` are the same idea on every page — a run that succeeded and
+ * a 👍 are both "good" — so they must be the same two hexes. They were not:
+ * the Home page and the Feedback page each carried their own `CHART_DARK` /
+ * `CHART_LIGHT` literals, and after the outcome work landed they disagreed by
+ * ΔE 9.3 (green) and 7.3 (red). That is the worst possible distance: near
+ * enough to read as the same idea, far enough to look like a bug.
+ *
+ * Feedback's copy was also the pre-fix pastel pair, `#86efac` / `#fca5a5`,
+ * which measures **ΔE 5.8 for deuteranopes** — below the ΔE 6 floor — on the
+ * two quantities in that view most needing to be told apart.
+ *
+ * Read as TEXT rather than imported, exactly like `dashboard-config-mirror`:
+ * the SPA is a separate Vite app with no import edge to core, and "a page
+ * hardcoded its own status hex" is a source-level fact.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+
+const DASHBOARD = join(import.meta.dirname, "../../dashboard/src");
+const read = (rel: string) => readFileSync(join(DASHBOARD, rel), "utf8");
+
+/**
+ * The same source with comments stripped.
+ *
+ * The invariant is about CODE: a page must not *use* its own status hex. Prose
+ * is the opposite — `FeedbackPage` names the retired `#86efac` / `#fca5a5`
+ * precisely to record why they went, and a test that forbade saying so would
+ * push out the explanation and keep the bug's epitaph nowhere.
+ */
+const readCode = (rel: string) =>
+  read(rel)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+
+/** The one module allowed to name a status colour. */
+const PALETTE = "lib/status-colors.ts";
+
+/** Every page that renders a status colour, and must therefore import them. */
+const CONSUMERS = ["components/HomePage.tsx", "components/FeedbackPage.tsx"];
+
+/**
+ * The retired literals. Each is a hex some page used to hardcode for a status
+ * meaning; none may reappear anywhere in the SPA.
+ *
+ * `#07a06f` and `#dc2626` are the old light-theme good/bad, `#86efac` and
+ * `#fca5a5` the dark-theme pair that failed CVD separation.
+ */
+const RETIRED = ["#07a06f", "#dc2626", "#86efac", "#fca5a5"];
+
+describe("dashboard status palette (issue #329)", () => {
+  it("defines the four status colours in one shared module", () => {
+    expect(existsSync(join(DASHBOARD, PALETTE))).toBe(true);
+
+    const src = read(PALETTE);
+    for (const key of ["good", "neutral", "info", "bad"]) {
+      expect(src).toMatch(new RegExp(`\\b${key}\\s*:`));
+    }
+  });
+
+  it("keeps the validated good/bad pair, which is what repairs the CVD failure", () => {
+    const src = read(PALETTE);
+    expect(src).toContain("#0ca30c");
+    expect(src).toContain("#cc2b5e");
+  });
+
+  it.each(CONSUMERS)("%s imports the palette rather than naming its own", (file) => {
+    expect(read(file)).toMatch(/from\s+"\.\.\/lib\/status-colors"/);
+  });
+
+  it.each(CONSUMERS)("%s hardcodes no retired status hex", (file) => {
+    const src = readCode(file);
+    for (const hex of RETIRED) {
+      expect(src).not.toContain(hex);
+    }
+  });
+
+  it("names each status colour in exactly one place across the SPA", () => {
+    // The palette module owns them; a page repeating a hex is the drift this
+    // test exists to catch, whichever page does it.
+    for (const file of CONSUMERS) {
+      const src = readCode(file);
+      for (const hex of ["#0ca30c", "#cc2b5e", "#4a7fb5", "#6b7280"]) {
+        expect(src).not.toContain(hex);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #329.

## Two problems, one fix

**1. The feedback chart failed colour-vision separation.** `FeedbackPage`'s dark pair `#86efac` / `#fca5a5` measures **ΔE 5.8 for deuteranopes** (OKLab ×100), below the ΔE 6 floor — on positive vs negative feedback counts, the two most semantically opposed quantities in the view.

**2. The dashboard had two greens for "good" and two reds for "bad".** After #328 the pages disagreed by ΔE 9.3 and 7.3 — the worst possible distance: near enough to read as the same idea, far enough to look like a mistake.

Both come from the same cause, which is the one #328 makes about `executions.success`: **one concept with two definitions drifts, and the drift is invisible until someone measures it.** `FeedbackPage` even carried a comment claiming its palette held "the same values as HomePage's charts" — true when written, false by the time anyone read it.

## The fix

`dashboard/src/lib/status-colors.ts` is now the only place in the SPA that names a status colour, keyed by **meaning** rather than by page:

```ts
export const STATUS = {
  good:    "#0ca30c",  // succeeded · positive
  neutral: "#6b7280",  // skipped (hatch)
  info:    "#4a7fb5",  // deferred
  bad:     "#cc2b5e",  // failed · negative
} as const;
```

Home maps its four outcomes onto it; Feedback maps positive/negative. Repairing the CVD failure falls out of removing the duplication, because the shared pair is the validated one — every pair clears ΔE 8 CVD and the 15 normal-vision floor in both themes.

`score` stays local to Feedback: it is a **categorical** line colour, not a status, and the distinction is the whole reason status colours are reserved.

Also removes `CHART.success` / `CHART.error` from `HomePage` — the bars moved to `OUTCOME` in #328 and neither key has had a reader since.

## No clash with the other charts

Checked before filing #329. Every cross-pair between the status palette and the categorical series it sits beside (token input/output/cache, cost) measures ΔE 12.9–44.6, and no status hue is reused as a series colour anywhere.

## The test

`tests/admin/dashboard-status-palette.test.ts`, following `dashboard-config-mirror`: the SPA is a separate Vite app with no import edge to core, so "a page hardcoded its own status hex" is a fact about text, not types.

It scans source **with comments stripped**, which is deliberate. `FeedbackPage` names the retired `#86efac` / `#fca5a5` on purpose, to record why they went — a test that forbade saying so would push the explanation out of the codebase and leave the bug's epitaph nowhere. The invariant is about what the code *uses*.

Written first and watched fail 7/7.

## Verification

- Full server suite **2986 passed**, 20 skipped, 0 failed (up 7 from the new file),
  re-run after rebasing onto current `main`.
- `@lastlight/dashboard` typechecks clean.
- Workspace `turbo run typecheck` clean, dep-cruiser included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017csqMy58ivRbLTKojhQnpJ

