### PR TITLE
fix(digest): stop Slack unfurling every PR link into a preview card

### DIFF
--- a/apps/server/spec/03-integrations.md
+++ b/apps/server/spec/03-integrations.md
@@ -337,11 +337,18 @@ Slack**. It is a `handler:` cron — `runRepoDigest` in `src/cron/repo-digest.ts
 - **One optional model call** (`digest.narrative`) turns those facts into a
   sentence of English. It is never asked to produce a number, and a failure
   drops the sentence rather than the digest.
-- **Every PR number is a link.** `prRef` emits a markdown link that
-  `markdownToSlackMrkdwn` converts to Slack's `<url|#294>` form — markdown
+- **Every PR number is a link, and none of them unfurl.** `prRef` emits a
+  markdown link that `markdownToSlackMrkdwn` converts to Slack's `<url|#294>`
+  form — markdown
   rather than that form directly, because the converter runs over these lines
   and would escape a pre-built one. Both numbers a digest prints are open pull
-  requests (`listOpenPullRequests`), so the target is always `/pull/N`.
+  requests (`listOpenPullRequests`), so the target is always `/pull/N`. The
+  post passes `unfurl: false`, which sets **both** `unfurl_links` and
+  `unfurl_media` — without it Slack expands each citation into a preview card
+  and buries the six lines of summary they annotate. It is opt-out per message
+  rather than a connector-wide default: for a conversational reply one shared
+  link and one useful preview is the right behaviour, and only a message whose
+  links are a REFERENCE LIST wants them off.
 - **The escalated-PR list is asked of GitHub** (open PRs labelled
   `requires-human`), not inferred from run rows — `fanOut` returns only
   `{dispatched, failures}` and a skip counts as a success, so an escalation is

--- a/apps/server/src/connectors/slack/connector.ts
+++ b/apps/server/src/connectors/slack/connector.ts
@@ -18,6 +18,20 @@ const log = logger("slack");
  * carries a `reply()` that posts a confirmation into the button's thread, so
  * the same approval-resolution path used by `/approve` can run unchanged.
  */
+/** Per-message overrides for {@link SlackConnector.sendMessage}. */
+export interface SendMessageOptions {
+  /**
+   * Whether Slack may expand the message's links into preview cards.
+   *
+   * Omitted (the default) leaves Slack's own behaviour alone, which is right
+   * for a conversational reply: one shared link, one useful preview. Pass
+   * `false` for a message whose links are a REFERENCE LIST rather than the
+   * content — the repo digest cites several pull requests, and a preview card
+   * per citation buries the six lines of actual summary.
+   */
+  unfurl?: boolean;
+}
+
 export interface SlackApprovalAction {
   decision: "approved" | "rejected";
   /** The paused workflow run id (the button's `value`). */
@@ -187,6 +201,7 @@ export class SlackConnector extends MessagingConnector {
     threadId: string | null,
     text: string,
     blocks?: KnownBlock[],
+    opts: SendMessageOptions = {},
   ): Promise<string | void> {
     const fallbackText = markdownToSlackMrkdwn(text);
     const autoBlocks = !blocks && hasMarkdownImage(text);
@@ -195,12 +210,19 @@ export class SlackConnector extends MessagingConnector {
       : autoBlocks
       ? markdownToSlackBlocks(text)
       : undefined;
+    // Unfurling is per-message and OFF means both switches off: `unfurl_links`
+    // governs text-ish targets, `unfurl_media` images and video, and a message
+    // full of GitHub links trips whichever one Slack decides applies. Left
+    // `undefined` by default so every existing caller keeps Slack's own
+    // behaviour rather than silently losing previews.
+    const unfurl = opts.unfurl === false ? { unfurl_links: false, unfurl_media: false } : {};
     try {
       const result = await this.web.chat.postMessage({
         channel: channelId,
         text: fallbackText,
         blocks: effectiveBlocks,
         thread_ts: threadId || undefined,
+        ...unfurl,
       });
       return result.ts;
     } catch (err) {
@@ -212,6 +234,7 @@ export class SlackConnector extends MessagingConnector {
         channel: channelId,
         text: fallbackText,
         thread_ts: threadId || undefined,
+        ...unfurl,
       });
       return result.ts;
     }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1255,7 +1255,11 @@ async function main() {
             config: config.digest,
             escalationLabel: REQUIRES_HUMAN_LABEL,
             post: async (channel, text, blocks) => {
-              const ts = await slackConnector!.sendMessage(channel, null, text, blocks as KnownBlock[]);
+              // No unfurls: a digest cites several PRs, and a preview card per
+              // citation buries the six lines of summary they annotate.
+              const ts = await slackConnector!.sendMessage(channel, null, text, blocks as KnownBlock[], {
+                unfurl: false,
+              });
               // A digest is a thing the bot wrote, so a 👍/👎 on it is a real
               // signal about whether it is worth sending (issue #255). The `ts`
               // exists only in this response — a send site that drops it makes

--- a/apps/server/tests/connectors/slack/connector.test.ts
+++ b/apps/server/tests/connectors/slack/connector.test.ts
@@ -199,6 +199,46 @@ describe("SlackConnector webhook receiver", () => {
     expect(payload.text).toBe("plain");
   });
 
+  it("leaves unfurling to Slack by default — an existing caller loses no previews", async () => {
+    let payload: any;
+    (conn as any).web.chat.postMessage = async (p: any) => {
+      payload = p;
+      return { ts: "9.9" };
+    };
+    await conn.sendMessage("C1", "T1", "see https://github.com/acme/widgets/pull/1");
+    expect(payload).not.toHaveProperty("unfurl_links");
+    expect(payload).not.toHaveProperty("unfurl_media");
+  });
+
+  it("disables BOTH unfurl switches when a caller opts out", async () => {
+    // Both, not just `unfurl_links`: the two govern different target types
+    // (text-ish vs image/video) and a message full of GitHub links trips
+    // whichever one Slack decides applies.
+    let payload: any;
+    (conn as any).web.chat.postMessage = async (p: any) => {
+      payload = p;
+      return { ts: "9.9" };
+    };
+    await conn.sendMessage("C1", null, "digest", undefined, { unfurl: false });
+    expect(payload.unfurl_links).toBe(false);
+    expect(payload.unfurl_media).toBe(false);
+  });
+
+  it("keeps the opt-out on the text-only retry path", async () => {
+    // The image-block fallback re-posts; without carrying the flags through,
+    // a digest that tripped that path would unfurl after all.
+    const calls: any[] = [];
+    (conn as any).web.chat.postMessage = async (p: any) => {
+      calls.push(p);
+      if (p.blocks) throw new Error("invalid_blocks");
+      return { ts: "9.9" };
+    };
+    await conn.sendMessage("C1", null, "![x](https://bad/img.png)", undefined, { unfurl: false });
+    expect(calls).toHaveLength(2);
+    expect(calls[1].unfurl_links).toBe(false);
+    expect(calls[1].unfurl_media).toBe(false);
+  });
+
   it("auto-promotes a markdown image to an image block", async () => {
     let payload: any;
     (conn as any).web.chat.postMessage = async (p: any) => {


### PR DESCRIPTION
Linking the PR numbers in v0.25.7 made the digest actionable and then unreadable — Slack expanded each citation into a preview card, so six lines of summary arrived buried under several cards of GitHub chrome.

The digest now posts with `unfurl: false`.

## Two decisions

**Both switches, not one.** `unfurl_links` and `unfurl_media` govern different target types (text-ish vs image/video), and a message full of GitHub links trips whichever one Slack decides applies. Setting only the obvious one would have half-worked, in a way that's tedious to notice. There's a test asserting both land in the payload.

**Opt-out per message, not a connector-wide default.** For a conversational reply — someone shares a link, the bot answers — one preview is genuinely useful. Only a message whose links are a *reference list*, several citations annotating content that isn't itself the links, wants them off. So `sendMessage` gained an optional `unfurl` and every existing caller is untouched, keeping Slack's own behaviour. A test pins that too, since "we silently stopped previewing links everywhere" is the regression this shape exists to avoid.

One easy-to-miss detail: the flags are carried onto the **text-only retry path** as well. `sendMessage` re-posts without blocks when Slack rejects auto-generated image blocks, and a digest that tripped that path would otherwise have unfurled after all.

## Still unfurling, deliberately

Chat replies and the in-place progress checklist (`SlackTransport`) are unchanged. Both post links — run artifacts, approval URLs — so if those are cluttering threads too, say so and they're a one-line change each. I didn't assume.

## Verification

`pnpm turbo run typecheck test build` green (3,215 tests, 3 new asserting the wire payload: default omits both flags, opt-out sets both, retry path keeps both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
