### PR TITLE
fix(k8s): reclaim a previous attempt's pod so a retry can proceed

### DIFF
--- a/apps/server/src/sandbox/k8s/kubernetes-sandbox.ts
+++ b/apps/server/src/sandbox/k8s/kubernetes-sandbox.ts
@@ -20,7 +20,12 @@ import { buildRunAgentScript } from "./run-agent-script.js";
 import { podNameFor } from "./naming.js";
 import { RunId } from "./run-id.js";
 import { streamPodLog } from "./log-stream.js";
-import { awaitPodResult, waitForContainerStart, waitForPodGone } from "./pod-lifecycle.js";
+import {
+  awaitPodResult,
+  reclaimStalePod,
+  waitForContainerStart,
+  waitForPodGone,
+} from "./pod-lifecycle.js";
 import { buildCloneInitContainer } from "./init-clone.js";
 import { buildSkillsInitContainer } from "./init-skills.js";
 import { buildAgentContextInitContainer } from "./init-agent-context.js";
@@ -405,6 +410,13 @@ export class KubernetesSandbox implements Sandbox, AgentContextSink {
     // it.
     const podLabel = podNameFor(taskId, "run");
     await this.ensureEgress();
+
+    // Clear a previous attempt's tombstone BEFORE creating anything (#336).
+    // These names are deterministic, so a retry of a run whose harness died
+    // mid-flight would otherwise 409 on the Secret create below — and again on
+    // the pod create, since deleting the pod is what GCs its Secrets. Only a
+    // finished pod is reclaimed; a live one still means a real collision.
+    await reclaimStalePod(this.apis.core, this.ns, podLabel.value);
 
     const secrets = await this.runSecrets.create({
       podLabel,

--- a/apps/server/src/sandbox/k8s/pod-lifecycle.ts
+++ b/apps/server/src/sandbox/k8s/pod-lifecycle.ts
@@ -166,6 +166,54 @@ async function initContainerLogs(
  * read error is treated as "not yet confirmed gone" and just retried
  * within the budget, never failing the caller's `dispose()`.
  */
+/** Pod phases that mean the pod has finished and holds nothing but its record. */
+const TERMINAL_POD_PHASES = new Set(["Succeeded", "Failed"]);
+
+/**
+ * Delete a previous attempt's finished pod so a retry can recreate the run.
+ *
+ * Sandbox object names are deterministic — {@link podNameFor} hashes the taskId
+ * with no attempt component — so a retry regenerates the same pod name and the
+ * same `<pod>-creds` / `<pod>-prompt` Secret names. `dispose()` normally clears
+ * all three, but a harness that dies mid-run never reaches it. The tombstone
+ * left behind makes every later attempt of that run fail: the Secret create
+ * 409s first (the Secrets are ownerRef'd to the pod, so they outlive it only
+ * because it was never deleted), and the pod create would 409 next.
+ *
+ * Only a TERMINAL pod is reclaimed. A pod still Pending or Running belongs to a
+ * live dispatch racing this one for the same taskId, and that collision must
+ * keep failing loudly — deleting it would turn a 409 into silent sabotage of
+ * someone else's run.
+ *
+ * Mirrors `dispose()`'s sequence, `waitForPodGone` included: the workspace PVC
+ * is `(repo,PR)`-scoped and RWO, so the replacement pod cannot attach it until
+ * the tombstone is really gone.
+ *
+ * Best-effort, like everything else on this path — a pod that cannot be read or
+ * deleted is left alone and the caller proceeds to fail on the create as before.
+ *
+ * @returns whether a stale pod was found and deleted.
+ */
+export async function reclaimStalePod(core: CoreV1Api, ns: string, name: string): Promise<boolean> {
+  let phase: string | undefined;
+  try {
+    const pod = await core.readNamespacedPodStatus({ name, namespace: ns });
+    phase = pod.status?.phase;
+  } catch {
+    return false; // absent (404) or unreadable — nothing to reclaim
+  }
+  if (!phase || !TERMINAL_POD_PHASES.has(phase)) return false;
+
+  try {
+    await core.deleteNamespacedPod({ name, namespace: ns });
+  } catch {
+    return false; // raced by the sweep, or forbidden — let the create surface it
+  }
+  log.info("Reclaimed a finished pod from a previous attempt", { pod: name, phase });
+  await waitForPodGone(core, ns, name);
+  return true;
+}
+
 export async function waitForPodGone(core: CoreV1Api, ns: string, name: string): Promise<void> {
   for (let attempt = 0; attempt < POD_DELETE_POLL_ATTEMPTS; attempt++) {
     try {

--- a/apps/server/tests/sandbox/k8s/kubernetes-sandbox.test.ts
+++ b/apps/server/tests/sandbox/k8s/kubernetes-sandbox.test.ts
@@ -67,6 +67,7 @@ function fakeApis(opts: FakeOpts = {}) {
   const pvcsCreated: any[] = [];
   const customCreated =
     opts.createNamespacedCustomObject ?? vi.fn(async () => ({}));
+  let podCreated = false;
   let podDeleted = false;
   let postDeletePolls = 0;
   const goneAfterDeletePolls = opts.goneAfterDeletePolls ?? 0;
@@ -75,15 +76,26 @@ function fakeApis(opts: FakeOpts = {}) {
       core: {
         createNamespacedPod: vi.fn(async ({ body }: any) => {
           if (opts.createPodThrows) throw new Error("pod create failed");
+          // A pod of this name exists again — reset the deleted-state so a
+          // SECOND run against the same fake reads back as live, the way a real
+          // namespace behaves once the name is recreated.
+          podCreated = true;
+          podDeleted = false;
+          postDeletePolls = 0;
           created.push(body);
           // Real createNamespacedPod echoes back the created object, with a
           // server-assigned uid — the ownerRef patch reads it off this return.
           return { ...body, metadata: { ...body.metadata, uid: "pod-uid-1" } };
         }),
         readNamespacedPodStatus: vi.fn(async () => {
-          // Mirrors real k8s: once the pod is actually deleted, subsequent
-          // status reads 404. `goneAfterDeletePolls` delays that 404 by N
-          // polls, for tests exercising `waitForPodGone`'s loop.
+          // Mirrors real k8s: a name that has never been created 404s. Without
+          // this the fake claimed a pod existed before `createNamespacedPod`,
+          // and `reclaimStalePod`'s pre-create probe (#336) read that phantom
+          // as a finished pod from a previous attempt and deleted it.
+          if (!podCreated) throw new ApiException(404, "Not Found", {}, {});
+          // Once the pod is actually deleted, subsequent status reads 404.
+          // `goneAfterDeletePolls` delays that 404 by N polls, for tests
+          // exercising `waitForPodGone`'s loop.
           if (podDeleted) {
             if (postDeletePolls < goneAfterDeletePolls) {
               postDeletePolls += 1;
@@ -431,8 +443,11 @@ describe("KubernetesSandbox", () => {
     await expect(
       sbx.runCommand("t1", "true", { cwd: "/w", timeoutSeconds: 30 } as any),
     ).rejects.toThrow(/init container "clone" failed \(exit 128\): Error/);
-    // Fails on the FIRST poll, not after the full ~60s start budget.
-    expect(apis.core.readNamespacedPodStatus).toHaveBeenCalledTimes(1);
+    // Fails on the FIRST start poll, not after the full ~60s start budget.
+    // Two reads, not one: `reclaimStalePod` probes for a previous attempt's
+    // tombstone before creating (#336), then `waitForContainerStart` polls once
+    // and gives up. A regression to the full budget would be ~180 reads.
+    expect(apis.core.readNamespacedPodStatus).toHaveBeenCalledTimes(2);
   });
 
   it("appends the init container's logs so the real git error is visible", async () => {

--- a/apps/server/tests/sandbox/k8s/reclaim-stale-pod.test.ts
+++ b/apps/server/tests/sandbox/k8s/reclaim-stale-pod.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import { ApiException } from "@kubernetes/client-node";
+import { reclaimStalePod } from "#src/sandbox/k8s/pod-lifecycle.js";
+
+/**
+ * Reclaiming a previous attempt's tombstone before creating a run (issue #336).
+ *
+ * Sandbox object names are deterministic — `podNameFor` is a sha1 of the taskId
+ * with no attempt component — so a retry regenerates the same pod name and the
+ * same `<pod>-creds` / `<pod>-prompt` Secret names. `dispose()` normally deletes
+ * the pod (cascade-GCing both Secrets), but a harness that dies mid-run never
+ * runs it. The tombstone then makes every retry of that run fail: first on the
+ * Secret create (409 AlreadyExists), and — if only the Secrets were cleaned —
+ * again on the pod create.
+ *
+ * The live/terminal distinction is the safety property. A 409 against a RUNNING
+ * pod is genuine concurrency (two dispatches racing for one taskId) and must
+ * keep failing; a 409 against a tombstone is a dead run's litter.
+ */
+
+function fakeCore(opts: { phase?: string; absent?: boolean; goneAfterDelete?: boolean } = {}) {
+  const { phase = "Succeeded", absent = false, goneAfterDelete = true } = opts;
+  let deleted = false;
+  const core = {
+    readNamespacedPodStatus: vi.fn(async ({ name, namespace }: any) => {
+      if (absent || (deleted && goneAfterDelete)) throw new ApiException(404, "Not Found", {}, {});
+      return { metadata: { name, namespace }, status: { phase } };
+    }),
+    deleteNamespacedPod: vi.fn(async () => {
+      deleted = true;
+      return {};
+    }),
+  } as any;
+  return { core };
+}
+
+describe("reclaimStalePod", () => {
+  it("reclaims a Succeeded tombstone so the retry can proceed", async () => {
+    const { core } = fakeCore({ phase: "Succeeded" });
+
+    const reclaimed = await reclaimStalePod(core, "lastlight-sandboxes", "ll-run-abc");
+
+    expect(reclaimed).toBe(true);
+    expect(core.deleteNamespacedPod).toHaveBeenCalledWith({
+      name: "ll-run-abc",
+      namespace: "lastlight-sandboxes",
+    });
+  });
+
+  it("reclaims a Failed tombstone too", async () => {
+    const { core } = fakeCore({ phase: "Failed" });
+
+    await expect(reclaimStalePod(core, "ns", "ll-run-abc")).resolves.toBe(true);
+    expect(core.deleteNamespacedPod).toHaveBeenCalled();
+  });
+
+  // The safety property. Deleting here would kill a legitimately in-flight run
+  // belonging to another dispatch, turning a loud 409 into silent sabotage.
+  it("leaves a Running pod alone — that is real concurrency, not litter", async () => {
+    const { core } = fakeCore({ phase: "Running" });
+
+    const reclaimed = await reclaimStalePod(core, "ns", "ll-run-abc");
+
+    expect(reclaimed).toBe(false);
+    expect(core.deleteNamespacedPod).not.toHaveBeenCalled();
+  });
+
+  it("leaves a Pending pod alone", async () => {
+    const { core } = fakeCore({ phase: "Pending" });
+
+    await expect(reclaimStalePod(core, "ns", "ll-run-abc")).resolves.toBe(false);
+    expect(core.deleteNamespacedPod).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when no pod of that name exists", async () => {
+    const { core } = fakeCore({ absent: true });
+
+    const reclaimed = await reclaimStalePod(core, "ns", "ll-run-abc");
+
+    expect(reclaimed).toBe(false);
+    expect(core.deleteNamespacedPod).not.toHaveBeenCalled();
+  });
+
+  // The workspace PVC is (repo,PR)-scoped and RWO, so the replacement pod cannot
+  // attach it until the tombstone is really gone. Returning before that races the
+  // volume release and surfaces as a Multi-Attach error on the new pod.
+  it("waits for the pod to be gone before returning", async () => {
+    const { core } = fakeCore({ phase: "Succeeded", goneAfterDelete: true });
+
+    await reclaimStalePod(core, "ns", "ll-run-abc");
+
+    const deleteOrder = core.deleteNamespacedPod.mock.invocationCallOrder[0];
+    const reads = core.readNamespacedPodStatus.mock.invocationCallOrder;
+    expect(reads.some((o: number) => o > deleteOrder)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #336.

## The problem

A run whose harness dies mid-flight becomes **permanently un-retryable**. Every attempt — automatic orphan recovery, the dashboard's Retry, any later re-dispatch — fails in ~100ms with:

```
409 AlreadyExists: secrets "ll-…-run-bed6151f-creds" already exists
```

`podNameFor` is a sha1 of the taskId with no attempt component, so a retry regenerates the same pod name and the same `<pod>-creds` / `<pod>-prompt` Secret names. `dispose()` normally deletes the pod — which cascade-GCs both Secrets via their ownerRef — but a harness that dies never reaches it.

**The bug is a skipped `dispose()`, not a naming problem.**

## Why cleaning up only the Secrets isn't enough

That was my first suggestion on the issue and it's wrong. `createNamespacedPod` (`kubernetes-sandbox.ts:505`) is also a plain create, so a retry that got past the Secrets would 409 on the pod instead — and `createPodOrCleanupSecrets` would then delete the Secrets it had just made. Different error, same dead end.

## The fix

Probe for the pod before creating anything, and reclaim it if it has finished — mirroring `dispose()`'s sequence:

```
pod with this name exists?
  ├─ terminal (Succeeded/Failed) → delete, waitForPodGone, proceed
  ├─ live (Pending/Running)      → leave it, fail as today
  └─ absent                      → proceed
```

Deleting the pod GCs its Secrets, so one probe fixes both 409s.

**`waitForPodGone` is load-bearing, not defensive.** The workspace PVC is `(repo,PR)`-scoped and RWO; the replacement pod can't attach it until the tombstone is really gone. That's the same rationale `dispose()` already documents.

**The live/terminal distinction is the safety property.** A 409 against a Running pod is genuine concurrency — two dispatches racing for one taskId — and must keep failing loudly. Deleting there would turn a loud error into silent sabotage of someone else's run.

## Deliberately no attempt counter

The issue floated giving each retry a fresh run id. I'd argue against it, and it's a non-goal here rather than an oversight:

The RWO PVC means the old pod must be deleted **whatever the new one is named** — so reclaim is required regardless, and the counter only avoids the name collision, which is the symptom. Against that it wants an attempt number threaded through every `podNameFor` caller (log streaming, the reclaim selector, artifact routes) and persisted so it survives a restart identically. Get that wrong and orphan recovery computes a name that doesn't match its own in-flight pod — a silent failure strictly worse than today's loud 409.

It composes cleanly on top of this if you later want per-attempt traceability.

## Test-fake changes

`kubernetes-sandbox.test.ts`'s fake needed two fidelity fixes that the pre-create probe exposes:

- `readNamespacedPodStatus` claimed a pod existed **before** `createNamespacedPod`, so the probe read a phantom finished pod and deleted it
- once deleted it stayed deleted forever, so a second run against the same fake never read back as live

Both now behave the way a real namespace does. One assertion moved from 1 read to 2 (the probe, then the single start poll) with a comment — a regression to the full start budget would still be ~180 reads, so the test's intent is intact.

## Verification

- `pnpm typecheck` — 12/12 tasks
- `pnpm test` — 8/8 tasks, 198 + 9 + 1 test files, 0 failures
- 6 new tests: terminal reclaimed, `Failed` reclaimed, Running/Pending left alone, absent is a no-op, and the delete-then-wait ordering
- Mutation-checked: removing the terminal-phase guard fails exactly the two safety tests and nothing else

Found on a `kubernetes`-backend deployment, where the recovery was `kubectl delete pod <run-pod>` — the manual equivalent of what this does.