### PR TITLE
feat(digest): link every PR number in the digest to GitHub

### DIFF
--- a/apps/server/spec/03-integrations.md
+++ b/apps/server/spec/03-integrations.md
@@ -337,6 +337,11 @@ Slack**. It is a `handler:` cron — `runRepoDigest` in `src/cron/repo-digest.ts
 - **One optional model call** (`digest.narrative`) turns those facts into a
   sentence of English. It is never asked to produce a number, and a failure
   drops the sentence rather than the digest.
+- **Every PR number is a link.** `prRef` emits a markdown link that
+  `markdownToSlackMrkdwn` converts to Slack's `<url|#294>` form — markdown
+  rather than that form directly, because the converter runs over these lines
+  and would escape a pre-built one. Both numbers a digest prints are open pull
+  requests (`listOpenPullRequests`), so the target is always `/pull/N`.
 - **The escalated-PR list is asked of GitHub** (open PRs labelled
   `requires-human`), not inferred from run rows — `fanOut` returns only
   `{dispatched, failures}` and a skip counts as a success, so an escalation is

--- a/apps/server/src/notify/digest-blocks.ts
+++ b/apps/server/src/notify/digest-blocks.ts
@@ -48,6 +48,24 @@ export interface DigestFacts {
   botFacts: BotFacts;
 }
 
+/**
+ * A pull-request reference as a markdown link — `[#294](https://github.com/…)`.
+ *
+ * Markdown, not Slack's own `<url|text>`: `renderDigest` passes every line
+ * through `markdownToSlackMrkdwn`, which converts links itself. Emitting
+ * `<url|#294>` here would go through that converter a second time and come out
+ * escaped. Doing it this way also means the fallback `text` and the block
+ * bodies get the same links, because both are built from the same lines.
+ *
+ * Always `/pull/`: every number this renders is an OPEN PULL REQUEST — the
+ * oldest unreviewed one and the escalated list both come from
+ * `listOpenPullRequests`. (GitHub would redirect `/issues/N` to `/pull/N`
+ * anyway, but there is no reason to spend a redirect on a known answer.)
+ */
+function prRef(repo: string, number: number): string {
+  return `[#${number}](https://github.com/${repo}/pull/${number})`;
+}
+
 /** How a workflow name reads in a sentence. Unknown names fall through verbatim. */
 const WORKFLOW_LABELS: Record<string, string> = {
   "pr-review": "reviewed",
@@ -76,9 +94,7 @@ export function renderDigest(facts: DigestFacts, narrative?: string): { text: st
   );
   if (r.oldestAwaiting) {
     repoLines.push(
-      // Plain `#N`, deliberately: `<#…>` is Slack's CHANNEL reference syntax
-      // and would render a PR number as a broken channel link.
-      `• Oldest unreviewed: #${r.oldestAwaiting.number} ${truncate(r.oldestAwaiting.title)} — open ${count(r.oldestAwaiting.ageDays, "day")}`,
+      `• Oldest unreviewed: ${prRef(repo, r.oldestAwaiting.number)} ${truncate(r.oldestAwaiting.title)} — open ${count(r.oldestAwaiting.ageDays, "day")}`,
     );
   }
 
@@ -94,7 +110,7 @@ export function renderDigest(facts: DigestFacts, narrative?: string): { text: st
   if (r.escalated.length > 0) {
     botLines.push(
       `• ⚠️ ${count(r.escalated.length, "PR")} waiting on a human: ` +
-        r.escalated.map((p) => `#${p.number}`).join(", "),
+        r.escalated.map((p) => prRef(repo, p.number)).join(", "),
     );
   }
 

--- a/apps/server/tests/cron/repo-digest.test.ts
+++ b/apps/server/tests/cron/repo-digest.test.ts
@@ -415,15 +415,35 @@ describe("repo digest — rendering", () => {
     expect(text).toContain("14 runs — 12 ok, 2 failed");
     expect(text).toContain("$4.12");
     expect(text).toContain("#412");
-    expect(text).toContain("waiting on a human: #401");
+    expect(text).toContain("waiting on a human:");
     expect(blocks[0]).toMatchObject({ type: "header" });
     expect(JSON.stringify(blocks)).toContain("Last Light");
   });
 
-  it("renders a PR number as plain text, never as a Slack channel reference", () => {
-    // `<#412>` would render as a broken channel link in Slack.
+  it("links every PR number to GitHub, in Slack's <url|text> form", () => {
+    const { text } = renderDigest(facts);
+    expect(text).toContain("<https://github.com/acme/widgets/pull/412|#412>");
+    expect(text).toContain("<https://github.com/acme/widgets/pull/401|#401>");
+  });
+
+  it("links them in the BLOCK bodies too, not just the fallback text", () => {
+    // The two are built from the same lines, so they cannot disagree — but the
+    // blocks are what anyone actually reads, so assert them directly.
+    const { blocks } = renderDigest(facts);
+    const sections = blocks
+      .filter((b): b is Extract<typeof b, { type: "section" }> => b.type === "section")
+      .map((b) => (b.text as { text: string }).text)
+      .join("\n");
+    expect(sections).toContain("<https://github.com/acme/widgets/pull/412|#412>");
+    expect(sections).toContain("<https://github.com/acme/widgets/pull/401|#401>");
+  });
+
+  it("never emits `<#412>` — that is Slack's CHANNEL reference syntax", () => {
+    // The bug the link syntax has to avoid: `<#N>` renders as a broken channel
+    // link, not a PR link.
     const { text } = renderDigest(facts);
     expect(text).not.toContain("<#412>");
+    expect(text).not.toContain("<#401>");
   });
 
   it("puts the narrative above the bullets, and omits the block when absent", () => {

--- a/apps/www/src/pages/docs/slack.astro
+++ b/apps/www/src/pages/docs/slack.astro
@@ -126,7 +126,7 @@ Repo
 • 7 PRs merged, 3 opened
 • 5 issues closed, 4 opened
 • 9 PRs open (2 awaiting review)
-• Oldest unreviewed: #412 Refactor the loader — open 9 days
+• Oldest unreviewed: #412 Refactor the loader — open 9 days   ← links to GitHub
 
 Last Light
 • 14 runs — 12 ok, 2 failed


### PR DESCRIPTION
The digest printed `#294` as plain text, so acting on *"2 PRs waiting on a human: #294, #282"* meant retyping the number into GitHub. Both numbers it prints are now links.

**Before / after** (real output from `cliftonc/drizzle-cube-fastify` on drizby):

```
• Oldest unreviewed: #46 Update postgres Docker tag to v18 — open 321 days
• ⚠️ 2 PRs waiting on a human: #294, #282
```
```
• Oldest unreviewed: <https://github.com/…/pull/46|#46> Update postgres Docker tag to v18 — open 321 days
• ⚠️ 2 PRs waiting on a human: <https://github.com/…/pull/294|#294>, <https://github.com/…/pull/282|#282>
```

## Two things worth a look

**Markdown, not Slack's `<url|text>`.** `prRef` emits `[#294](https://…)` and lets `markdownToSlackMrkdwn` do the conversion, because `renderDigest` already runs every line through that converter — handing it a pre-built `<url|#294>` would come back escaped as `&lt;…&gt;`. Building them this way also means the fallback `text` and the block bodies get *identical* links, since both are rendered from the same lines. There's a test for each surface rather than just the text one.

**Always `/pull/N`.** Every number a digest prints is an open pull request — the oldest-unreviewed one and the escalated list both come from `listOpenPullRequests`. GitHub would redirect `/issues/N` → `/pull/N` anyway, but there's no reason to spend a redirect on an answer we already have.

## Not changed

The `owner/repo` header stays plain text: Slack `header` blocks are `plain_text` only and cannot carry a link. Linking it would mean demoting the title to a `section`, which costs the larger type — not worth it for a repo name that's one click from any of the PR links below it.

## Verification

Rendered the real drizzle-cube-fastify digest through the built code and checked the emitted Slack syntax in both the fallback text and the section blocks (output above). Four new tests: the link form in `text`, the same in the block bodies, and that `<#412>` — Slack's *channel* reference syntax, which would render as a broken channel link — never appears.

`pnpm turbo run typecheck test build` green (3,212 tests); `astro check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
