### PR TITLE
fix(core): log a failed phase at error level with its cause

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -85,7 +85,7 @@ import {
 } from "./notify/index.js";
 import type { EventEnvelope } from "./connectors/types.js";
 import { logger } from "./logging/logger.js";
-import { logPhaseEnd } from "./logging/phase-log.js";
+import { logPhaseEnd, logPhaseStart } from "./logging/phase-log.js";
 
 /**
 /**
@@ -1003,7 +1003,7 @@ async function main() {
             }
           : undefined),
       onPhaseStart: async (phase) => {
-        log.info("Phase start", { workflowName, phase });
+        logPhaseStart(log, workflowName, phase);
         // Refresh the Slack thinking indicator so long-running phases
         // don't leave the thread looking dead. threadId doubles as both
         // the message anchor and the thread root for DM threads.

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -85,6 +85,7 @@ import {
 } from "./notify/index.js";
 import type { EventEnvelope } from "./connectors/types.js";
 import { logger } from "./logging/logger.js";
+import { logPhaseEnd } from "./logging/phase-log.js";
 
 /**
 /**
@@ -1011,7 +1012,7 @@ async function main() {
         }
       },
       onPhaseEnd: async (phase, result) => {
-        log.info("Phase end", { workflowName, phase, success: result.success });
+        logPhaseEnd(log, workflowName, phase, result);
         // The marker harvest (09 → S1). This is the ONLY moment the two marker
         // lines exist in memory — `{{phaseOutputs}}` is empty across a run
         // boundary and the shared per-PR workspace is `reset --hard`-ed between

--- a/apps/server/src/logging/phase-log.ts
+++ b/apps/server/src/logging/phase-log.ts
@@ -1,0 +1,42 @@
+import type { LoggerPort, PhaseResult } from "lastlight-workflow-engine";
+
+/**
+ * The single "Phase end" log call, shared by every workflow host.
+ *
+ * Extracted because the two call sites — `index.ts` (fresh dispatch) and
+ * `workflows/resume.ts` (orphan recovery and the dashboard's Retry) — were
+ * byte-identical duplicates. That is precisely the shape where one gets fixed
+ * and the other silently doesn't, and the resume path is the one where
+ * diagnosis matters most: a run reaching it is already known to have been
+ * interrupted.
+ *
+ * A failed phase logs at `error` and carries `result.error`. Both halves of
+ * that matter and for different reasons:
+ *
+ *   - the LEVEL, because `level: error` is the rule operators actually alert
+ *     on. Logging failures at `info` means a harness whose runs are all failing
+ *     looks healthy to anything watching the log stream.
+ *   - the CAUSE, because `success: false` alone cannot distinguish an auth
+ *     failure from a quota rejection from a scheduling failure from a bug.
+ *
+ * `core/scheduler.ts` already logs `error` with the cause when a phase THROWS.
+ * This covers the other path: an executor that catches a failure and returns it
+ * as a failed `PhaseResult` (`executors/orchestrator.ts` does this for sandbox
+ * provisioning errors, `stopReason: "error_sandbox"`). Before this, such a
+ * failure reached the run record and telemetry but never the logs.
+ */
+export function logPhaseEnd(
+  log: LoggerPort,
+  workflowName: string,
+  phase: string,
+  result: PhaseResult,
+): void {
+  if (result.success) {
+    log.info("Phase end", { workflowName, phase, success: true });
+    return;
+  }
+  // `error` stays in the payload even when undefined: a failure that captured
+  // no cause is still a failure, and the field's presence is what makes the
+  // gap visible rather than ambiguous.
+  log.error("Phase end", { workflowName, phase, success: false, error: result.error });
+}

--- a/apps/server/src/logging/phase-log.ts
+++ b/apps/server/src/logging/phase-log.ts
@@ -25,6 +25,16 @@ import type { LoggerPort, PhaseResult } from "lastlight-workflow-engine";
  * provisioning errors, `stopReason: "error_sandbox"`). Before this, such a
  * failure reached the run record and telemetry but never the logs.
  */
+/**
+ * The matching "Phase start" call. No failure semantics — this exists only so
+ * the pair stays together: the same three hosts emitted it as three separate
+ * literals, which is the duplication that let `logPhaseEnd`'s sites drift apart
+ * in the first place.
+ */
+export function logPhaseStart(log: LoggerPort, workflowName: string, phase: string): void {
+  log.info("Phase start", { workflowName, phase });
+}
+
 export function logPhaseEnd(
   log: LoggerPort,
   workflowName: string,

--- a/apps/server/src/workflows/resume.ts
+++ b/apps/server/src/workflows/resume.ts
@@ -20,7 +20,7 @@ import {
   type NotifierState,
 } from "../notify/index.js";
 import { logger } from "../logging/logger.js";
-import { logPhaseEnd } from "../logging/phase-log.js";
+import { logPhaseEnd, logPhaseStart } from "../logging/phase-log.js";
 
 const log = logger("resume");
 
@@ -129,7 +129,7 @@ function makeCallbacks(
           }
         }
       : undefined,
-    onPhaseStart: async (phase) => log.info("Phase start", { workflowName, phase }),
+    onPhaseStart: async (phase) => logPhaseStart(log, workflowName, phase),
     onPhaseEnd: async (phase, result) => {
       logPhaseEnd(log, workflowName, phase, result);
       // The marker harvest has to be wired on the RESUME paths too, not only on
@@ -348,7 +348,7 @@ export async function resumeSimpleRun(run: WorkflowRun, opts: ResumeOptions): Pr
             log.warn("Failed to post to Slack thread", { err });
           }
         },
-        onPhaseStart: async (phase) => log.info("Phase start", { workflowName: run.workflowName, phase }),
+        onPhaseStart: async (phase) => logPhaseStart(log, run.workflowName, phase),
         onPhaseEnd: async (phase, result) => {
           logPhaseEnd(log, run.workflowName, phase, result);
           harvestFixMarkers(opts.db, run.id, run.workflowName, phase, result.output);

--- a/apps/server/src/workflows/resume.ts
+++ b/apps/server/src/workflows/resume.ts
@@ -20,6 +20,7 @@ import {
   type NotifierState,
 } from "../notify/index.js";
 import { logger } from "../logging/logger.js";
+import { logPhaseEnd } from "../logging/phase-log.js";
 
 const log = logger("resume");
 
@@ -130,7 +131,7 @@ function makeCallbacks(
       : undefined,
     onPhaseStart: async (phase) => log.info("Phase start", { workflowName, phase }),
     onPhaseEnd: async (phase, result) => {
-      log.info("Phase end", { workflowName, phase, success: result.success });
+      logPhaseEnd(log, workflowName, phase, result);
       // The marker harvest has to be wired on the RESUME paths too, not only on
       // the fresh dispatch in `index.ts`. A fix run that paused for an approval
       // gate or was picked back up after a harness restart completes its
@@ -349,7 +350,7 @@ export async function resumeSimpleRun(run: WorkflowRun, opts: ResumeOptions): Pr
         },
         onPhaseStart: async (phase) => log.info("Phase start", { workflowName: run.workflowName, phase }),
         onPhaseEnd: async (phase, result) => {
-          log.info("Phase end", { workflowName: run.workflowName, phase, success: result.success });
+          logPhaseEnd(log, run.workflowName, phase, result);
           harvestFixMarkers(opts.db, run.id, run.workflowName, phase, result.output);
         },
       };

--- a/apps/server/tests/logging/phase-log.test.ts
+++ b/apps/server/tests/logging/phase-log.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import type { LoggerPort } from "lastlight-workflow-engine";
+import type { PhaseResult } from "lastlight-workflow-engine";
+import { logPhaseEnd } from "#src/logging/phase-log.js";
+
+/**
+ * "Phase end" is the ONLY record a failed phase leaves (issue #335).
+ *
+ * `PhaseResult` carries an `error` field that both `onPhaseEnd` handlers used to
+ * drop, logging `success: false` at `info` and nothing else. Every phase failure
+ * was therefore indistinguishable from every other, and — the operational cost —
+ * alerting on `level: error` never fired for a harness whose runs were all
+ * failing.
+ *
+ * The failure that surfaced this was a Kubernetes 409 caught and RETURNED by
+ * `executors/orchestrator.ts` (`stopReason: "error_sandbox"`), not thrown. The
+ * throw path in `core/scheduler.ts` already logs `error` with the cause; the
+ * returned path had no equivalent, so the error reached the run record and
+ * telemetry but never the log stream.
+ *
+ * These tests hold both call sites (`index.ts`, `workflows/resume.ts`) to the
+ * one helper, which is the point of extracting it: the two lines were
+ * byte-identical duplicates, which is how one gets fixed and the other doesn't.
+ */
+
+function fakeLogger(): LoggerPort & { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> } {
+  const log = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(),
+  };
+  log.child.mockReturnValue(log);
+  return log as unknown as LoggerPort & {
+    info: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+}
+
+const ok: PhaseResult = { phase: "review", success: true, output: "done" };
+
+describe("logPhaseEnd", () => {
+  it("logs a successful phase at info", () => {
+    const log = fakeLogger();
+    logPhaseEnd(log, "pr-review", "review", ok);
+
+    expect(log.info).toHaveBeenCalledWith("Phase end", {
+      workflowName: "pr-review",
+      phase: "review",
+      success: true,
+    });
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it("logs a failed phase at ERROR, carrying the cause", () => {
+    const log = fakeLogger();
+    const failed: PhaseResult = {
+      phase: "review",
+      success: false,
+      output: "",
+      error: 'secrets "ll-run-abc-creds" already exists',
+    };
+
+    logPhaseEnd(log, "pr-review", "review", failed);
+
+    expect(log.error).toHaveBeenCalledWith("Phase end", {
+      workflowName: "pr-review",
+      phase: "review",
+      success: false,
+      error: 'secrets "ll-run-abc-creds" already exists',
+    });
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  // The level must not depend on whether a cause was captured — a failure with
+  // no `error` is still a failure, and is exactly the case that most needs to be
+  // greppable. Downgrading it to `info` would restore the original bug for the
+  // subset of failures that carry no message.
+  it("logs a failed phase at ERROR even when no cause was captured", () => {
+    const log = fakeLogger();
+    const failed: PhaseResult = { phase: "review", success: false, output: "" };
+
+    logPhaseEnd(log, "pr-review", "review", failed);
+
+    expect(log.error).toHaveBeenCalledWith("Phase end", {
+      workflowName: "pr-review",
+      phase: "review",
+      success: false,
+      error: undefined,
+    });
+    expect(log.info).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/tests/logging/phase-log.test.ts
+++ b/apps/server/tests/logging/phase-log.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import type { LoggerPort } from "lastlight-workflow-engine";
 import type { PhaseResult } from "lastlight-workflow-engine";
-import { logPhaseEnd } from "#src/logging/phase-log.js";
+import { logPhaseEnd, logPhaseStart } from "#src/logging/phase-log.js";
 
 /**
  * "Phase end" is the ONLY record a failed phase leaves (issue #335).
@@ -40,6 +40,19 @@ function fakeLogger(): LoggerPort & { info: ReturnType<typeof vi.fn>; error: Ret
 }
 
 const ok: PhaseResult = { phase: "review", success: true, output: "done" };
+
+describe("logPhaseStart", () => {
+  it("logs at info with the workflow and phase", () => {
+    const log = fakeLogger();
+    logPhaseStart(log, "pr-review", "review");
+
+    expect(log.info).toHaveBeenCalledWith("Phase start", {
+      workflowName: "pr-review",
+      phase: "review",
+    });
+    expect(log.error).not.toHaveBeenCalled();
+  });
+});
 
 describe("logPhaseEnd", () => {
   it("logs a successful phase at info", () => {


### PR DESCRIPTION
Closes #335.

## The problem

`onPhaseEnd` logged `success: false` at `info` and dropped `PhaseResult.error`:

```json
{"level":"info","component":"resume","workflowName":"pr-review",
 "phase":"review","success":false,"msg":"Phase end"}
```

Every phase failure was therefore indistinguishable from every other, and — the operational cost — **alerting on `level: error` never fired** for a harness whose runs were all failing.

## Why the existing error path didn't cover it

`core/scheduler.ts` L220 already logs at error with the cause when a phase *throws*. That branch is correct and untouched.

The gap is the caught-and-returned path. `executors/orchestrator.ts` L292-318 catches sandbox provisioning failures and **returns** them:

```ts
const stopReason = err instanceof QuotaExceededError ? "error_quota" : "error_sandbox";
return { success: false, output: "", turns: 0, error: msg, durationMs, stopReason };
```

so `scheduler.ts`'s `catch` is bypassed and the failure flows down the ordinary path as a failed `PhaseResult`.

The error was populated the whole way — `orchestrator.ts:314` → `phase-executor.ts:216` → persisted to the execution store — so it reached the run record and telemetry, but never the logs. It was captured everywhere except the surface most deployments alert on.

## What this changes

Extracts the call into `src/logging/phase-log.ts` and logs a failed phase at `error` with `result.error`.

**Three call sites, not two as the issue said** — `index.ts` plus *both* handlers in `workflows/resume.ts`. Two were byte-identical, which is exactly how one gets fixed and the others don't; that's why this is a helper rather than three patches.

`error` stays in the payload when `undefined`: a failure that captured no cause is still a failure, and is the case that most needs to be greppable. There's a test pinning that, since downgrading it to `info` would restore the original bug for the subset of failures carrying no message.

## Commits

1. **`fix(core):`** the bug fix + tests
2. **`refactor(core):`** routes `"Phase start"` through the same helper — it was three separate literals in the same three files. No behaviour change, no bug. **Separable — drop this commit if you'd prefer the fix stay minimal.**

## Open question for maintainers

I used `error` level, since the point is that `level: error` alerting should fire. If phases fail routinely in normal operation that could be noisy and `warn` may suit you better — happy to change it.

## Verification

- `pnpm typecheck` — 12/12 tasks
- `pnpm test` — 8/8 tasks, 198 + 9 + 1 test files, 0 failures
- 4 new tests covering both helpers, including the no-cause edge case
- No test previously touched `onPhaseEnd`; these are the first

Found while diagnosing #336 on a `kubernetes`-backend deployment, where a 409 during run-scoped Secret creation produced exactly this silent failure.