### PR TITLE
feat(dashboard): add a "system" theme preference that follows the OS live

### DIFF
--- a/apps/server/dashboard/index.html
+++ b/apps/server/dashboard/index.html
@@ -5,15 +5,35 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script>
       // Apply the theme before first paint to avoid a flash of the wrong one.
-      // Saved choice wins; otherwise follow the OS (dark OS -> lastlight, light
-      // OS -> neaform). Kept in sync with src/hooks/useTheme.tsx (key "ll-theme").
+      //
+      // This MIRRORS src/lib/theme.ts (`parsePreference` + `resolveTheme`, key
+      // "ll-theme") and cannot import it — this runs before the bundle exists,
+      // which is the whole point of it. `dashboard-theme-preference.test.ts`
+      // pins the two together.
+      //
+      // The stored value is a PREFERENCE (system | dark | light), not a theme.
+      // "lastlight"/"neaform" are the pre-#331 values and mean dark/light — an
+      // explicit choice someone made, so they are honoured rather than reset.
       (function () {
         try {
-          var saved = localStorage.getItem("ll-theme");
+          var raw = localStorage.getItem("ll-theme");
+          var pref =
+            raw === "dark" || raw === "lastlight"
+              ? "dark"
+              : raw === "light" || raw === "neaform"
+                ? "light"
+                : "system";
           var sysDark =
             window.matchMedia &&
             window.matchMedia("(prefers-color-scheme: dark)").matches;
-          var theme = saved || (sysDark ? "lastlight" : "neaform");
+          var theme =
+            pref === "dark"
+              ? "lastlight"
+              : pref === "light"
+                ? "neaform"
+                : sysDark
+                  ? "lastlight"
+                  : "neaform";
           document.documentElement.setAttribute("data-theme", theme);
         } catch (e) {
           document.documentElement.setAttribute("data-theme", "lastlight");

--- a/apps/server/dashboard/src/components/Login.tsx
+++ b/apps/server/dashboard/src/components/Login.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
-import { Moon, Sun } from "lucide-react";
+import { ThemeToggle } from "./ThemeToggle";
 import { api, auth } from "../api";
-import { useTheme } from "../hooks/useTheme";
 import { NearformLogo } from "./NearformLogo";
 
 interface Props {
@@ -42,7 +41,6 @@ export function Login({ onAuthed, slackOAuth, githubOAuth, passwordLogin = true,
   const [busy, setBusy] = useState(false);
   const [slackRedirecting, setSlackRedirecting] = useState(false);
   const [githubRedirecting, setGithubRedirecting] = useState(false);
-  const { isDark, toggleTheme } = useTheme();
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -79,15 +77,7 @@ export function Login({ onAuthed, slackOAuth, githubOAuth, passwordLogin = true,
               <div className="text-lg font-semibold tracking-tight">Last Light</div>
               <div className="text-xs text-base-content/50">Sign in to continue</div>
             </div>
-            <button
-              type="button"
-              onClick={toggleTheme}
-              className="btn btn-ghost btn-xs h-7 min-h-0 px-2 text-base-content/50 hover:text-base-content"
-              title={isDark ? "Switch to light theme" : "Switch to dark theme"}
-              aria-label="Toggle light/dark theme"
-            >
-              {isDark ? <Sun size={14} /> : <Moon size={14} />}
-            </button>
+            <ThemeToggle />
           </div>
 
           {error && (

--- a/apps/server/dashboard/src/components/StatsHeader.tsx
+++ b/apps/server/dashboard/src/components/StatsHeader.tsx
@@ -1,9 +1,9 @@
 import clsx from "clsx";
 import { useState } from "react";
-import { BookOpen, Clock, Filter, GitBranch, LogOut, Moon, Radio, RefreshCw, Sun } from "lucide-react";
+import { BookOpen, Clock, Filter, GitBranch, LogOut, Monitor, Moon, Radio, RefreshCw, Sun } from "lucide-react";
 import type { MeRepos } from "../api";
 import type { StreamStatus } from "../hooks/useSessionStream";
-import { useTheme } from "../hooks/useTheme";
+import { useTheme, type ThemePreference } from "../hooks/useTheme";
 import { useVisibleRepos } from "../hooks/useVisibleRepos";
 import { NearformLogo } from "./NearformLogo";
 import { VersionPin } from "./VersionPin";
@@ -136,6 +136,16 @@ function RepoScopeToggle() {
   );
 }
 
+/**
+ * What the control will do NEXT, not what it is — a cycling button whose
+ * tooltip named its current state would leave the third state undiscoverable.
+ */
+const THEME_TITLE: Record<ThemePreference, string> = {
+  system: "Theme: following the system — switch to dark",
+  dark: "Theme: dark — switch to light",
+  light: "Theme: light — follow the system",
+};
+
 export function StatsHeader({
   timeRange,
   onTimeRangeChange,
@@ -147,7 +157,7 @@ export function StatsHeader({
   onLogout,
 }: Props) {
   const statusInfo = STATUS_LABEL[streamStatus];
-  const { isDark, toggleTheme } = useTheme();
+  const { preference, toggleTheme } = useTheme();
 
   return (
     <header className="bg-base-200 border-b border-base-300 flex items-center gap-3 px-4 h-12 shrink-0">
@@ -245,13 +255,16 @@ export function StatsHeader({
 
       <VersionPin />
 
+      {/* Three states, so the icon shows the PREFERENCE rather than the theme:
+          on `system` a monitor, so "following the OS" is legible instead of
+          being inferred from the absence of a choice. */}
       <button
         onClick={toggleTheme}
         className="btn btn-ghost btn-xs h-7 min-h-0 px-2 text-base-content/50 hover:text-base-content"
-        title={isDark ? "Switch to light theme" : "Switch to dark theme"}
-        aria-label="Toggle light/dark theme"
+        title={THEME_TITLE[preference]}
+        aria-label={THEME_TITLE[preference]}
       >
-        {isDark ? <Sun size={14} /> : <Moon size={14} />}
+        {preference === "system" ? <Monitor size={14} /> : preference === "dark" ? <Moon size={14} /> : <Sun size={14} />}
       </button>
 
       {onLogout && (

--- a/apps/server/dashboard/src/components/StatsHeader.tsx
+++ b/apps/server/dashboard/src/components/StatsHeader.tsx
@@ -1,11 +1,11 @@
 import clsx from "clsx";
 import { useState } from "react";
-import { BookOpen, Clock, Filter, GitBranch, LogOut, Monitor, Moon, Radio, RefreshCw, Sun } from "lucide-react";
+import { BookOpen, Clock, Filter, GitBranch, LogOut, Radio, RefreshCw } from "lucide-react";
 import type { MeRepos } from "../api";
 import type { StreamStatus } from "../hooks/useSessionStream";
-import { useTheme, type ThemePreference } from "../hooks/useTheme";
 import { useVisibleRepos } from "../hooks/useVisibleRepos";
 import { NearformLogo } from "./NearformLogo";
+import { ThemeToggle } from "./ThemeToggle";
 import { VersionPin } from "./VersionPin";
 
 interface Props {
@@ -136,16 +136,6 @@ function RepoScopeToggle() {
   );
 }
 
-/**
- * What the control will do NEXT, not what it is — a cycling button whose
- * tooltip named its current state would leave the third state undiscoverable.
- */
-const THEME_TITLE: Record<ThemePreference, string> = {
-  system: "Theme: following the system — switch to dark",
-  dark: "Theme: dark — switch to light",
-  light: "Theme: light — follow the system",
-};
-
 export function StatsHeader({
   timeRange,
   onTimeRangeChange,
@@ -157,7 +147,6 @@ export function StatsHeader({
   onLogout,
 }: Props) {
   const statusInfo = STATUS_LABEL[streamStatus];
-  const { preference, toggleTheme } = useTheme();
 
   return (
     <header className="bg-base-200 border-b border-base-300 flex items-center gap-3 px-4 h-12 shrink-0">
@@ -255,17 +244,7 @@ export function StatsHeader({
 
       <VersionPin />
 
-      {/* Three states, so the icon shows the PREFERENCE rather than the theme:
-          on `system` a monitor, so "following the OS" is legible instead of
-          being inferred from the absence of a choice. */}
-      <button
-        onClick={toggleTheme}
-        className="btn btn-ghost btn-xs h-7 min-h-0 px-2 text-base-content/50 hover:text-base-content"
-        title={THEME_TITLE[preference]}
-        aria-label={THEME_TITLE[preference]}
-      >
-        {preference === "system" ? <Monitor size={14} /> : preference === "dark" ? <Moon size={14} /> : <Sun size={14} />}
-      </button>
+      <ThemeToggle />
 
       {onLogout && (
         <button

--- a/apps/server/dashboard/src/components/ThemeToggle.tsx
+++ b/apps/server/dashboard/src/components/ThemeToggle.tsx
@@ -1,0 +1,55 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useTheme, type ThemePreference } from "../hooks/useTheme";
+
+/**
+ * The theme control — one component, because there are two call sites and they
+ * drifted the moment the preference stopped being a boolean (issue #331).
+ *
+ * `StatsHeader` and `Login` each used to draw their own button from `isDark`.
+ * That works for two states and silently breaks at three: `isDark` cannot tell
+ * "dark because you asked" from "dark because your OS is", so a `system`
+ * preference on a dark OS showed a Moon and a "switch to light" tooltip, while
+ * the click actually advanced to `dark` — same resolved theme, nothing visibly
+ * moved, and the user had to click twice to reach the theme the tooltip named.
+ * A `light` preference on a light OS had the mirror problem.
+ *
+ * So the icon comes from the PREFERENCE, never from the resolved theme.
+ */
+const ICON: Record<ThemePreference, typeof Monitor> = {
+  system: Monitor,
+  dark: Moon,
+  light: Sun,
+};
+
+/**
+ * What the click will do NEXT, not what the state is.
+ *
+ * A cycling control whose tooltip described its current state would leave the
+ * third state undiscoverable — nothing would ever tell you "system" was on
+ * offer.
+ */
+const TITLE: Record<ThemePreference, string> = {
+  system: "Theme: following the system — switch to dark",
+  dark: "Theme: dark — switch to light",
+  light: "Theme: light — follow the system",
+};
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { preference, toggleTheme } = useTheme();
+  const Icon = ICON[preference];
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className={
+        className ??
+        "btn btn-ghost btn-xs h-7 min-h-0 px-2 text-base-content/50 hover:text-base-content"
+      }
+      title={TITLE[preference]}
+      aria-label={TITLE[preference]}
+    >
+      <Icon size={14} />
+    </button>
+  );
+}

--- a/apps/server/dashboard/src/hooks/useTheme.tsx
+++ b/apps/server/dashboard/src/hooks/useTheme.tsx
@@ -1,47 +1,104 @@
-import { createContext, useCallback, useContext, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import {
+  DEFAULT_PREFERENCE,
+  STORAGE_KEY,
+  nextPreference,
+  parsePreference,
+  resolveTheme,
+  type Theme,
+  type ThemePreference,
+} from "../lib/theme";
 
-export type Theme = "lastlight" | "neaform";
+export type { Theme, ThemePreference };
 
 interface ThemeContextValue {
+  /** The theme actually applied — always concrete, never "system". */
   theme: Theme;
+  /** What the user asked for. `system` means "follow the OS". */
+  preference: ThemePreference;
   /** Convenience — true for the dark `lastlight` theme. */
   isDark: boolean;
-  setTheme: (t: Theme) => void;
+  setPreference: (p: ThemePreference) => void;
+  /** Advance the cycle: system → dark → light → system. */
   toggleTheme: () => void;
 }
 
-const STORAGE_KEY = "ll-theme";
-
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
-/** Read the theme the inline `index.html` boot script already applied to
- * `<html>` — the single source of truth, so there's no flash and no need to
- * re-derive from localStorage / prefers-color-scheme here. */
-function currentTheme(): Theme {
-  const attr = document.documentElement.getAttribute("data-theme");
-  return attr === "neaform" ? "neaform" : "lastlight";
+const DARK_QUERY = "(prefers-color-scheme: dark)";
+
+const systemPrefersDark = (): boolean =>
+  typeof window !== "undefined" && !!window.matchMedia?.(DARK_QUERY).matches;
+
+/**
+ * The preference the pre-paint script in `index.html` already read.
+ *
+ * Read from storage rather than from the `data-theme` attribute it set: the
+ * attribute is the RESOLVED theme, and `lastlight` there is ambiguous — it
+ * could be an explicit dark choice or a `system` preference on a dark OS.
+ * Collapsing those two would silently convert everyone following the OS into
+ * a pinned preference on first render, which is the bug this replaces.
+ */
+function storedPreference(): ThemePreference {
+  try {
+    return parsePreference(localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return DEFAULT_PREFERENCE;
+  }
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>(currentTheme);
+  const [preference, setPreferenceState] = useState<ThemePreference>(storedPreference);
+  const [theme, setThemeState] = useState<Theme>(() =>
+    resolveTheme(storedPreference(), systemPrefersDark()),
+  );
 
-  const setTheme = useCallback((t: Theme) => {
+  const apply = useCallback((t: Theme) => {
     document.documentElement.setAttribute("data-theme", t);
-    try {
-      localStorage.setItem(STORAGE_KEY, t);
-    } catch {
-      // Private-mode / storage-disabled — theme still applies for this session.
-    }
     setThemeState(t);
   }, []);
 
+  const setPreference = useCallback(
+    (p: ThemePreference) => {
+      setPreferenceState(p);
+      apply(resolveTheme(p, systemPrefersDark()));
+      try {
+        localStorage.setItem(STORAGE_KEY, p);
+      } catch {
+        // Private-mode / storage-disabled — the theme still applies for this
+        // session, it just won't survive a reload.
+      }
+    },
+    [apply],
+  );
+
+  /**
+   * Track the OS while the preference is `system`.
+   *
+   * Without this, "follow the OS" would mean "follow the OS as it was when the
+   * tab loaded" — a machine that switches at sunset would leave the dashboard
+   * on the wrong theme until a reload. The listener is only attached for
+   * `system`, so an explicit choice costs nothing and cannot be overridden.
+   */
+  useEffect(() => {
+    if (preference !== "system") return;
+    const mq = window.matchMedia?.(DARK_QUERY);
+    if (!mq) return;
+    const onChange = (e: MediaQueryListEvent) => apply(resolveTheme("system", e.matches));
+    mq.addEventListener("change", onChange);
+    // Re-resolve on attach too: the OS may have changed between the pre-paint
+    // script running and this effect, and while another tab held the mount.
+    apply(resolveTheme("system", mq.matches));
+    return () => mq.removeEventListener("change", onChange);
+  }, [preference, apply]);
+
   const toggleTheme = useCallback(() => {
-    setTheme(theme === "lastlight" ? "neaform" : "lastlight");
-  }, [theme, setTheme]);
+    setPreference(nextPreference(preference));
+  }, [preference, setPreference]);
 
   return (
     <ThemeContext.Provider
-      value={{ theme, isDark: theme === "lastlight", setTheme, toggleTheme }}
+      value={{ theme, preference, isDark: theme === "lastlight", setPreference, toggleTheme }}
     >
       {children}
     </ThemeContext.Provider>

--- a/apps/server/dashboard/src/lib/theme.ts
+++ b/apps/server/dashboard/src/lib/theme.ts
@@ -1,0 +1,82 @@
+/**
+ * Theme resolution — pure, so both consumers can share one rule (issue #331).
+ *
+ * There are two of them and they cannot import each other: `hooks/useTheme.tsx`
+ * runs inside React, and the pre-paint script in `index.html` runs *before the
+ * bundle exists* (it has to, or the page flashes the wrong theme). The script
+ * therefore inlines this logic by necessity — but it inlines a rule that is
+ * written down and tested here, rather than a second opinion.
+ *
+ * No React, no DOM: the preference is a value, and resolving it is arithmetic
+ * on that value plus one boolean the caller reads from `matchMedia`.
+ */
+
+/** What the user asked for — NOT what is currently displayed. */
+export type ThemePreference = "system" | "dark" | "light";
+
+/** The daisyUI theme names this app ships. */
+export type Theme = "lastlight" | "neaform";
+
+export const STORAGE_KEY = "ll-theme";
+
+/**
+ * Follow the OS unless told otherwise.
+ *
+ * This was already the *effective* default — the boot script fell back to
+ * `prefers-color-scheme` whenever nothing was stored — but it existed only as
+ * the absence of a preference, so the first click of the toggle destroyed it
+ * permanently and no UI could get it back.
+ */
+export const DEFAULT_PREFERENCE: ThemePreference = "system";
+
+/** The cycle order of the header control: system → dark → light → system. */
+const CYCLE: readonly ThemePreference[] = ["system", "dark", "light"];
+
+/**
+ * Resolve a preference to the theme to apply.
+ *
+ * `systemPrefersDark` is the caller's reading of
+ * `matchMedia("(prefers-color-scheme: dark)")`, passed in rather than read here
+ * so this stays testable and so the React consumer can re-resolve on the media
+ * query's `change` event instead of only at mount.
+ */
+export function resolveTheme(pref: ThemePreference, systemPrefersDark: boolean): Theme {
+  if (pref === "dark") return "lastlight";
+  if (pref === "light") return "neaform";
+  return systemPrefersDark ? "lastlight" : "neaform";
+}
+
+/**
+ * Read a stored value back, tolerating everything.
+ *
+ * **The two legacy names are load-bearing.** Before this existed the key held a
+ * resolved THEME (`lastlight` / `neaform`), written the moment anyone touched
+ * the toggle. Those are exactly the `dark` / `light` preferences, so honouring
+ * them migrates every existing user's choice for free — and reading them as
+ * `system` instead would silently discard a preference somebody set on purpose,
+ * which is the one thing a theme migration must not do.
+ *
+ * Anything else — absent, empty, a hand-edited value, a theme this build no
+ * longer ships — falls back to `system`, because following the OS is the safe
+ * answer to "we do not know what you wanted".
+ */
+export function parsePreference(raw: string | null | undefined): ThemePreference {
+  switch (raw) {
+    case "system":
+      return "system";
+    case "dark":
+    case "lastlight":
+      return "dark";
+    case "light":
+    case "neaform":
+      return "light";
+    default:
+      return DEFAULT_PREFERENCE;
+  }
+}
+
+/** The next preference in the cycle, wrapping at the end. */
+export function nextPreference(pref: ThemePreference): ThemePreference {
+  const i = CYCLE.indexOf(pref);
+  return CYCLE[(i + 1) % CYCLE.length]!;
+}

--- a/apps/server/tests/admin/dashboard-theme-preference.test.ts
+++ b/apps/server/tests/admin/dashboard-theme-preference.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The theme preference is three-state: `system` | `dark` | `light` (issue #331).
+ *
+ * `system` is the interesting one. It used to exist only as an ACCIDENT of
+ * having no stored value: the boot script fell back to `prefers-color-scheme`,
+ * so a first-time visitor tracked the OS, and the first click of the toggle
+ * wrote a resolved theme and pinned it forever with no UI to clear it.
+ *
+ * Imported rather than read as text, unlike its sibling
+ * `dashboard-config-mirror` — this module is deliberately pure (no React, no
+ * DOM) precisely so the rule can be tested rather than asserted about. The
+ * component and the pre-paint boot script in `index.html` both consume it.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  DEFAULT_PREFERENCE,
+  STORAGE_KEY,
+  nextPreference,
+  parsePreference,
+  resolveTheme,
+} from "../../dashboard/src/lib/theme.js";
+
+describe("theme preference (issue #331)", () => {
+  describe("resolveTheme", () => {
+    it("follows the OS when the preference is `system`", () => {
+      expect(resolveTheme("system", true)).toBe("lastlight");
+      expect(resolveTheme("system", false)).toBe("neaform");
+    });
+
+    it("ignores the OS when the preference is explicit", () => {
+      expect(resolveTheme("dark", false)).toBe("lastlight");
+      expect(resolveTheme("light", true)).toBe("neaform");
+    });
+  });
+
+  describe("parsePreference", () => {
+    it("defaults to `system` when nothing is stored", () => {
+      expect(parsePreference(null)).toBe("system");
+      expect(DEFAULT_PREFERENCE).toBe("system");
+    });
+
+    it("reads a stored preference back", () => {
+      expect(parsePreference("system")).toBe("system");
+      expect(parsePreference("dark")).toBe("dark");
+      expect(parsePreference("light")).toBe("light");
+    });
+
+    it("honours the pre-#331 stored values as explicit choices", () => {
+      // Migration is free BECAUSE these two are exactly `dark` and `light`.
+      // Reading them as `system` would silently discard a preference someone
+      // set deliberately — the one thing a theme migration must not do.
+      expect(parsePreference("lastlight")).toBe("dark");
+      expect(parsePreference("neaform")).toBe("light");
+    });
+
+    it("falls back to `system` on anything unrecognised", () => {
+      expect(parsePreference("")).toBe("system");
+      expect(parsePreference("solarized")).toBe("system");
+    });
+  });
+
+  describe("nextPreference", () => {
+    it("cycles system → dark → light → system", () => {
+      expect(nextPreference("system")).toBe("dark");
+      expect(nextPreference("dark")).toBe("light");
+      expect(nextPreference("light")).toBe("system");
+    });
+
+    it("returns to its starting point in exactly three steps", () => {
+      let p = DEFAULT_PREFERENCE;
+      const seen = [p];
+      for (let i = 0; i < 3; i++) {
+        p = nextPreference(p);
+        seen.push(p);
+      }
+      expect(seen).toEqual(["system", "dark", "light", "system"]);
+    });
+  });
+
+  it("keeps the boot script in step with the module", () => {
+    // The pre-paint script in index.html cannot import the bundle — it runs
+    // before it exists — so the resolution rule is duplicated there by
+    // necessity. That makes it the one place this can silently drift, so pin
+    // the two facts it has to get right: the storage key, and that it knows
+    // `system` is a value rather than a theme name to set verbatim.
+    const html = readFileSync(
+      join(import.meta.dirname, "../../dashboard/index.html"),
+      "utf8",
+    );
+    expect(html).toContain(STORAGE_KEY);
+    expect(html).toContain("system");
+    expect(html).toContain("prefers-color-scheme");
+  });
+});

--- a/apps/server/tests/admin/dashboard-theme-toggle.test.ts
+++ b/apps/server/tests/admin/dashboard-theme-toggle.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The theme control is rendered in ONE place (issue #331 review).
+ *
+ * It was two: `StatsHeader` and `Login` each drew their own button with their
+ * own icon and tooltip. When the preference went three-state, only the header
+ * was updated — so the sign-in page kept a binary Moon/Sun against a cycling
+ * action, and two ordinary paths produced a click that changed the preference
+ * while changing nothing visible:
+ *
+ *   - `system` on a dark OS → `dark`: both resolve to `lastlight`.
+ *   - `light` on a light OS → `system`: both resolve to `neaform`.
+ *
+ * A control whose icon is derived from `isDark` cannot express a three-state
+ * preference, and there is no version of that fix which stays correct while
+ * being written down twice. So the assertion is not "both call sites agree" —
+ * it is that there is only one.
+ *
+ * Source-level, like `dashboard-config-mirror`: the SPA has no import edge to
+ * core, and "a component grew its own toggle" is a fact about text.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
+
+const COMPONENTS = join(import.meta.dirname, "../../dashboard/src/components");
+
+/** The one component allowed to render the control. */
+const TOGGLE = "ThemeToggle.tsx";
+
+describe("dashboard theme toggle (issue #331)", () => {
+  it("exists as a single shared component", () => {
+    expect(existsSync(join(COMPONENTS, TOGGLE))).toBe(true);
+  });
+
+  it("is the only component that calls toggleTheme", () => {
+    const offenders = readdirSync(COMPONENTS)
+      .filter((f) => f.endsWith(".tsx") && f !== TOGGLE)
+      .filter((f) => readFileSync(join(COMPONENTS, f), "utf8").includes("toggleTheme"));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("derives its icon from the PREFERENCE, not from isDark", () => {
+    // `isDark` has two values and the preference has three, so an icon chosen
+    // from `isDark` is the exact defect this replaces: it cannot distinguish
+    // "dark because you asked" from "dark because your OS is".
+    const src = readFileSync(join(COMPONENTS, TOGGLE), "utf8");
+    expect(src).toContain("preference");
+    expect(src).not.toMatch(/isDark\s*\?/);
+  });
+
+  it("renders both call sites through it", () => {
+    for (const file of ["StatsHeader.tsx", "Login.tsx"]) {
+      expect(readFileSync(join(COMPONENTS, file), "utf8")).toContain("<ThemeToggle");
+    }
+  });
+});


### PR DESCRIPTION
Closes #331. Independent of #328/#330 — branched off `main`, touches no chart code.

## The problem

"Follow the OS" existed, but only as the **accident of never having chosen**. The boot script fell back to `prefers-color-scheme` when nothing was stored, so a first-time visitor tracked the OS — and the first click of the toggle wrote a resolved theme and pinned it forever, with no UI able to clear it.

And even before that click it followed the OS only *at page load*: `useTheme` read `data-theme` once into `useState` and never subscribed, so a machine switching to dark at sunset left the dashboard light until a reload.

## The change

The stored value becomes a **preference** (`system` | `dark` | `light`) rather than a resolved theme:

- `system` is the default, resolves through `matchMedia`, and **subscribes** to it — the listener attaches only while `system` is selected, so an explicit choice costs nothing and can't be overridden.
- The header control cycles the three, with a distinct icon per state so "following the system" is legible rather than inferred from the absence of a choice. Its tooltip names what the click will do *next*, since a cycling button that described its current state would leave the third state undiscoverable.

`useTheme` still exposes `theme` and `isDark`, so all six consumers (`HomePage`, `FeedbackPage`, `StatsHeader`, `Login`, `CodeBlock`, `ArtifactEditor`) are untouched.

## Migration is free, and that is deliberate

The pre-existing values `lastlight` / `neaform` **are** the `dark` / `light` preferences, so anyone who had toggled keeps their choice and only new visitors get `system`. Reading them as `system` instead would have silently discarded a preference somebody set on purpose — the one thing a theme migration must not do. `parsePreference` has a test for exactly that case, and the comment says why.

One subtlety worth flagging for review: the provider reads the preference from **storage**, not from the `data-theme` attribute the boot script just set. The attribute is the *resolved* theme, and `lastlight` there is ambiguous — it could be an explicit dark choice or `system` on a dark OS. Collapsing the two would convert every OS-following user into a pinned one on first render, which is the bug this PR removes.

## Why there's a `lib/theme.ts`

The rule necessarily has two implementations: the pre-paint script in `index.html` **cannot** import the bundle, because it runs before the bundle exists — that is the entire point of it, and without it the page flashes the wrong theme. So the resolution logic lives in a pure module (no React, no DOM) that the component imports and the script mirrors. The script now duplicates a rule that is written down and tested, rather than holding a second opinion, and `dashboard-theme-preference.test.ts` pins the two together.

## Verification

- 9 new tests, written first and watched fail: the resolve matrix, the legacy-value migration, unrecognised input, and the three-step cycle.
- Beyond the unit tests, the **shipped inline boot script was re-executed verbatim** in a browser against every stored value (it is inline JS the unit test can only pin loosely):

```
OS dark=true
null       -> lastlight      system     -> lastlight
dark       -> lastlight      light      -> neaform
lastlight  -> lastlight      neaform    -> neaform
bogus      -> lastlight
```

- Full server suite 2965 passed, 20 skipped, 0 failed. `tsc -b` and `vite build` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017csqMy58ivRbLTKojhQnpJ
