### PR TITLE
fix(cli): send `repo`, not `repos`, for security and health

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1609,6 +1609,21 @@ async function main() {
       return c.json({ error: `Repo not managed: ${unmanaged.join(", ")}` }, 403);
     }
 
+    // Fail a context the dispatcher will reject BEFORE returning 202. The
+    // dispatch below is fire-and-forget, so without this the caller gets
+    // `{accepted: true}` and an execution id for a run that dies moments later
+    // in the harness log — indistinguishable, from the CLI, from success.
+    // Mirrors `dispatchWorkflow`'s own condition exactly, Slack exemption
+    // included: a `slack:`-prefixed triggerId legitimately carries no repo.
+    const hasSlackTrigger =
+      typeof context.triggerId === "string" && context.triggerId.startsWith("slack:");
+    if (typeof context.repo !== "string" && !hasSlackTrigger) {
+      return c.json(
+        { error: `Missing 'repo' in context for workflow '${workflowName}'` },
+        400,
+      );
+    }
+
     apiLog.info("CLI triggered", { workflowName });
 
     // Run asynchronously — return immediately with a stable id the caller

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1148,7 +1148,12 @@ async function cmdSkill(name: string): Promise<void> {
     if (claim) context.commentBody = claim;
     if (!JSON_OUT) console.log(`Triggering ${name} on ${parsed.owner}/${parsed.repo}#${parsed.number}…`);
   } else {
-    context = { repos: [target], mode: "scan" };
+    // `repo`, singular — `/api/run` hands the context to `dispatchWorkflow`,
+    // which requires it. `{ repos: [...] }` is the CRON fan-out shape, and only
+    // `dispatchCronWorkflow` expands it (cron/fanout.ts); sent here it reaches
+    // the plain dispatcher untranslated and every run dies with
+    // "missing 'repo' in context" — after the endpoint has already returned 202.
+    context = { repo: target, sender: "cli" };
     if (!JSON_OUT) console.log(`Triggering ${name} scan on ${target}…`);
   }
   const data = await apiPost(`/api/run`, { skill, context });


### PR DESCRIPTION
Closes #339.

## The bug

`lastlight security <owner/repo>` and `lastlight health <owner/repo>` — the two `repoLevelOnly` commands — build the **cron fan-out** context and post it to the **non-fan-out** endpoint:

```ts
// cli.ts, before
context = { repos: [target], mode: "scan" };
await apiPost(`/api/run`, { skill, context });
```

`/api/run` passes the context straight to `dispatchWorkflow` (`index.ts:1621`), which requires `context.repo` (`index.ts:410`). The only code that understands `repos` is `dispatchCronWorkflow`, which maps it to a per-run `repo` (`cron/fanout.ts:97`) — and that is never on this path.

So both commands failed on every invocation. `mode: "scan"` is inert too; the only reference to it in dispatch is a comment in `workflows/simple.ts:605` describing it as pass-through context.

## Why it stayed hidden

`/api/run` dispatches fire-and-forget and returns **202 before dispatch is attempted**. Its managed-repo guard *does* understand `repos`, so an unmanaged repo correctly 403s — which makes the endpoint look like it validated the payload when it only validated the repo list.

The caller sees:

```
$ lastlight security owner/repo
Triggering security scan on owner/repo…
Accepted: {"accepted":true,"executionId":"815cf4cd-…","workflow":"security-review"}
$ echo $?
0
```

and, ~90s later, only in the harness log:

```json
{"level":"error","component":"dispatch","workflowName":"security-review",
 "msg":"dispatchWorkflow(security-review): missing 'repo' in context"}
```

## Commits

1. **`fix(cli):`** — send `{ repo: target, sender: "cli" }`. The argument is a single repo, so the array was never meaningful, and `sender` matches the issue-scoped branch directly above it.
2. **`fix(core):`** — reject a repo-less `/api/run` with 400 before the 202, mirroring `dispatchWorkflow`'s condition exactly (Slack exemption included: a `slack:`-prefixed `triggerId` legitimately carries no repo). **Separable — drop it if you'd rather keep the fix minimal.**

The second commit is the regression fence for the first: with it in place, this class of mistake fails immediately and visibly at the call site instead of asynchronously in a log.

## On tests — worth being upfront

**Neither change has a unit test, and I couldn't add one without a refactor I didn't think was mine to make.** `packages/cli/src/cli.ts` exports nothing (tests import from siblings like `cli-server.ts`), and `/api/run` is defined inline inside the server bootstrap in `index.ts`, so there's no seam to mount it against — `tests/engine/dispatcher.test.ts` tests `dispatch()`, not the route.

Two ways forward if you'd like coverage, happy to do either:
- extract the context builder into `packages/cli/src/skill-context.ts` and test it directly
- factor the `/api/run` handler into a testable function taking `{ workflowName, context }`

Verified manually instead: the old payload reproduces `missing 'repo' in context`, the new one dispatches and the run completes.

## Verification

- `pnpm typecheck` — 12/12 tasks
- `pnpm test` — 8/8 tasks, 197 + 9 + 1 test files, 0 failures
- Reproduced and confirmed fixed against a live v0.25.7 deployment (`kubernetes` sandbox backend): the corrected payload dispatched a `security-review` that ran to completion (`scan=ok`, 17 turns, 428s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)