### PR TITLE
Fix the review pipeline's silent failures, and make the run visible

### DIFF
--- a/apps/evals/src/pr-context.ts
+++ b/apps/evals/src/pr-context.ts
@@ -209,6 +209,12 @@ export function buildPrState(args: {
     // gates attempt bookkeeping, which this harness does not run.
     headAuthor: "dependabot[bot]",
     headIsOurs: false,
+    // Nor did it OPEN the PR — a distinct question from `headIsOurs`, and the
+    // one the review gate reads. Every eval case is a third party's pull
+    // request; a case that set this would be asking the harness to grade a
+    // review the dispatch gate refuses to run at all.
+    authorLogin: "dependabot[bot]",
+    authorIsOurs: false,
     headRef: s.head_ref ?? args.branch,
     baseRef: s.base_ref ?? "main",
     isDraft: s.is_draft ?? false,

--- a/apps/server/dashboard/src/components/PhaseDetailPanel.tsx
+++ b/apps/server/dashboard/src/components/PhaseDetailPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from "../api";
 import { GhLink } from "./GhLink";
 import { repoUrl, issueUrl } from "../lib/githubLinks";
+import { isNoOpSummary, phaseSummary } from "../lib/phase-outcome";
 
 /**
  * In-SPA navigation to the artifact editor for a specific doc — the Repos tab's
@@ -143,6 +144,9 @@ export function PhaseDetailPanel({
   // resolves a repeated label last-wins; this keeps the two views in agreement.
   const historyEntry = run.phaseHistory.filter((h) => h.phase === phaseName).at(-1);
 
+  const summary = phaseSummary(historyEntry);
+  const noOp = summary ? isNoOpSummary(summary) : false;
+
   const statusLabel = execution
     ? execution.success === true
       ? // A generic-loop `until_bash` check records success = "did the check
@@ -253,6 +257,37 @@ export function PhaseDetailPanel({
 
       {tab === "details" && (
         <div className="flex flex-col gap-4">
+          {/* What the phase DID — first, because it is what the user clicked to
+            * find out. A green tick answers "did it break"; only this answers
+            * "did it do anything". `post-review` is the case that forced it:
+            * `skipped: …`, `already-reviewed: …` and `posted review: 4 inline,
+            * 1 in body, event=COMMENT` all rendered as the same silent green
+            * node, so a run that posted nothing looked completely healthy.
+            * Absent for plain agent phases (they record no summary) — render
+            * nothing at all rather than an empty box. */}
+          {summary && (
+            <div>
+              <div className="text-2xs font-semibold uppercase tracking-wider text-base-content/40 mb-1">
+                Outcome
+              </div>
+              <div
+                className={clsx(
+                  "text-xs wrap-break-word whitespace-pre-wrap rounded border px-3 py-2",
+                  noOp
+                    ? "border-base-300/60 bg-base-200/40 text-base-content/60 italic"
+                    : "border-base-300/40 bg-base-200/30 text-base-content/80",
+                )}
+              >
+                {noOp && (
+                  <span className="badge badge-xs badge-ghost font-mono mr-2 align-middle not-italic">
+                    no-op
+                  </span>
+                )}
+                {summary}
+              </div>
+            </div>
+          )}
+
           {phaseDef && (
             <div className="grid grid-cols-2 gap-3">
               <Field label="Type">{phaseDef.type}</Field>
@@ -269,7 +304,12 @@ export function PhaseDetailPanel({
             </div>
           )}
 
-          {!execution && (
+          {/* Suppressed once an outcome exists. A HANDLER phase (`post-review`,
+            * a `fanout` join) runs in-process and never writes an `executions`
+            * row, so this box is permanent for it — and "No execution recorded
+            * yet." beside a phase that just posted a review is the opposite of
+            * what happened. */}
+          {!execution && !summary && (
             <div className="text-xs text-base-content/50 border border-base-300/40 bg-base-200/30 rounded px-3 py-2">
               No execution recorded yet.
             </div>

--- a/apps/server/dashboard/src/components/PrStatePanel.tsx
+++ b/apps/server/dashboard/src/components/PrStatePanel.tsx
@@ -190,6 +190,15 @@ export function PrStatePanel({ run }: { run: WorkflowRun }) {
               value={`${str(state.authorLogin) || "unknown"}${state.authorIsOurs ? " · ours" : ""}`}
               tone={state.authorIsOurs ? "warn" : undefined}
             />
+            {/* WHO ASKED. Recorded beside the snapshot rather than in it: the
+                snapshot is what is true of the PR, this is what was true of the
+                dispatch. It is also the flag that lets a re-review of an
+                already-reviewed head actually post, so "why did this run say
+                nothing" is answerable from here. */}
+            <Fact
+              label="trigger"
+              value={ctx.explicitRequest === true ? "asked for" : "automatic"}
+            />
             <Fact
               label="shape"
               value={[

--- a/apps/server/dashboard/src/components/PrStatePanel.tsx
+++ b/apps/server/dashboard/src/components/PrStatePanel.tsx
@@ -181,6 +181,15 @@ export function PrStatePanel({ run }: { run: WorkflowRun }) {
                 life — the same `costBaselineUsd` boundary that re-arms the
                 attempt counter. */}
             <Fact label="spent on this problem" value={`$${spent.toFixed(2)}`} />
+            {/* WHO OPENED IT. Distinct from the head-commit author already on
+                the snapshot: GitHub refuses a review event on a PR you opened,
+                so `ours` here means a review can never post, however green
+                every phase looks. */}
+            <Fact
+              label="pr author"
+              value={`${str(state.authorLogin) || "unknown"}${state.authorIsOurs ? " · ours" : ""}`}
+              tone={state.authorIsOurs ? "warn" : undefined}
+            />
             <Fact
               label="shape"
               value={[

--- a/apps/server/dashboard/src/components/WorkflowList.tsx
+++ b/apps/server/dashboard/src/components/WorkflowList.tsx
@@ -198,8 +198,40 @@ function ResizablePipeline({
     document.addEventListener("mouseup", onUp);
   }, [pipelineHeight]);
 
+  // The harness records a terminal failure as a string on the run context.
+  // Shown only for a terminal run: a `running` run can carry a stale `error`
+  // from an earlier phase that was since retried, and banner-ing that would
+  // report a live run as broken.
+  const contextError = run.context?.error;
+  const runFailureReason =
+    (run.status === "failed" || run.status === "cancelled") && typeof contextError === "string"
+      ? contextError
+      : null;
+
   return (
     <div ref={containerRef} className="flex flex-col flex-1 min-h-0">
+      {/* Why the run failed.
+       *
+       * Not every failure has a phase node to hang off. A handler phase that
+       * throws before it writes an `executions` row leaves NOTHING in the
+       * pipeline — `post-review` rejecting a review is the case that prompted
+       * this: the graph showed every phase green, the run said `failed`, and
+       * the reason ("GitHub rejected the review … Can not request changes on
+       * your own pull request") existed only on `context.error`, reachable
+       * from the API and nowhere in the UI. A run that fails invisibly reads
+       * as a bug in the dashboard rather than an answer about the run. */}
+      {runFailureReason && (
+        <div className="shrink-0 mb-3 rounded border border-error/40 bg-error/5 px-3 py-2">
+          <div className="text-2xs font-semibold uppercase tracking-wider text-error/80">
+            {run.status === "cancelled" ? "Cancelled" : "Failed"}
+            {run.currentPhase ? ` · ${run.currentPhase}` : ""}
+          </div>
+          <div className="mt-1 text-xs text-base-content/80 break-words whitespace-pre-wrap font-mono">
+            {runFailureReason}
+          </div>
+        </div>
+      )}
+
       {/* Pipeline section — capped at 50% by default */}
       <div
         data-pipeline

--- a/apps/server/dashboard/src/components/WorkflowPipeline.tsx
+++ b/apps/server/dashboard/src/components/WorkflowPipeline.tsx
@@ -22,6 +22,7 @@ import {
   type PhaseStatus,
   type PipelineNodeData,
 } from "./pipeline-node";
+import { isNoOpSummary, phaseSummary } from "../lib/phase-outcome";
 
 type PhaseNodeData = PipelineNodeData;
 
@@ -36,7 +37,8 @@ function nodeDataEqual(a: PhaseNodeData, b: PhaseNodeData): boolean {
     a.duration === b.duration &&
     a.selected === b.selected &&
     a.kind === b.kind &&
-    a.pulse === b.pulse
+    a.pulse === b.pulse &&
+    a.summary === b.summary
   );
 }
 
@@ -394,11 +396,30 @@ export function WorkflowPipeline({
         }
       }
 
+      // What the phase DID, so a green-but-did-nothing node is distinguishable
+      // from a green-and-did-a-lot one without opening the panel.
+      //
+      // TOP ROW ONLY (`y === 0`). Two reasons, both about not bloating the
+      // graph: the stacked nodes are loop iterations and fan-out branches whose
+      // summaries are boilerplate ("iteration 3 — work complete"), and their
+      // vertical pitch is the fixed NODE_ROW_HEIGHT constant, which an extra
+      // line per card would silently overrun. Every node still carries the full
+      // text in its tooltip and in the detail panel.
+      const summary = y === 0 ? phaseSummary(histEntry) : undefined;
+
       return {
         id: name,
         type: "phase",
         position: { x, y },
-        data: { label, status, timestamp, duration, selected: selectedPhase === name },
+        data: {
+          label,
+          status,
+          timestamp,
+          duration,
+          summary,
+          summaryNoOp: summary ? isNoOpSummary(summary) : undefined,
+          selected: selectedPhase === name,
+        },
         style: { width: NODE_WIDTH },
       };
     };

--- a/apps/server/dashboard/src/components/WorkflowPipeline.tsx
+++ b/apps/server/dashboard/src/components/WorkflowPipeline.tsx
@@ -128,6 +128,69 @@ function findParentDeclared(name: string, declared: string[]): string | null {
   return best;
 }
 
+/**
+ * The derived-phase-name grammar, MIRRORED from
+ * `packages/workflow-engine/src/core/phase-ref.ts` (`PhaseRef.format`/`parse`).
+ *
+ * Mirrored rather than imported because the dashboard has no dependency on
+ * `lastlight-workflow-engine` — the same reason it hand-mirrors the config
+ * types in `api.ts`. If the grammar there gains a form, it has to be added
+ * here too; the failure mode is cosmetic (the raw ledger key renders, which is
+ * exactly what this replaces) rather than a crash.
+ *
+ * Branch names are schema-constrained to `[A-Za-z0-9-]`, and that is what makes
+ * the greedy-base split unambiguous against a base that may itself contain `_`.
+ * Order matters: the two SUFFIXED branch forms must be tried before the bare
+ * one, and likewise for the iteration forms.
+ */
+type DerivedRef =
+  | { kind: "branch"; base: string; branch: string; suffix?: "retry" | "check" }
+  | { kind: "iter"; base: string; index: number; suffix?: "retry" | "check" }
+  | { kind: "fix" | "recheck"; base: string; index: number };
+
+function parseDerived(name: string): DerivedRef | null {
+  let m = name.match(/^(.*)_branch_([A-Za-z0-9-]+)_(retry|check)$/);
+  if (m) return { kind: "branch", base: m[1]!, branch: m[2]!, suffix: m[3] as "retry" | "check" };
+  m = name.match(/^(.*)_branch_([A-Za-z0-9-]+)$/);
+  if (m) return { kind: "branch", base: m[1]!, branch: m[2]! };
+  m = name.match(/^(.*)_iter_(\d+)_(retry|check)$/);
+  if (m) return { kind: "iter", base: m[1]!, index: Number(m[2]), suffix: m[3] as "retry" | "check" };
+  m = name.match(/^(.*)_iter_(\d+)$/);
+  if (m) return { kind: "iter", base: m[1]!, index: Number(m[2]) };
+  m = name.match(/^(.*)_fix_(\d+)$/);
+  if (m) return { kind: "fix", base: m[1]!, index: Number(m[2]) };
+  m = name.match(/^(.*)_recheck_(\d+)$/);
+  if (m) return { kind: "recheck", base: m[1]!, index: Number(m[2]) };
+  return null;
+}
+
+/**
+ * A SHORT label for a derived node. Short is the requirement, not a preference:
+ * these render in a 110px card under a parent that already names the phase, so
+ * `survey_branch_contract` overflowed its box and read as a different phase
+ * rather than as one branch of the node directly above it.
+ */
+function derivedLabel(ref: DerivedRef): string {
+  const suffix = "suffix" in ref && ref.suffix ? (ref.suffix === "check" ? " · gate" : " · retry") : "";
+  switch (ref.kind) {
+    case "branch":
+      return `${ref.branch}${suffix}`;
+    case "iter":
+      return `#${ref.index}${suffix}`;
+    case "fix":
+      return `fix ${ref.index}`;
+    case "recheck":
+      return `recheck ${ref.index}`;
+  }
+}
+
+/** The branch node a `_retry` / `_check` row hangs off, if it is one. */
+function branchParentOf(name: string): string | null {
+  const ref = parseDerived(name);
+  if (!ref || ref.kind !== "branch" || !ref.suffix) return null;
+  return `${ref.base}_branch_${ref.branch}`;
+}
+
 interface Props {
   run: WorkflowRun;
   /** Workflow YAML definition. The pipeline is fully definition-driven. */
@@ -236,7 +299,13 @@ export function WorkflowPipeline({
       run.status === "failed" || run.status === "succeeded" || run.status === "cancelled";
 
     const buildNode = (name: string, x: number, y: number): Node<PhaseNodeData> => {
-      const label = declaredLabelByName.get(name) ?? name;
+      // Declared name → its YAML `label:`. Otherwise it is a DERIVED name
+      // (a fan-out branch or a loop iteration), and the raw ledger key is the
+      // last resort rather than the default: `survey_branch_contract` overflows
+      // a 110px card and reads as an unrelated phase instead of as one branch
+      // of the node above it.
+      const derived = declaredLabelByName.has(name) ? null : parseDerived(name);
+      const label = declaredLabelByName.get(name) ?? (derived ? derivedLabel(derived) : name);
       const histEntry = historyMap.get(name);
       const exec = execByPhase.get(name);
 
@@ -283,23 +352,45 @@ export function WorkflowPipeline({
           .map((k) => execByPhase.get(k))
           .filter((e): e is WorkflowRunExecution => !!e);
         if (kidExecs.length > 0) {
+          // A FAN-OUT's children are concurrent; a LOOP's are sequential. That
+          // one difference changes both answers below, so decide it once.
+          const isFanout = kids.some((k) => parseDerived(k)?.kind === "branch");
           const lastExec = execByPhase.get(kids[kids.length - 1]!);
           if (kidExecs.some((kx) => kx.success === undefined))
             status = isTerminalRun ? "failed" : "active";
-          else if (lastExec?.success === true)
+          else if (isFanout) {
+            // "Last child wins" is a loop rule — the final iteration is the
+            // outcome. Concurrent branches have no last, only a worst: one red
+            // branch is a red fan-out however the start times happened to sort.
+            const failed = kidExecs.find((kx) => kx.success === false && kx.stopReason !== "skipped");
+            const skipped = kidExecs.every((kx) => kx.stopReason === "skipped");
+            status = failed ? "failed" : skipped ? "skipped" : "done";
+          } else if (lastExec?.success === true)
             // Same rule as the leaf above: a loop whose LAST child is a red
             // exit check ran out of iterations without its gate ever going
             // green. That is not a failure, but it is not a pass either.
             status = lastExec.stopReason === "condition_not_met" ? "unmet" : "done";
           else if (lastExec?.success === false)
             status = lastExec.stopReason === "skipped" ? "skipped" : "failed";
-          // Span the loop: earliest iteration start + summed iteration durations.
           timestamp = kidExecs.reduce(
             (min, kx) => (kx.startedAt < min ? kx.startedAt : min),
             kidExecs[0]!.startedAt,
           );
-          const totalMs = kidExecs.reduce((sum, kx) => sum + (kx.durationMs ?? 0), 0);
-          if (totalMs > 0) duration = totalMs / 1000;
+          if (isFanout) {
+            // WALL CLOCK, not the sum. Summing concurrent branches reports a
+            // number the run never spent: the five surveys of a real pr-review
+            // measured 161+59+235+233+194s, which summed to 882s for a phase
+            // that actually took 235 — so the fan-out looked like the most
+            // expensive step in the run when it was the point at which the run
+            // stopped being sequential.
+            const startMs = kidExecs.map((kx) => Date.parse(kx.startedAt));
+            const endMs = kidExecs.map((kx) => Date.parse(kx.startedAt) + (kx.durationMs ?? 0));
+            const spanMs = Math.max(...endMs) - Math.min(...startMs);
+            if (spanMs > 0) duration = spanMs / 1000;
+          } else {
+            const totalMs = kidExecs.reduce((sum, kx) => sum + (kx.durationMs ?? 0), 0);
+            if (totalMs > 0) duration = totalMs / 1000;
+          }
         }
       }
 
@@ -425,7 +516,39 @@ export function WorkflowPipeline({
       linkTo(name, prevId);
       prevId = name;
 
-      const children = childrenByParent.get(name) ?? [];
+      let children = childrenByParent.get(name) ?? [];
+      // A `type: fanout` column. Its children are CONCURRENT branches, not loop
+      // iterations, so neither the ordering nor the edges below can be the
+      // chain a loop wants.
+      const isFanoutColumn = children.some((c) => parseDerived(c)?.kind === "branch");
+      if (isFanoutColumn) {
+        // Group each branch with its own `_retry` / `_check` rows. Sorting the
+        // flat list by start time scattered them — the five branches start
+        // within milliseconds of each other, so the order jittered between
+        // polls and a branch's gate rarely landed next to the branch it gates.
+        const groupOf = (n: string): string => branchParentOf(n) ?? n;
+        const rank = (n: string): number => {
+          const ref = parseDerived(n);
+          return ref?.kind === "branch" && ref.suffix ? (ref.suffix === "retry" ? 1 : 2) : 0;
+        };
+        const firstStart = new Map<string, string>();
+        for (const c of children) {
+          const g = groupOf(c);
+          const s = execByPhase.get(c)?.startedAt ?? "";
+          const cur = firstStart.get(g);
+          if (cur === undefined || (s && s < cur)) firstStart.set(g, s);
+        }
+        children = [...children].sort((a, b) => {
+          const ga = groupOf(a);
+          const gb = groupOf(b);
+          if (ga !== gb) {
+            const sa = firstStart.get(ga) ?? "";
+            const sb = firstStart.get(gb) ?? "";
+            return sa === sb ? ga.localeCompare(gb) : sa.localeCompare(sb);
+          }
+          return rank(a) - rank(b);
+        });
+      }
       // Weave each iteration's interactive gate in right after the iteration it
       // belongs to, so the vertical stack reads run → gate → run → gate → run.
       type StackItem =
@@ -446,9 +569,22 @@ export function WorkflowPipeline({
         reactFlowNodes.push(
           item.kind === "phase" ? buildNode(item.name, x, y) : buildApprovalNode(item.a, x, y),
         );
+        // WHERE THE EDGE COMES FROM is the difference between "these ran in
+        // sequence" and "these ran at once", and it is the only thing on this
+        // canvas that says which. A loop chains child→child, because iteration
+        // 2 really did wait for iteration 1. A fan-out must NOT: its branches
+        // all start from the parent, and chaining them drew five concurrent
+        // surveys as a five-deep ladder — the one claim the picture makes about
+        // a fan-out, made backwards.
+        //
+        // A branch's own `_retry` / `_check` row hangs off THAT BRANCH rather
+        // than the parent, so a gate sits under the thing it gates.
+        const source = isFanoutColumn
+          ? (item.kind === "phase" ? branchParentOf(item.name) ?? name : name)
+          : childPrev;
         reactFlowEdges.push({
-          id: `${childPrev}->${childId}`,
-          source: childPrev,
+          id: `${source}->${childId}`,
+          source,
           target: childId,
           sourceHandle: "bottom",
           targetHandle: "top",

--- a/apps/server/dashboard/src/components/pipeline-node.tsx
+++ b/apps/server/dashboard/src/components/pipeline-node.tsx
@@ -1,5 +1,6 @@
 import { Position, Handle, type Node, type NodeProps } from "@xyflow/react";
 import clsx from "clsx";
+import { truncateSummary } from "../lib/phase-outcome";
 
 /**
  * Shared pipeline node presentation, used by BOTH the workflow-run pipeline
@@ -47,6 +48,20 @@ export interface PipelineNodeData extends Record<string, unknown> {
   tags?: PhaseTag[];
   /** Secondary line under the label (e.g. the phase id when it differs). */
   subtitle?: string;
+  /**
+   * Run-view: the phase's OUTCOME SUMMARY — what it did, from its
+   * `phase_history` entry (see `lib/phase-outcome.ts`). Clipped to at most two
+   * short lines; the full text rides the card's `title` and the detail panel. A
+   * card is 110px wide, so this is deliberately a hint that a phase is worth
+   * clicking, not the place to read the outcome.
+   */
+  summary?: string;
+  /**
+   * The summary says the phase declined to do its work. Display-only: it mutes
+   * the summary line so a green-but-did-nothing phase is distinguishable from a
+   * green-and-did-a-lot one at a glance, and never touches {@link status}.
+   */
+  summaryNoOp?: boolean;
   /**
    * Override the status-derived surface with a neutral brand (primary) tint.
    * Used by the definition view, whose phases have no run status — a brand
@@ -222,7 +237,10 @@ export function PhaseFlowNode({ data }: NodeProps<Node<PipelineNodeData>>) {
   );
 
   return (
-    <div className={containerClass}>
+    // The full outcome summary as the card's tooltip — a 110px node can only
+    // ever show a clipped line, and truncating with no way to read the rest is
+    // how you learn a phase did something without learning what.
+    <div className={containerClass} title={data.summary}>
       {data.loops && <LoopArc />}
       {/* Horizontal handles carry the main left-to-right pipeline; the vertical
           handles carry loop-iteration stacks so those edges run straight down. */}
@@ -242,6 +260,16 @@ export function PhaseFlowNode({ data }: NodeProps<Node<PipelineNodeData>>) {
       )}
       {data.duration !== undefined && (
         <span className="text-2xs text-base-content/40 font-mono">{formatDuration(data.duration)}</span>
+      )}
+      {data.summary && (
+        <span
+          className={clsx(
+            "text-2xs leading-tight max-w-full break-words line-clamp-2",
+            data.summaryNoOp ? "italic text-base-content/45" : "text-base-content/65",
+          )}
+        >
+          {truncateSummary(data.summary)}
+        </span>
       )}
       {data.tags && data.tags.length > 0 && <TagRow tags={data.tags} />}
       <Handle type="source" position={Position.Right} id="right" className={handleClass} />

--- a/apps/server/dashboard/src/components/timeline/ToolPair.tsx
+++ b/apps/server/dashboard/src/components/timeline/ToolPair.tsx
@@ -1,7 +1,9 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import clsx from "clsx";
 import DOMPurify from "dompurify";
 import AnsiToHtml from "ansi-to-html";
+import { Maximize2, X } from "lucide-react";
 import type { ToolPair as ToolPairType } from "../../timeline/types";
 import { MessageCard, RowIcon } from "./MessageCard";
 import { CodeBlock } from "./CodeBlock";
@@ -18,7 +20,13 @@ interface Props {
   isNew?: boolean;
 }
 
-const RESULT_TRUNCATE_CHARS = 8000;
+// Inline the tool result stays a preview: it sits inside a scrolling feed of
+// hundreds of cards, and Prism highlights synchronously. The full-screen view
+// is the escape hatch, so it gets a limit high enough to be moot against the
+// shim's own 64KB tool_result cap (engine/event-shim.ts).
+const INLINE_TRUNCATE_CHARS = 8000;
+const FULLSCREEN_TRUNCATE_CHARS = 200_000;
+
 // eslint-disable-next-line no-control-regex
 const ANSI_RE = /\x1b\[[\d;]*m/;
 const ansiConverter = new AnsiToHtml({ fg: "#c9d1d9", bg: "transparent", escapeXML: true });
@@ -44,133 +52,288 @@ function stringifyResultContent(content: unknown): { text: string; isJson: boole
   }
 }
 
+function truncate(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  return (
+    text.slice(0, limit) +
+    `\n\n... (${(text.length - limit).toLocaleString()} more chars)`
+  );
+}
+
+function Pane({
+  label,
+  tone,
+  children,
+}: {
+  label: string;
+  tone?: "error";
+  children: ReactNode;
+}) {
+  // `min-w-0` on the column is what keeps an unwrapped 400-column log line
+  // scrolling inside its own <pre> instead of widening the grid track and
+  // pushing the whole feed sideways.
+  return (
+    <div className="flex flex-col min-w-0 min-h-0">
+      <div
+        className={clsx(
+          "text-2xs uppercase tracking-wider font-semibold mb-1 shrink-0",
+          tone === "error" ? "text-error" : "text-base-content/55",
+        )}
+      >
+        {label}
+      </div>
+      <div className="flex-1 min-w-0 min-h-0">{children}</div>
+    </div>
+  );
+}
+
+function PaneNote({ children }: { children: ReactNode }) {
+  return <div className="text-2xs text-base-content/40 italic py-2">{children}</div>;
+}
+
+function ToolPanes({
+  argsJson,
+  argsLang,
+  resultText,
+  resultIsJson,
+  hasResult,
+  isError,
+  maxHeight,
+  limit,
+  className,
+}: {
+  argsJson: string;
+  argsLang: string;
+  resultText: string;
+  resultIsJson: boolean;
+  hasResult: boolean;
+  isError: boolean;
+  maxHeight: string;
+  limit: number;
+  className?: string;
+}) {
+  return (
+    <div className={clsx("grid gap-3 md:grid-cols-2", className)}>
+      <Pane label="Input">
+        <CodeBlock code={argsJson} language={argsLang} maxHeight={maxHeight} />
+      </Pane>
+      <Pane label={isError ? "Error" : "Output"} tone={isError ? "error" : undefined}>
+        {!hasResult ? (
+          <PaneNote>(still running - no result yet)</PaneNote>
+        ) : resultText ? (
+          <CodeBlock
+            code={truncate(resultText, limit)}
+            language={resultIsJson ? "json" : "text"}
+            maxHeight={maxHeight}
+          />
+        ) : (
+          <PaneNote>(empty)</PaneNote>
+        )}
+      </Pane>
+    </div>
+  );
+}
+
 export function ToolPair({ pair, isNew }: Props) {
-  const [argsExpanded, setArgsExpanded] = useState(false);
-  const [resultExpanded, setResultExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [maximized, setMaximized] = useState(false);
 
   const input = (pair.use.content as { input?: Record<string, unknown> })?.input ?? {};
   const resultContent = (pair.result?.content as { content?: unknown })?.content;
   const isError = (pair.result?.content as { is_error?: boolean })?.is_error === true;
-  const { text: resultText, isJson } = stringifyResultContent(resultContent);
-  const argsJson = JSON.stringify(input, null, 2);
+  const { text: resultText, isJson } = useMemo(
+    () => stringifyResultContent(resultContent),
+    [resultContent],
+  );
+  const argsJson = useMemo(() => JSON.stringify(input, null, 2), [input]);
   const summary = summarizeResult(resultContent);
   const toolLabel = formatToolName(pair.toolName);
   const family = classifyTool(pair.toolName);
   const vis = FAMILY_VISUAL[family];
   const Icon = iconForTool(pair.toolName, family);
+  const argsLang = getArgsLang(pair.toolName);
+  const title = toolLabel.prefix ? `${toolLabel.prefix}.${toolLabel.label}` : toolLabel.label;
+
+  useEffect(() => {
+    if (!maximized) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMaximized(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [maximized]);
+
+  const panes = (
+    <ToolPanes
+      argsJson={argsJson}
+      argsLang={argsLang}
+      resultText={resultText}
+      resultIsJson={isJson}
+      hasResult={pair.result != null}
+      isError={isError}
+      maxHeight="22rem"
+      limit={INLINE_TRUNCATE_CHARS}
+      className="mt-2"
+    />
+  );
+
+  const resultRow = pair.result && (
+    <button
+      type="button"
+      onClick={() => setExpanded(!expanded)}
+      className="w-full flex items-center gap-2 text-left min-w-0 cursor-pointer hover:text-base-content"
+    >
+      <span
+        className={clsx(
+          "text-2xs uppercase tracking-wider font-semibold shrink-0",
+          isError ? "text-error" : "text-base-content/55",
+        )}
+      >
+        {isError ? "Error" : "Result"}
+      </span>
+      {summary.kind === "empty" ? (
+        <span className="text-2xs text-base-content/40 italic">(empty)</span>
+      ) : (
+        <>
+          <span className="text-base-content/25 shrink-0">-</span>
+          {!expanded && (() => {
+            const preview =
+              summary.kind === "text" ? summary.preview :
+              summary.kind === "json" ? summary.preview :
+              summary.kind === "array" ? `[${summary.length}] ${summary.preview ? "- " + summary.preview : ""}` :
+              "";
+            const hasAnsi = typeof preview === "string" && ANSI_RE.test(preview);
+            return hasAnsi ? (
+              <span
+                className="text-xs font-mono truncate flex-1"
+                dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(ansiConverter.toHtml(preview), { ADD_ATTR: ["style"] }) }}
+              />
+            ) : (
+              <span
+                className={clsx(
+                  "text-xs font-mono truncate flex-1",
+                  summary.kind === "json" ? "text-base-content/60" : "text-base-content/75",
+                )}
+              >
+                {preview}
+              </span>
+            );
+          })()}
+          <span className="ml-auto text-2xs text-base-content/40 font-mono shrink-0 flex items-center gap-2">
+            {summary.kind === "text" && summary.lines && summary.lines > 1 && (
+              <span>{summary.lines.toLocaleString()} lines</span>
+            )}
+            {summary.kind === "array" && (
+              <span>{summary.length.toLocaleString()} items</span>
+            )}
+            <span>{formatBytes(summary.bytes)}</span>
+            <span>{expanded ? "-" : "+"}</span>
+          </span>
+        </>
+      )}
+    </button>
+  );
+
+  const body = resultRow || expanded ? (
+    <>
+      {resultRow}
+      {expanded && panes}
+    </>
+  ) : null;
 
   return (
-    <MessageCard
-      isNew={isNew}
-      timestamp={pair.timestamp}
-      dense
-      title={
-        <>
-          <RowIcon Icon={Icon} color={vis.color} bg={vis.bg} />
-          <span className="text-2xs font-semibold uppercase tracking-wider text-base-content/80 shrink-0 font-mono">
-            {toolLabel.prefix ? `${toolLabel.prefix}.${toolLabel.label}` : toolLabel.label}
-          </span>
-          <span className="text-base-content/25 shrink-0">-</span>
-          {renderToolSummary(pair.toolName, input)}
-        </>
-      }
-      headerRight={
-        <div className="flex items-center gap-1.5 shrink-0">
-          {pair.result == null && (
-            <span className="badge badge-xs badge-warning animate-pulse">running</span>
-          )}
-          {isError && <span className="badge badge-xs badge-error">error</span>}
-          <button
-            onClick={() => setArgsExpanded(!argsExpanded)}
-            className="text-2xs text-base-content/45 hover:text-base-content font-mono"
-            title="Toggle full args"
-          >
-            {argsExpanded ? "- args" : "+ args"}
-          </button>
-        </div>
-      }
-    >
-      {argsExpanded && (
-        <div className="mb-2">
-          <CodeBlock code={argsJson} language={getArgsLang(pair.toolName)} maxHeight="24rem" />
-        </div>
-      )}
-      {pair.result && (
-        <div>
-          <button
-            type="button"
-            disabled={summary.kind === "empty"}
-            onClick={() => summary.kind !== "empty" && setResultExpanded(!resultExpanded)}
-            className={clsx(
-              "w-full flex items-center gap-2 text-left min-w-0",
-              summary.kind !== "empty" && "cursor-pointer hover:text-base-content",
-            )}
-          >
-            <span
-              className={clsx(
-                "text-2xs uppercase tracking-wider font-semibold shrink-0",
-                isError ? "text-error" : "text-base-content/55",
-              )}
-            >
-              {isError ? "Error" : "Result"}
+    <>
+      <MessageCard
+        isNew={isNew}
+        timestamp={pair.timestamp}
+        dense
+        title={
+          <>
+            <RowIcon Icon={Icon} color={vis.color} bg={vis.bg} />
+            <span className="text-2xs font-semibold uppercase tracking-wider text-base-content/80 shrink-0 font-mono">
+              {title}
             </span>
-            {summary.kind === "empty" ? (
-              <span className="text-2xs text-base-content/40 italic">(empty)</span>
-            ) : (
-              <>
-                <span className="text-base-content/25 shrink-0">-</span>
-                {!resultExpanded && (() => {
-                  const preview =
-                    summary.kind === "text" ? summary.preview :
-                    summary.kind === "json" ? summary.preview :
-                    summary.kind === "array" ? `[${summary.length}] ${summary.preview ? "- " + summary.preview : ""}` :
-                    "";
-                  const hasAnsi = typeof preview === "string" && ANSI_RE.test(preview);
-                  return hasAnsi ? (
-                    <span
-                      className="text-xs font-mono truncate flex-1"
-                      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(ansiConverter.toHtml(preview), { ADD_ATTR: ["style"] }) }}
-                    />
-                  ) : (
-                    <span
-                      className={clsx(
-                        "text-xs font-mono truncate flex-1",
-                        summary.kind === "json" ? "text-base-content/60" : "text-base-content/75",
-                      )}
-                    >
-                      {preview}
-                    </span>
-                  );
-                })()}
-                <span className="ml-auto text-2xs text-base-content/40 font-mono shrink-0 flex items-center gap-2">
-                  {summary.kind === "text" && summary.lines && summary.lines > 1 && (
-                    <span>{summary.lines.toLocaleString()} lines</span>
-                  )}
-                  {summary.kind === "array" && (
-                    <span>{summary.length.toLocaleString()} items</span>
-                  )}
-                  <span>{formatBytes(summary.bytes)}</span>
-                  <span>{resultExpanded ? "-" : "+"}</span>
-                </span>
-              </>
+            <span className="text-base-content/25 shrink-0">-</span>
+            {renderToolSummary(pair.toolName, input)}
+          </>
+        }
+        headerRight={
+          <div className="flex items-center gap-1.5 shrink-0">
+            {pair.result == null && (
+              <span className="badge badge-xs badge-warning animate-pulse">running</span>
             )}
-          </button>
-          {resultExpanded && resultText && (
-            <div className="mt-2">
-              <CodeBlock
-                code={
-                  resultText.length > RESULT_TRUNCATE_CHARS
-                    ? resultText.slice(0, RESULT_TRUNCATE_CHARS) +
-                      `\n\n... (${(resultText.length - RESULT_TRUNCATE_CHARS).toLocaleString()} more chars)`
-                    : resultText
-                }
-                language={isJson ? "json" : "text"}
-                maxHeight="32rem"
-              />
+            {isError && <span className="badge badge-xs badge-error">error</span>}
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="text-2xs text-base-content/45 hover:text-base-content font-mono"
+              title="Toggle input and output"
+            >
+              {expanded ? "- io" : "+ io"}
+            </button>
+            <button
+              onClick={() => setMaximized(true)}
+              className="text-base-content/40 hover:text-base-content"
+              title="Open full screen"
+            >
+              <Maximize2 size={12} />
+            </button>
+          </div>
+        }
+      >
+        {body}
+      </MessageCard>
+
+      {/* Portalled because the feed is a scroll container inside a flex app
+          shell — a `fixed` overlay rendered in place is one `transform` on any
+          ancestor away from being clipped to that container. */}
+      {maximized &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+            onClick={() => setMaximized(false)}
+          >
+            <div
+              className="ll-surface border border-base-300 rounded-xl shadow-2xl w-full h-full flex flex-col overflow-hidden"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-center gap-2 px-4 py-2 border-b border-base-300/60 shrink-0">
+                <RowIcon Icon={Icon} color={vis.color} bg={vis.bg} />
+                <span className="text-2xs font-semibold uppercase tracking-wider text-base-content/80 shrink-0 font-mono">
+                  {title}
+                </span>
+                <span className="text-base-content/25 shrink-0">-</span>
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  {renderToolSummary(pair.toolName, input)}
+                </div>
+                {isError && <span className="badge badge-xs badge-error shrink-0">error</span>}
+                <button
+                  onClick={() => setMaximized(false)}
+                  className="btn btn-xs btn-ghost shrink-0"
+                  title="Close (Esc)"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+              <div className="flex-1 min-h-0 overflow-auto p-4">
+                {/* A viewport calc rather than `100%`: a percentage max-height
+                    against a flex/grid track that is itself content-sized
+                    resolves to none in some engines, and the panes would then
+                    grow past the dialog instead of scrolling inside it. */}
+                <ToolPanes
+                  argsJson={argsJson}
+                  argsLang={argsLang}
+                  resultText={resultText}
+                  resultIsJson={isJson}
+                  hasResult={pair.result != null}
+                  isError={isError}
+                  maxHeight="calc(100vh - 10rem)"
+                  limit={FULLSCREEN_TRUNCATE_CHARS}
+                />
+              </div>
             </div>
-          )}
-        </div>
-      )}
-    </MessageCard>
+          </div>,
+          document.body,
+        )}
+    </>
   );
 }

--- a/apps/server/dashboard/src/lib/phase-outcome.ts
+++ b/apps/server/dashboard/src/lib/phase-outcome.ts
@@ -1,0 +1,66 @@
+/**
+ * A phase's OUTCOME SUMMARY — the one line it recorded about what it actually
+ * did, as opposed to whether it went green.
+ *
+ * The summary is the optional `summary` field of a `phase_history` entry
+ * (`workflow_runs.phase_history[]`), written through the engine's
+ * `PhaseReporter.persistPhase(phase, summary)` seam. That makes it the ONE
+ * generic vehicle across every phase type: handler phases (`post-review`,
+ * `fanout`), context phases, dedup skips, loop iterations and the terminal /
+ * approval markers all write it, and it is served whole on
+ * `GET /admin/api/workflow-runs/:id`. Plain agent phases record none — that is
+ * expected, not a gap, and callers must render nothing rather than an empty box.
+ *
+ * Why this exists at all: a phase that SUCCEEDED but did nothing was visually
+ * identical to one that succeeded and did a lot. `post-review` alone returns
+ * `skipped: …`, `already-reviewed: …` and `posted review: 4 inline, 1 in body,
+ * event=COMMENT` — all three rendered as the same green tick with no text, so
+ * the drizzle-cube#937 run looked completely healthy while posting nothing and
+ * the only way to find out was the admin API.
+ */
+
+/**
+ * Leading tokens a phase uses when its summary is reporting that it did NOT do
+ * the work — deliberately a short closed vocabulary rather than a general
+ * "sounds like a skip" heuristic, because a false positive here would label a
+ * phase that really posted/pushed something as a no-op.
+ *
+ * The producers, so the list can be checked against them:
+ * - `skipped:` — `post-review`'s agent-declined branch.
+ * - `already…` — `resolveReviewPost`'s `already-posted:` / `already-reviewed:`,
+ *   the dispatch gate's `already-assessed:`, and the engine's
+ *   `Already completed (deduplicated)`.
+ * - `duplicate:` — `post-review` withholding a word-for-word repeat APPROVE.
+ * - `stale:` — `post-review` declining to post against a moved head.
+ */
+const NO_OP_SUMMARY_RE = /^(skipped|already[\w-]*|duplicate|stale)\b/i;
+
+/**
+ * The summary to display for a phase, or `undefined` when there is nothing to
+ * say. Blank-but-present summaries normalize to `undefined` so no caller has to
+ * decide whether `""` deserves a box.
+ */
+export function phaseSummary(entry: { summary?: string } | undefined): string | undefined {
+  const text = entry?.summary?.trim();
+  return text ? text : undefined;
+}
+
+/**
+ * Does this summary say the phase declined to do its work? Display-only — it
+ * tints and badges the summary and NEVER changes a phase's status, so a miss
+ * costs a shade of grey rather than a wrong verdict. The full text is always
+ * rendered beside it.
+ */
+export function isNoOpSummary(summary: string): boolean {
+  return NO_OP_SUMMARY_RE.test(summary);
+}
+
+/**
+ * Shorten a summary to fit a pipeline node (110px wide — one clipped line is
+ * all that fits without bloating the graph). The untruncated text still reaches
+ * the user through the node's `title` and, in full, the phase detail panel.
+ */
+export function truncateSummary(summary: string, max = 40): string {
+  const oneLine = summary.replace(/\s+/g, " ").trim();
+  return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
+}

--- a/apps/server/skills/pr-review/SKILL.md
+++ b/apps/server/skills/pr-review/SKILL.md
@@ -81,8 +81,13 @@ listing dumps a large payload for nothing.
 **Stop conditions** (check before reviewing):
 - PR authored by `last-light[bot]` → skip. Never self-review.
 - `merged === true` → stop. This skill reviews open PRs only.
-- A `last-light[bot]` review already exists on the **current head SHA** → stop;
-  don't post a duplicate. (A re-review is fine once new commits land.)
+A prior `last-light[bot]` review at the current head SHA is **not** a stop
+condition. Whether an already-reviewed head deserves another look was decided
+before you were dispatched, weighing the prior review against the trigger mode,
+the changed paths, and whether a human asked directly — an explicit request
+overrides de-duplication. If you are running, that question has already been
+answered yes; re-deciding it here can only overturn it. Posting is idempotent
+per head SHA regardless, so a genuine duplicate costs nothing.
 
 ### 2. Read the prior discussion
 

--- a/apps/server/spec/05-router.md
+++ b/apps/server/spec/05-router.md
@@ -855,7 +855,16 @@ Two consequences worth stating outright:
   becomes a decision. The **one** thing it does not override is the run
   lock, which is checked above it: the lock is not policy but a physical
   constraint (one workspace, one branch, one agent). The requester is told
-  so, and the sweep is the re-pickup.
+  so, and the sweep is the re-pickup. The gate is **not the last reader**:
+  the flag is projected onto the run context (`context.explicitRequest`, set
+  at the `dispatchWorkflow` choke point beside `context.prState`) because
+  `post-review` asks the same head-SHA question again once the review is
+  written, and without it that step silently overturned the dispatch — eight
+  minutes of pipeline, a `succeeded` run and no review. See
+  `resolveReviewPost` in [Workflow engine](/spec/06-workflow-engine). Note
+  what is deliberately not carried: the `review.requestLabel`. A label is a
+  standing state, not a discrete act, so it would authorise a fresh review of
+  an unchanged head on every push and every sweep until somebody removed it.
 - **The sweep is exempt from the `pending` deferral.** `defer` on
   `checks-pending` applies on every route *except* `route === "sweep"`. A
   check run that never CONCLUDES — a fork PR's `workflow_run` awaiting

--- a/apps/server/spec/06-workflow-engine.md
+++ b/apps/server/spec/06-workflow-engine.md
@@ -257,7 +257,17 @@ extend when a deployment needs a step the engine should not know about.
   serves no App-token or diff endpoint). A genuine failure — missing findings
   after a real review, or a GitHub error surviving the body-only retry — **fails
   the phase**; a legitimate `skip` succeeds without posting. Idempotent on
-  resume (no-op when a bot review already exists on the head SHA). This replaced
+  resume, and the idempotency is narrower than it reads: a handler phase writes
+  no `executions` row, so `shouldRunPhase` never skips it and every resume or
+  retry re-executes it. What it must not re-post is the review **this run**
+  posted, which is not the same fact as "a review exists on the head SHA" — a
+  maintainer's explicit `@bot review` on a head we reviewed yesterday is a
+  request for exactly that. `resolveReviewPost` (`src/engine/pr-decisions.ts`,
+  the same module the dispatch gate asks) tells them apart on the review the
+  **dispatch snapshot** saw: still the same one ⇒ prior, and an explicit request
+  overrides it; appeared since ⇒ ours, and nothing overrides that. The two used
+  to be one guard, so an explicit re-review ran the whole pipeline, reported
+  `succeeded` and posted nothing. This replaced
   the earlier in-sandbox `type: script` poster, which depended on the AI
   hand-writing `pr_number`/`base_ref`/`head_sha` into the JSON and silently
   `exit 0`'d on any mismatch.

--- a/apps/server/src/engine/dispatcher.ts
+++ b/apps/server/src/engine/dispatcher.ts
@@ -348,6 +348,18 @@ export async function dispatch(
       if (disposition.forkPr) {
         await noticeForkPr(handler, prState, deps);
       }
+      // We opened this PR, so GitHub will not accept a review event on it. The
+      // flag is set only when a human asked directly (see
+      // `Decision.selfAuthoredPr`), so this replies to the ask and stays silent
+      // on the webhook and cron routes that re-examine the same PR forever.
+      // `envelope.reply` rather than a `notice…` recorder for exactly that
+      // reason: one ask, one answer, nothing to de-duplicate.
+      if (disposition.selfAuthoredPr) {
+        await envelope.reply(
+          `I can't review this one — I opened it, and GitHub won't accept an approval or a ` +
+            `change request on your own pull request. Worth a human pair of eyes instead.`,
+        );
+      }
       return { kind: "skipped", reason: `${handler}: ${disposition.reason}` };
     }
   }

--- a/apps/server/src/engine/dispatcher.ts
+++ b/apps/server/src/engine/dispatcher.ts
@@ -252,6 +252,13 @@ export async function dispatch(
     // both override mode, draft and dedup exactly as `@bot review` does. The
     // router has already dropped requests naming somebody else.
     envelope.type === "pr.review_requested";
+  // Carried down to `dispatchWorkflow`, which projects it onto the RUN CONTEXT
+  // — the same way `_prState` rides down beside it. The gate below is not the
+  // last step that has to know a human asked: `post-review` re-decides "we
+  // already reviewed this head" once the review is written, and with no way to
+  // see the request it silently overturned the dispatch this flag authorised
+  // (`resolveReviewPost`).
+  context._explicitRequest = explicitRequest;
   // Which route this dispatch arrived on, for `resolveReviewTrigger`. Only
   // `checks-settled` satisfies `after-checks`; `attention` is what defers.
   const reviewRoute: ReviewTriggerOptions["route"] =

--- a/apps/server/src/engine/pr-decisions.ts
+++ b/apps/server/src/engine/pr-decisions.ts
@@ -913,6 +913,11 @@ export function resolveReviewTrigger(
     return { decision: "skip", reason: "draft: review.skipDraft is on", inputs };
   }
 
+  // Per-head DEDUP, and only that. Below the explicit-request branch, so an
+  // `@bot review` overrides it — and `post-review` must reach the same answer
+  // once the review is written, which is what {@link resolveReviewPost} is for.
+  // The two used to disagree, and the run that lost eight minutes to the
+  // disagreement is named there.
   if (state.botReviewAtHead) {
     return {
       decision: "skip",
@@ -1048,6 +1053,132 @@ export function resolveReviewTrigger(
   return {
     decision: "dispatch",
     reason: `${cfg.trigger}: ${route} route, checks ${state.checksState}`,
+    inputs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveReviewPost — the head-SHA question, asked the second time
+// ---------------------------------------------------------------------------
+
+/** Publish the review this run produced, or say nothing? */
+export type ReviewPostDecision = "post" | "skip";
+
+/**
+ * One of OUR reviews standing on the head SHA — as thin as
+ * {@link resolveReviewPost} needs it to be, and the shape
+ * {@link PrState.botReviewAtHead} persists.
+ */
+export interface HeadReview {
+  state: string;
+  /** See {@link PrState.botReviewAtHead} — an identity, not a date. */
+  submittedAt?: string | null;
+}
+
+/**
+ * Is this the SAME review, or a second one on the same commit?
+ *
+ * `submittedAt` refutes identity; it cannot establish it. Two of our reviews on
+ * one commit are minutes apart, so two DIFFERENT stamps prove "not the same
+ * one" — while a pair of nulls proves nothing, and a snapshot persisted before
+ * that field existed (a run dispatched by the previous build and resumed after
+ * the deploy) has exactly that shape.
+ *
+ * So: different ⇒ different, anything else ⇒ the same. The cost of that
+ * direction being wrong is one duplicate review, on a re-entry whose timestamps
+ * GitHub declined to populate; the cost of the other direction is the silence
+ * {@link resolveReviewPost} exists to end.
+ */
+function sameReview(a: HeadReview, b: HeadReview): boolean {
+  const at = a.submittedAt ?? null;
+  const bt = b.submittedAt ?? null;
+  if (at !== null && bt !== null) return at === bt;
+  return true;
+}
+
+/**
+ * "We have already reviewed this head SHA" — asked the SECOND time, after the
+ * run happened and the review is written.
+ *
+ * One fact, two questions, and conflating them is the bug this exists to stop.
+ * {@link resolveReviewTrigger} asks *may we spend a run*, where a prior review
+ * is DEDUP and an explicit request overrides it. This asks *may we publish the
+ * review we have already paid for*, where the same prior review is not dedup at
+ * all: `post-review` re-executes on every resume and every retry — it is a
+ * handler phase, so it writes no `executions` row and `shouldRunPhase` never
+ * skips it — and without a guard a boot-time resume posts a second copy of what
+ * the first pass already published.
+ *
+ * The two are distinguishable, and the discriminator costs nothing: the review
+ * the DISPATCH SNAPSHOT saw. One that is still the review
+ * `resolveReviewTrigger` was asked to override is a PRIOR review — post over
+ * it, because a maintainer asked for exactly that. One that appeared since is
+ * OURS, posted minutes ago by this very run — never post over that, whoever
+ * asked. Read off GitHub rather than off a marker we write on the way past, so
+ * it still holds when the run died between the POST and its own bookkeeping,
+ * which is precisely when a resume happens.
+ *
+ * cliftonc/drizzle-cube#937 is the case: an `@last-light review` on a head we
+ * had already reviewed surveyed, adjudicated and reconciled for eight minutes,
+ * reported `succeeded`, and posted nothing — the gate had correctly decided
+ * `requested: an explicit review request overrides mode, draft and dedup`, and
+ * this step then re-decided it in the other direction.
+ *
+ * `explicitRequest` here is the SAME value the gate was given: a discrete human
+ * act (an `@bot review` comment, a review request by name, `lastlight review`).
+ * Note what it deliberately is NOT — the `review.requestLabel`. A label is a
+ * standing state rather than an act: it is still there on the next push and the
+ * next 30-minute sweep, each of which the trigger gate dispatches, so honouring
+ * it here would post a fresh review of an unchanged head every half hour until
+ * somebody took the label off. The same distinction {@link
+ * Decision.selfAuthoredPr} draws for its one-comment-per-ask notice.
+ */
+export function resolveReviewPost(opts: {
+  /** Our review on the head this run is posting against, read just now. */
+  atHead: HeadReview | null;
+  /** The one the dispatch snapshot carried — {@link PrState.botReviewAtHead}. */
+  atDispatch: HeadReview | null;
+  /** A human asked for THIS run, by name. See {@link ReviewTriggerOptions}. */
+  explicitRequest?: boolean;
+}): Decision<ReviewPostDecision> {
+  const inputs = {
+    atHead: opts.atHead?.state ?? null,
+    atHeadSubmittedAt: opts.atHead?.submittedAt ?? null,
+    atDispatch: opts.atDispatch?.state ?? null,
+    atDispatchSubmittedAt: opts.atDispatch?.submittedAt ?? null,
+    explicitRequest: !!opts.explicitRequest,
+  };
+
+  if (!opts.atHead) {
+    return {
+      decision: "post",
+      reason: "unreviewed-head: nothing of ours stands on this commit",
+      inputs,
+    };
+  }
+
+  // OURS, from this run: it was not there when we were dispatched. This is the
+  // re-entry guard, and it binds however loudly the human asked — a second copy
+  // of the review they are already reading answers nobody.
+  if (!opts.atDispatch || !sameReview(opts.atHead, opts.atDispatch)) {
+    return {
+      decision: "skip",
+      reason: `already-posted: the ${opts.atHead.state} on this head was not there at dispatch, so this run posted it`,
+      inputs,
+    };
+  }
+
+  if (!opts.explicitRequest) {
+    return {
+      decision: "skip",
+      reason: `already-reviewed: we reviewed this head before the run started (${opts.atHead.state})`,
+      inputs,
+    };
+  }
+
+  return {
+    decision: "post",
+    reason: `requested: an explicit review request overrides the ${opts.atHead.state} already on this head`,
     inputs,
   };
 }

--- a/apps/server/src/engine/pr-decisions.ts
+++ b/apps/server/src/engine/pr-decisions.ts
@@ -164,6 +164,21 @@ export interface Decision<T> {
    * this.
    */
   forkPr?: true;
+  /**
+   * Set ONLY on the review skip taken because WE opened this pull request, and
+   * ONLY when a human asked for the review directly.
+   *
+   * Both halves matter. Keyed on the deciding branch rather than on
+   * `prState.authorIsOurs` for the reason {@link forkPr}'s header records
+   * (#256): the flag must explain the decision that was taken, not every skip a
+   * bot-authored PR happens to take. And gated on the explicit request because
+   * a PR we opened is re-examined on every push, every check and every review
+   * cron — a notice on those would be a comment per event, forever, on a PR
+   * nobody asked about. An explicit `@bot review` is a discrete human act, so
+   * one comment per ask needs no de-duplication record at all; that is why this
+   * carries no `…AtSha` guard where {@link forkPr} needs one.
+   */
+  selfAuthoredPr?: true;
 }
 
 // ---------------------------------------------------------------------------
@@ -842,6 +857,29 @@ export function resolveReviewTrigger(
   const blind = readDegradedDrop<ReviewTriggerDecision>("skip", state, inputs);
   if (blind) return blind;
 
+  // A PR WE opened. GitHub refuses `APPROVE` and `REQUEST_CHANGES` on your own
+  // pull request (422), and `resolveEvent` produces one or the other for every
+  // review — `APPROVE` on a clean findings set, the agent's explicit event
+  // otherwise — so the posting step cannot succeed in either direction. Left to
+  // run, the pipeline surveys, adjudicates and reconciles for ~10 minutes and
+  // then dies at `post-review`, which is the whole cost of the review for none
+  // of the result.
+  //
+  // ABOVE the run lock and the trigger modes deliberately: this is not policy
+  // about when a review is wanted, it is a fact about what GitHub will accept,
+  // and it does not become false by waiting. Below `readDegradedDrop` only
+  // because a PR we could not read has no trustworthy author.
+  if (state.authorIsOurs) {
+    return {
+      decision: "skip",
+      reason: `self-authored: we opened this PR (${state.authorLogin}), and GitHub refuses a review event on your own pull request`,
+      inputs,
+      // The notice is owed to a human who asked, and to nobody else — see
+      // `Decision.selfAuthoredPr`.
+      ...(opts.explicitRequest ? { selfAuthoredPr: true as const } : {}),
+    };
+  }
+
   // The PR-scoped run lock, before anything else — see `runLockDrop`. Above the
   // explicit-request branch on purpose: the lock is not policy but a physical
   // constraint (one workspace, one branch, one agent), so it is the one thing an
@@ -1223,6 +1261,10 @@ export function resolveDispatchDisposition(
       // the same reason and one more — it is what stops the caller posting a
       // placeholder check against a head SHA we could not read.
       ...(review.runInFlight ? { runInFlight: review.runInFlight } : {}),
+      // Carried through the collapse for the same reason as the rest: the
+      // caller keys on the typed field, and `decision: "skip"` alone cannot say
+      // which skip it was.
+      ...(review.selfAuthoredPr ? { selfAuthoredPr: true as const } : {}),
       ...(review.readDegraded ? { readDegraded: true as const } : {}),
       // Same rule again: the check projection needs the finer verdict, and the
       // collapse to run/skip is exactly what would lose it.

--- a/apps/server/src/engine/pr-state.ts
+++ b/apps/server/src/engine/pr-state.ts
@@ -212,8 +212,13 @@ export interface PrState {
   /**
    * The bot's own most recent review AT THE CURRENT HEAD SHA, or null. A push
    * invalidates it naturally (GitHub records the review's `commit_id`).
+   *
+   * `submittedAt` is carried as an IDENTITY rather than a date — nothing orders
+   * it. It is the only field distinguishing two of our reviews on ONE commit,
+   * which is what lets `resolveReviewPost` tell the review this run was sent to
+   * override from the review this run has just posted.
    */
-  botReviewAtHead: { state: string } | null;
+  botReviewAtHead: { state: string; submittedAt: string | null } | null;
   /**
    * The bot's most recent posted review at ANY head SHA, with the SHA it was
    * submitted against — the baseline the generated-only re-review gate diffs
@@ -666,7 +671,9 @@ export async function resolvePrState(
         state.settledCheckCount = summary.settledCount;
       }
       state.baseChecksState = baseState;
-      state.botReviewAtHead = review.atHead ? { state: review.atHead.state } : null;
+      state.botReviewAtHead = review.atHead
+        ? { state: review.atHead.state, submittedAt: review.atHead.submittedAt }
+        : null;
       state.lastBotReview = review.latest ? { state: review.latest.state, sha: review.latest.sha } : null;
       state.headAuthor = author;
       state.headIsOurs = !!deps.botLogin && author === deps.botLogin;

--- a/apps/server/src/engine/pr-state.ts
+++ b/apps/server/src/engine/pr-state.ts
@@ -153,6 +153,24 @@ export interface PrState {
    * own commit on top of an escalation does not count as intervention).
    */
   headIsOurs: boolean;
+  /**
+   * `authorLogin === botLogin` — did WE OPEN this pull request?
+   *
+   * A DIFFERENT question from {@link headIsOurs}, and the difference is
+   * load-bearing. `headIsOurs` asks who pushed the head COMMIT, so it is true
+   * whenever a fix run landed on someone else's PR — using it here would
+   * suppress reviews of human PRs the agent had merely touched. GitHub's rule
+   * is about the pull request's AUTHOR: it refuses `APPROVE` and
+   * `REQUEST_CHANGES` on a PR you opened (422), which is what made a review of
+   * our own build output run the whole pipeline and then fail at the last step
+   * with "Can not request changes on your own pull request".
+   *
+   * Derived here for the same reason `headIsOurs` is — so the decision
+   * functions stay pure over the snapshot and never need the bot identity.
+   */
+  authorIsOurs: boolean;
+  /** The PR author's GitHub login — `<botName>[bot]` when we opened it. */
+  authorLogin: string;
   /** The PR's head branch — what a fix run clones and pushes to. */
   headRef: string;
   /**
@@ -543,6 +561,8 @@ export async function resolvePrState(
     headSha: "",
     headAuthor: "",
     headIsOurs: false,
+    authorIsOurs: false,
+    authorLogin: "",
     headRef: "",
     baseRef: "",
     isDraft: false,
@@ -585,6 +605,8 @@ export async function resolvePrState(
       state.headRef = pr.head?.ref ?? "";
       state.baseRef = pr.base?.ref ?? "";
       state.isDraft = !!pr.draft;
+      state.authorLogin = pr.user?.login ?? "";
+      state.authorIsOurs = !!deps.botLogin && state.authorLogin === deps.botLogin;
       state.title = pr.title ?? "";
       state.body = pr.body ?? "";
       state.labels = (pr.labels ?? [])

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -497,6 +497,33 @@ async function main() {
         ? (context._prState as PrState)
         : null;
     let prState: PrState | null = inheritedPrState;
+
+    // DID A HUMAN ASK FOR THIS RUN, BY NAME? Resolved once, here, for the same
+    // reason the snapshot above is: every route funnels through this function,
+    // and the two that can answer `true` answer it differently.
+    //
+    // It is NOT part of `PrState` and must not become one. The snapshot is what
+    // is true of the pull request — re-resolvable from GitHub, identical for
+    // every workflow that looks at the PR this minute. This is a property of
+    // one DISPATCH: the same PR, at the same SHA, is explicitly requested on
+    // the comment route and not on the sweep that follows it 30 minutes later.
+    // Putting it on the snapshot would make `renderContext` — a pure function
+    // over `PrState` — vary by how the run was triggered, and would let a
+    // persisted snapshot claim a request that belonged to a different run.
+    //
+    // So it rides the run CONTEXT, projected below beside `prState`, which is
+    // the record of what this dispatch decided rather than of what the PR is.
+    const explicitRequest =
+      // The event/comment route decided already (`dispatcher.ts`) — a
+      // `@bot review`, a Slack ask, a review requested by name.
+      context._explicitRequest === true ||
+      // A direct `/api/run` (the CLI's `lastlight review`, the dashboard) is an
+      // operator asking for a REVIEW by hand, and overrides mode, draft and
+      // dedup exactly as `@bot review` does. Deliberately narrowed to
+      // `pr-review`: the fix family's skips are budgets and live facts rather
+      // than policy, and the human override for those already exists on the
+      // comment path.
+      (workflowName === REVIEW_WORKFLOW && context._triggerType === "api");
     if (
       !prState &&
       prScopedWorkflows().has(workflowName) &&
@@ -532,13 +559,7 @@ async function main() {
           // that reaches an `after-checks` PR no further `check_suite` will ever
           // fire for.
           route: reviewRouteFromContext(context),
-          // A direct `/api/run` (the CLI, the dashboard) is an operator asking
-          // for a REVIEW by hand, and overrides mode, draft and dedup exactly as
-          // `@bot review` does. Deliberately narrowed to `pr-review`: the fix
-          // family's skips are budgets and live facts rather than policy, and
-          // the human override for those already exists on the comment path.
-          explicitRequest:
-            workflowName === REVIEW_WORKFLOW && context._triggerType === "api",
+          explicitRequest,
           logPrefix: "[dispatch]",
         },
         { db, github, botLogin: config.botLogin, botMention: `@${config.botName}` },
@@ -636,6 +657,9 @@ async function main() {
       _triggerType,
       _prState: _inheritedPrState,
       _reviewRoute: _ignoredReviewRoute,
+      // Plucked so the wire name never reaches the run context: it is projected
+      // below, once, under the name every reader uses.
+      _explicitRequest: _ignoredExplicitRequest,
       repo: _r,
       issueNumber,
       prNumber,
@@ -730,6 +754,12 @@ async function main() {
         ),
       );
       extra.prState = prState;
+      // Beside the snapshot, and deliberately not inside it (see the resolution
+      // above). Scoped to PR-scoped runs because they are the only ones with a
+      // reader — `post-review`, whose `resolveReviewPost` needs to tell a
+      // maintainer's deliberate re-review from its own re-entry — and because a
+      // `false` on every issue-triage run is noise nobody can act on.
+      extra.explicitRequest = explicitRequest;
     }
 
     // For PR-scoped read workflows, resolve the PR head ref and ask the

--- a/apps/server/src/workflows/handlers/post-review.ts
+++ b/apps/server/src/workflows/handlers/post-review.ts
@@ -16,7 +16,7 @@ import {
 } from "../../engine/github/review-poster.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import { defaultReviewConfig } from "lastlight-shared/config-types";
-import { hasMaterialChange } from "../../engine/pr-decisions.js";
+import { hasMaterialChange, resolveReviewPost, type HeadReview } from "../../engine/pr-decisions.js";
 import { logger } from "../../logging/logger.js";
 
 const log = logger("post-review");
@@ -192,6 +192,28 @@ export function readCleanDischarges(dir: string): ReadonlySet<string> | undefine
 }
 
 /**
+ * The review that stood on the head SHA when this run was DISPATCHED, off the
+ * persisted `context.prState` — `resolveReviewPost`'s discriminator between a
+ * prior review and this run's own.
+ *
+ * Read defensively rather than through the `PrState` type: the context is JSON
+ * that outlives the build that wrote it, and a run dispatched before
+ * `submittedAt` was recorded has the same shape minus that field. `null` — no
+ * snapshot at all, which is every eval-harness run — degrades to "treat
+ * anything at the head as ours", i.e. exactly the unconditional guard this
+ * replaced.
+ */
+function dispatchReview(ctx: TemplateContext): HeadReview | null {
+  const state = (ctx as Record<string, unknown>).prState;
+  if (!state || typeof state !== "object") return null;
+  const review = (state as Record<string, unknown>).botReviewAtHead;
+  if (!review || typeof review !== "object") return null;
+  const { state: reviewState, submittedAt } = review as Record<string, unknown>;
+  if (typeof reviewState !== "string") return null;
+  return { state: reviewState, submittedAt: typeof submittedAt === "string" ? submittedAt : null };
+}
+
+/**
  * Parse one context-projected boundary number back off its string form.
  * The projection is `specContext`'s (`pr-decisions.ts`); garbage degrades to
  * the caller's default — the direction `config.ts` coerces the same keys.
@@ -237,8 +259,10 @@ function parseThresholds(v: unknown): Record<string, number> {
  *
  * A genuine failure — missing findings after a real review, or a GitHub error
  * that survives the body-only retry — FAILS the phase visibly; only a
- * legitimate `skip` succeeds without posting. Idempotent on resume: it no-ops
- * when a bot review already exists on the current head SHA.
+ * legitimate `skip` succeeds without posting. Idempotent on resume: a review
+ * this run already posted on the head SHA is never posted twice — see
+ * {@link resolveReviewPost}, which is also what keeps that idempotency from
+ * swallowing a maintainer's deliberate re-review of an unchanged head.
  */
 export class GitHubPostReviewHandler implements PhaseTypeHandler {
   constructor(
@@ -290,6 +314,13 @@ export class GitHubPostReviewHandler implements PhaseTypeHandler {
       (typeof ctx.prNumber === "number" ? ctx.prNumber : undefined) ??
       (typeof ctx.issueNumber === "number" && ctx.issueNumber > 0 ? ctx.issueNumber : undefined);
     if (!prNumber) return fail("post-review: no PR number in run context; cannot post review");
+
+    // A human asked for THIS run by name — projected onto the run context at
+    // the dispatch choke point (`src/index.ts`), so every route carries it
+    // identically and a resume of this run still carries the request that
+    // started it. Absent (an eval-harness run, a context written before the
+    // field existed) reads as `false`, which is the pre-existing behaviour.
+    const explicitRequest = ctx.explicitRequest === true;
 
     // Read the agent's findings from the host checkout. The review phase writes
     // it at `.lastlight/pr-review/findings.json` relative to the repo cwd; the
@@ -355,10 +386,26 @@ export class GitHubPostReviewHandler implements PhaseTypeHandler {
         .getBotReviewHistory(owner, repo, prNumber, headSha, getRuntimeConfig()?.botLogin)
         .catch(() => ({ atHead: null, latest: null }));
 
-      // Idempotency: skip if a bot review already exists on this head SHA
-      // (guards resume / re-entry from double-posting).
-      if (history.atHead) {
-        return succeed(`already reviewed head ${headSha.slice(0, 7)} (${history.atHead.state})`);
+      // "We already reviewed this head" — decided ONCE, by the same module the
+      // dispatch gate asks. Two things are being told apart here and they used
+      // to be one: a resume/re-entry finding the review this run itself posted
+      // (never post again) versus a maintainer's deliberate `@bot review` on a
+      // head we reviewed yesterday (post — that is the whole ask). The
+      // discriminator is the dispatch snapshot, which is why `atDispatch` comes
+      // off the persisted run context rather than a fresh read.
+      const post = resolveReviewPost({
+        atHead: history.atHead,
+        atDispatch: dispatchReview(ctx),
+        explicitRequest,
+      });
+      if (post.decision === "skip") {
+        log.info("Not posting a review", {
+          repo: `${owner}/${repo}`,
+          prNumber,
+          reason: post.reason,
+          inputs: post.inputs,
+        });
+        return succeed(`${post.reason} — ${headSha.slice(0, 7)}`);
       }
 
       const stale = await this.staleAgainstCurrentHead(github, owner, repo, prNumber, headSha);
@@ -426,7 +473,7 @@ export class GitHubPostReviewHandler implements PhaseTypeHandler {
       this.recordDisposition(hostRepoDir, boundary, review.tiered);
     }
 
-    const repeat = this.repeatOfLastReview(history.latest, review);
+    const repeat = this.repeatOfLastReview(history.latest, review, explicitRequest);
     if (repeat) {
       log.info("Skipping a duplicate review post", { repo: `${owner}/${repo}`, prNumber, summary: repeat });
       return succeed(repeat);
@@ -502,11 +549,22 @@ export class GitHubPostReviewHandler implements PhaseTypeHandler {
    * suppressing a duplicate APPROVE changes nothing; suppressing a duplicate
    * CHANGES_REQUESTED would turn a `failure` check into a passing one and open
    * a merge gate the review deliberately closed.
+   *
+   * Off for an EXPLICIT request, and that is not a courtesy — it is the same
+   * rule `resolveReviewPost` applies one guard above. The shape this catches is
+   * an unprompted re-review of a push that changed nothing a reviewer can read;
+   * a maintainer who typed `@bot review` on an unchanged head is asking for
+   * precisely the review this would suppress, and would get eight minutes of
+   * pipeline and silence. Suppressing a duplicate APPROVE is safe (the check
+   * concludes `neutral`, which passes) — but so is posting one, and only one of
+   * the two answers the question.
    */
   private repeatOfLastReview(
     last: { state: string; sha: string; body: string | null } | null,
     review: { body: string; event: string; comments: unknown[] },
+    explicitRequest: boolean,
   ): string | null {
+    if (explicitRequest) return null;
     if (review.event !== "APPROVE" || review.comments.length > 0) return null;
     if (!last || last.state !== "APPROVED" || last.body !== review.body) return null;
     return `duplicate: this APPROVE is word-for-word the one we posted on ${last.sha.slice(0, 7)}`;

--- a/apps/server/tests/engine/dispatcher.test.ts
+++ b/apps/server/tests/engine/dispatcher.test.ts
@@ -1596,6 +1596,46 @@ describe('dispatch — the pr-review trigger gate (Phase 7)', () => {
     expect(await dispatch(envelope, deps)).toEqual({ kind: 'dispatched', workflow: 'pr-review' });
   });
 
+  // THE GATE IS NOT THE LAST READER. `post-review` re-decides "we already
+  // reviewed this head" once the review is written, and with no way to see the
+  // request it overturned the very dispatch this flag authorised — eight
+  // minutes of pipeline, `succeeded`, and nothing posted
+  // (cliftonc/drizzle-cube#937). So the flag has to leave this function on the
+  // context, which `dispatchWorkflow` projects onto the run.
+  it('hands the explicit request down on the context, for the step that posts', async () => {
+    withReview({ trigger: 'on-request' });
+    const dispatchWorkflow = vi.fn().mockResolvedValue({ success: true });
+    const github = prGithubStub({ botReview: { state: 'APPROVED' } });
+    const envelope = makeEnvelope({
+      type: 'comment.created',
+      repo: 'cliftonc/lastlight',
+      prNumber: 8,
+      body: '@last-light review',
+    });
+    const deps = makeDeps(
+      {
+        action: 'handler',
+        handler: 'pr-review',
+        context: { _routeKey: 'github.pr_review', repo: 'cliftonc/lastlight', prNumber: 8 },
+      },
+      { db: mockDb() as any, github, dispatchWorkflow },
+    );
+
+    await dispatch(envelope, deps);
+
+    expect(dispatchWorkflow.mock.calls[0][1]._explicitRequest).toBe(true);
+  });
+
+  it('marks an automatic dispatch as one nobody asked for', async () => {
+    withReview({ trigger: 'eager' });
+    const dispatchWorkflow = vi.fn().mockResolvedValue({ success: true });
+    const { envelope, deps } = reviewDeps(prGithubStub({ checksState: 'pending' }), dispatchWorkflow);
+
+    await dispatch(envelope, deps);
+
+    expect(dispatchWorkflow.mock.calls[0][1]._explicitRequest).toBe(false);
+  });
+
   it('does not post a placeholder on the 30-minute sweep route — that would be one check per tick', async () => {
     withReview({ trigger: 'on-request', postsCheck: true });
     const dispatchWorkflow = vi.fn();

--- a/apps/server/tests/engine/pr-decisions.test.ts
+++ b/apps/server/tests/engine/pr-decisions.test.ts
@@ -622,6 +622,27 @@ describe("resolveReviewTrigger", () => {
       /^requested:/,
     ],
     [
+      // The one thing that outranks the explicit request above, because it is
+      // not a policy question: GitHub 422s a review event on a PR we opened,
+      // so "always dispatches" would dispatch a run that cannot post.
+      "a PR we opened is skipped even when a human asks",
+      { authorIsOurs: true, authorLogin: "last-light[bot]" },
+      { trigger: "eager" },
+      { explicitRequest: true },
+      "skip",
+      /^self-authored:/,
+    ],
+    [
+      // The guard must key on who OPENED the PR, never on who pushed the head
+      // commit — our fix landing on a human's PR must not suppress its review.
+      "our commit on someone else's PR still reviews",
+      { authorIsOurs: false, authorLogin: "cliftonc", headIsOurs: true, headAuthor: "last-light[bot]" },
+      { trigger: "eager" },
+      { explicitRequest: true },
+      "dispatch",
+      /^requested:/,
+    ],
+    [
       "the request label is an explicit ask too",
       { labels: ["needs-review"] },
       { trigger: "on-request", requestLabel: "needs-review" },

--- a/apps/server/tests/engine/pr-decisions.test.ts
+++ b/apps/server/tests/engine/pr-decisions.test.ts
@@ -21,6 +21,7 @@ import {
   resolveReviewTrigger,
   resolveDispatchDisposition,
   reviewCheckPlacement,
+  resolveReviewPost,
   renderContext,
   isGeneratedPath,
   allPathsGenerated,
@@ -827,6 +828,81 @@ describe("resolveReviewTrigger", () => {
     const d = resolveReviewTrigger(state(over), { ...review, ...cfgOver }, opts);
     expect(d.decision).toBe(expected);
     expect(d.reason).toMatch(reason);
+  });
+});
+
+/**
+ * `resolveReviewPost` — the head-SHA question asked the second time, after the
+ * run happened and the review is written.
+ *
+ * The whole table is one distinction: a review that stood on the head BEFORE
+ * this run was dispatched is a prior review (an explicit request overrides it,
+ * which is what the gate already decided), and one that appeared since is this
+ * run's own (never post over it, however the run was triggered).
+ *
+ * cliftonc/drizzle-cube#937 is the first column and the second row: the gate
+ * said `requested: an explicit review request overrides mode, draft and dedup`,
+ * and this step re-decided it in the other direction, for eight minutes and no
+ * review.
+ */
+describe("resolveReviewPost", () => {
+  const prior = { state: "APPROVED", submittedAt: "2026-08-05T20:14:46Z" };
+  /** The one this run posted before it died and was resumed. */
+  const ours = { state: "APPROVED", submittedAt: "2026-08-05T20:41:02Z" };
+
+  const cases: [
+    string,
+    Parameters<typeof resolveReviewPost>[0],
+    "post" | "skip",
+    RegExp,
+  ][] = [
+    [
+      "a head with nothing of ours on it posts, asked or not",
+      { atHead: null, atDispatch: null },
+      "post",
+      /^unreviewed-head:/,
+    ],
+    [
+      "the prior review the gate overrode does not stop the review it authorised",
+      { atHead: prior, atDispatch: prior, explicitRequest: true },
+      "post",
+      /^requested:/,
+    ],
+    [
+      "the same prior review skips when nobody asked — the dedup case, unchanged",
+      { atHead: prior, atDispatch: prior },
+      "skip",
+      /^already-reviewed:/,
+    ],
+    [
+      "a review that was not there at dispatch is OURS — a resume must not post twice",
+      { atHead: ours, atDispatch: null, explicitRequest: true },
+      "skip",
+      /^already-posted:/,
+    ],
+    [
+      "…including when it was posted OVER a prior review, which only the stamp tells apart",
+      { atHead: ours, atDispatch: prior, explicitRequest: true },
+      "skip",
+      /^already-posted:/,
+    ],
+    [
+      // A run dispatched by a build that recorded no `submittedAt`, resumed
+      // after the deploy that added it: unidentifiable, so it reads as the
+      // prior review. `explicitRequest` cannot be set on such a context either,
+      // so the pair is self-consistent and the answer is today's.
+      "a snapshot with no timestamp is read as the prior review, not as ours",
+      { atHead: { state: "APPROVED", submittedAt: null }, atDispatch: { state: "APPROVED" } },
+      "skip",
+      /^already-reviewed:/,
+    ],
+  ];
+
+  it.each(cases)("%s", (_name, opts, expected, reason) => {
+    const d = resolveReviewPost(opts);
+    expect(d.decision).toBe(expected);
+    expect(d.reason).toMatch(reason);
+    expect(d.inputs.explicitRequest).toBe(!!opts.explicitRequest);
   });
 });
 

--- a/apps/server/tests/workflows/post-review.test.ts
+++ b/apps/server/tests/workflows/post-review.test.ts
@@ -826,6 +826,113 @@ describe("post-review action (runPostReview)", () => {
     });
   });
   /**
+   * A review already standing on the head SHA — and the two situations that
+   * fact describes (`resolveReviewPost`).
+   *
+   * cliftonc/drizzle-cube#937: an `@last-light review` on a head we had already
+   * reviewed surveyed, adjudicated and reconciled for eight minutes, reported
+   * `succeeded`, and posted nothing. The dispatch gate had decided the request
+   * overrode dedup; this step then re-decided it the other way.
+   *
+   * Fixing that must not cost what the guard was written for. `post-review` is
+   * a handler phase with no `executions` row, so `shouldRunPhase` never skips
+   * it and every resume/retry re-executes it — the review it finds at the head
+   * is then its OWN, and posting a second copy is the failure mode. The
+   * discriminator is the dispatch snapshot, so both cases are exercised here
+   * with the same `explicitRequest: true` context.
+   */
+  describe("a review already on the head SHA", () => {
+    const AT_DISPATCH = "2026-08-05T20:14:46Z";
+    const reviewAtHead = (body: string, submittedAt: string) => ({
+      id: 7,
+      state: "APPROVED",
+      commit_id: HEAD_SHA,
+      body,
+      submitted_at: submittedAt,
+      user: { login: "last-light[bot]" },
+    });
+    /** The snapshot the dispatch gate resolved, as `index.ts` persists it. */
+    const snapshot = (botReviewAtHead: unknown) => ({ prState: { botReviewAtHead } });
+
+    it("skips the post when nobody asked — the unchanged idempotency case", async () => {
+      setPriorReviews([reviewAtHead("Reviewed already.", AT_DISPATCH)]);
+      const taskId = "widget-42-athead-auto";
+      seedFindings(taskId, "widget", { summary: "Looks good.", event: "APPROVE", findings: [] });
+      const { executor, rep } = makeExecutor(taskId, {
+        ...snapshot({ state: "APPROVED", submittedAt: AT_DISPATCH }),
+      });
+
+      const outcome = await executor.execute(NODE, {});
+
+      expect(outcome.status).toBe("succeeded");
+      expect(rep.failed).toHaveLength(0);
+      expect(reviews).toHaveLength(0);
+      expect(outcome.results[0]!.output).toMatch(/^already-reviewed:/);
+    });
+
+    it("POSTS over the prior review when a human asked for this run by name", async () => {
+      setPriorReviews([reviewAtHead("Reviewed already.", AT_DISPATCH)]);
+      const taskId = "widget-42-athead-asked";
+      seedFindings(taskId, "widget", { summary: "Had another look.", event: "APPROVE", findings: [] });
+      const { executor, rep } = makeExecutor(taskId, {
+        explicitRequest: true,
+        // The review at the head is the very one the gate decided to override.
+        ...snapshot({ state: "APPROVED", submittedAt: AT_DISPATCH }),
+      });
+
+      const outcome = await executor.execute(NODE, {});
+
+      expect(outcome.status).toBe("succeeded");
+      expect(rep.failed).toHaveLength(0);
+      expect(reviews).toHaveLength(1);
+      expect((reviews[0]!.body as { body: string }).body).toContain("Had another look.");
+    });
+
+    it("does NOT double-post on a re-entry — the review at the head is this run's own", async () => {
+      // Dispatched on a head with no review of ours; by the time post-review
+      // re-executes (a resume, a Retry) there is one, so it is ours. The
+      // explicit request must not override this: a second copy of the review
+      // they are already reading answers nobody.
+      setPriorReviews([reviewAtHead("Had another look.", "2026-08-05T20:41:02Z")]);
+      const taskId = "widget-42-athead-reentry";
+      seedFindings(taskId, "widget", { summary: "Had another look.", event: "APPROVE", findings: [] });
+      const { executor, rep } = makeExecutor(taskId, {
+        explicitRequest: true,
+        ...snapshot(null),
+      });
+
+      const outcome = await executor.execute(NODE, {});
+
+      expect(outcome.status).toBe("succeeded");
+      expect(rep.failed).toHaveLength(0);
+      expect(reviews).toHaveLength(0);
+      expect(outcome.results[0]!.output).toMatch(/^already-posted:/);
+    });
+
+    it("does NOT double-post the re-review it already posted OVER a prior one", async () => {
+      // The hard half of the re-entry case: an explicit re-review that posted
+      // and then died leaves TWO of our reviews on the head. Only the timestamp
+      // tells the one we were sent to override from the one we posted.
+      setPriorReviews([
+        reviewAtHead("Reviewed already.", AT_DISPATCH),
+        reviewAtHead("Had another look.", "2026-08-05T20:41:02Z"),
+      ]);
+      const taskId = "widget-42-athead-reentry-twice";
+      seedFindings(taskId, "widget", { summary: "Had another look.", event: "APPROVE", findings: [] });
+      const { executor } = makeExecutor(taskId, {
+        explicitRequest: true,
+        ...snapshot({ state: "APPROVED", submittedAt: AT_DISPATCH }),
+      });
+
+      const outcome = await executor.execute(NODE, {});
+
+      expect(outcome.status).toBe("succeeded");
+      expect(reviews).toHaveLength(0);
+      expect(outcome.results[0]!.output).toMatch(/^already-posted:/);
+    });
+  });
+
+  /**
    * The duplicate-review guard (issue #271).
    *
    * nearform/skillspro#1641: two APPROVEs six minutes and 400 identical bytes
@@ -893,6 +1000,20 @@ describe("post-review action (runPostReview)", () => {
       const taskId = "widget-42-dupe-changes";
       seedFindings(taskId, "widget", { summary: SUMMARY, event: "REQUEST_CHANGES", findings: [] });
       const { executor } = makeExecutor(taskId);
+      expect((await executor.execute(NODE, {})).status).toBe("succeeded");
+      expect(reviews).toHaveLength(1);
+    });
+
+    // The same carve-out `resolveReviewPost` makes one guard above: the shape
+    // this rule catches is an UNPROMPTED re-review of a push that changed
+    // nothing readable. A maintainer who typed `@bot review` is asking for
+    // precisely the review it would suppress, and suppressing it hands them
+    // eight minutes of pipeline and silence.
+    it("posts a word-for-word repeat when a human asked for this run by name", async () => {
+      setPriorReviews(priorApprove("0ldsha0", SUMMARY));
+      const taskId = "widget-42-dupe-asked";
+      seedFindings(taskId, "widget", { summary: SUMMARY, event: "APPROVE", findings: [] });
+      const { executor } = makeExecutor(taskId, { explicitRequest: true });
       expect((await executor.execute(NODE, {})).status).toBe("succeeded");
       expect(reviews).toHaveLength(1);
     });

--- a/docs/plans/review-pipeline-improvements.md
+++ b/docs/plans/review-pipeline-improvements.md
@@ -1,0 +1,105 @@
+# Review pipeline — the first production run, and what it argues for
+
+Companion to [`deterministic-pr-levers.md`](deterministic-pr-levers.md), which is the design doc and the measurement journal for the review evidence pipeline. That doc's evidence is entirely from the eval harness against gold. This one is about the pipeline's **first run on a real PR in production**, what that run establishes, and the four things it exposes. Everything here is n=1 and must be read against `review-pipeline-run-variance`: recall swung 0.320 → 0.080 across three byte-identical wp3 runs. A single run cannot justify a change; it can only tell you which arm to buy.
+
+The run: `1e3b69b7-7e3f-41c8-8b32-0c840e581cfd` on the `drizby` deployment (v0.27.0, `sandbox.backend: docker`, `review.analysis.enabled: true`, `obligationContract: minimal`, `mint: all-in-diff,registrations`, surveys on `openai/gpt-5.4-mini`, `probes: false`), reviewing `cliftonc/drizzle-cube#937` — human-authored, 2627 additions / 14 deletions, 32 files, a dbt→Drizzle codegen feature.
+
+## What it establishes
+
+**The pipeline produces postable, verifiable, non-noisy findings on a real PR.** Nine findings, `event: REQUEST_CHANGES`, verdict failing on both axes; seven would have posted (five inline, two body), two tiered `internal`. All seven verified true against source at that head — exact line numbers, verbatim quoted code, no hallucinated paths. This is the first time the pipeline's output has been checked line-by-line against a repo nobody built gold for, and it survived.
+
+**It beat the review it replaced, on the same head.** The prior two-phase APPROVE claimed a violation of `src/cli/CLAUDE.md`, a file that did not exist at that ref. `adjudicate` searched for it, failed, and withdrew the concern — the pipeline caught a hallucinated citation in its own predecessor. That is the anti-speculation and verbatim-anchoring machinery (WP6) doing exactly the job it was built for, on evidence the eval harness cannot produce because gold sets do not contain the bot's own past mistakes.
+
+**Zero clean quotes reached the maintainer.** The two verification reports tiered `internal` at confidence 0.18 and 0.01. `tierFindings` (`apps/server/src/engine/github/review-poster.ts:711-755`) checks explicit-internal, then clean-discharge, then `internalFloor` (0.15) — before any per-family threshold. The 0.01 finding was below the floor; the 0.18 one never reached a threshold at all, because the earlier rules fired first. The attention boundary is working as designed at the one place its failure would be most visible.
+
+**Two Criticals were executably reproduced** — the security branch ran the generator under `tsx` and demonstrated attacker-controlled dbt metadata splicing into emitted TypeScript identifier positions. Note what that means mechanically: `probes: false`, so `prepare` and `falsify` were both skipped, and this reproduction happened **inside a survey branch**. The design separates generator from checker deliberately (`falsify` "must not see the reasoning it checks") — here the generator ran its own oracle. That is simultaneously the strongest argument yet for E4 (reproduction converted the run's two best findings) and evidence that the separation is a property of the *phase graph*, not of what a branch is able to do.
+
+One further first: this is the first pipeline run at `sandbox.backend: docker`, where `BACKEND_MAX_CONCURRENT` is 6 (`apps/server/src/workflows/handlers/fanout.ts:68-74`), so the survey fan-out actually ran wide. `deterministic-pr-levers.md` warns that eval wall-clock does not transfer to a gondolin deployment; on docker it does.
+
+**The methodological caveat, stated once and loudly**: there is no gold for `drizzle-cube#937`. Seven-of-seven verified is a precision statement with **no recall denominator**. Nothing below may be read as a recall result.
+
+## What the run exposes
+
+### 1. Obligation allocation is inverted (sharpest)
+
+`obligations.json` for a 32-file / 2627-line PR: contract **12**, enforcement **1**, security **0**, state **0**, tests **0**. Contract simultaneously hit its ceiling — `dropped[]` carrying `"over the per-family ceiling of 12 for contract"` (`packages/code-facts/src/seed.ts:809`) — *and* dropped real obligations, while three families seeded nothing at all.
+
+The budget cannot move. `FAMILY_CAPS` (`packages/code-facts/src/seed.ts:346-352`) is contract 12 / enforcement 12 / state 8 / security 8 / tests 8, and `maxObligations: 48` is their sum by construction (`seed.ts:227-232`; `apps/server/config/default.yaml:388-391` documents it as a backstop that "cannot bind on a shipped configuration"). So 35 of 48 slots went unclaimed while the one family with demand was refused. That is not a bug — the ceilings were built on 2026-08-25 precisely to stop cross-family ranking, and they measurably fixed the mechanics (byte-identical 12/12/12 on heavy cases vs the floors era's 17/15/8). But the shape they produce on a large single-feature PR is a document that is starved and capped at the same time.
+
+### 2. The best findings came from the family with no obligations
+
+Security seeded zero, took the freeform charter, self-directed a probe, and produced both reproduced Criticals. Enforcement got its single obligation — about a usage string — and returned one Minor non-finding in 36 s. On this run the deterministic seeding steered effort *away* from the defects.
+
+Do not over-read this. `deterministic-pr-levers.md` records the opposite result twice: LD3's IRIS ablation measured half-mechanism seeds as **actively harmful** (−3), and the `obligationContract: full` experiment took discharge compliance 0/33 → 33/33 while matched gold on the same cases went 4-of-5 to **zero**. The tension between reliable seeding and discovery is old, documented, and unresolved; this run is one more data point on it, from the discovery side, at n=1. It is not a refutation of seeding.
+
+Two things do follow. First, the zero-mint path is *designed* to be productive — `renderFamilyBlock` writes "not a licence to skip the family … Work the diff for this family's question directly" plus the staged diff (`packages/code-facts/src/seed-render.ts:482-497`) — and it worked. Second, there is a **confound the run cannot separate**: security is also the only branch with a bespoke skill (below). Freeform-vs-seeded and third-skill-vs-not moved together.
+
+### 3. Every family reads (nearly) the same generic skills
+
+`apps/server/workflows/pr-review.yaml:293` declares `skills: [pr-review, code-review]` at the fan-out phase. Four of the five branches override only `prompt:` and `context_file:`. **The brief for this doc was wrong on one point: `security` already overrides, at line 395, with `[pr-review, code-review, security-review]`** — committed in `ce5929ab`, the pipeline's own merge.
+
+So per-branch skills are not merely supported (`apps/server/src/workflows/CLAUDE.md:199-220`; `fanout.ts:812-813` resolves `branch.skills ?? phase.skills`, and `fanout.ts:771-774` keys the staging bundle on the branch label so `.lastlight-skills/<label>/` cannot collide) — they are already in use. The question is not whether to enable them but what should go in them.
+
+Be honest about the answer. The family prompts already carry 99–143 lines of family-specific instruction each (`apps/server/workflows/prompts/survey-*.md`), and the brief carries the family's obligations. A per-family skill that restates its prompt is pure token cost. There are exactly three things a skill can carry that a prompt cannot, and only two of them apply today:
+
+- **Subtraction.** `code-review`'s "What to check" (`apps/server/skills/code-review/SKILL.md:114-155`) is a ten-axis checklist — correctness, contracts, edge cases, security, complexity, duplication, type safety, regression risk, test coverage, fit. Every survey branch reads all ten. LD9 says specialists are separated by *question*; this hands each specialist the whole question set. That is the one clear win, and it is a subtraction, not an addition.
+- **Progressive disclosure via `references/`.** The pattern exists (`skills/pr-review/references/findings-schema.md`, `skills/security-review/references/issue-format.md`): material too long to inline, loaded on demand. A per-family question catalogue is exactly this shape — and question catalogues are the intervention that bought G1.
+- **Nothing else.** For `contract`, `enforcement` and `state`, the prompt already says what a skill would say. Writing them a skill today buys tokens and no signal.
+
+The one bespoke skill that does exist is the wrong one. `security-review`'s frontmatter describes a *cron scan* — "Files one dated summary issue with a task-list of findings … Use on a security cron" (`apps/server/skills/security-review/SKILL.md:1-6`), and its body's contract is "File **one summary issue per run**". None of that is what a survey branch does. The branch that produced this run's two best findings is reading a skill written for a different workflow, and we cannot tell whether it helped, hurt, or was ignored.
+
+One caveat that is not stylistic. `pr-review.yaml:285-289` and `fanout.ts:463-468` both pin the invariant that the shared prompt head — skills, AGENTS.md, diff summary — stays **byte-identical across branches** so six passes share one provider-side cached prefix. Per-family skills break that by construction. It is a cost claim, not a correctness one, and `security` already voids it today, so the honest move is to measure the cache-read delta rather than treat it as blocking.
+
+### 4. Severity inflation
+
+All three Criticals were `Important` in the surveys; `adjudicate` promoted them. For a local CLI parsing the user's own dbt artifacts, "a malicious manifest injects code" is codegen robustness, not a security boundary — the supplier of the input already has the capability the finding grants.
+
+The mechanism is in the rubric: `code-review` defines "**Critical** — security issues, data loss, breaking changes" (`SKILL.md:100-101`). Membership in the security *category* is sufficient. There is no trust-boundary predicate anywhere in the definition, so any input-shaped hazard is Critical by construction. Severity is not decorative the way confidence is — it feeds `rankOf` and therefore inline ordering under `maxInlineComments`, so miscalibration spends the maintainer's top slots.
+
+## Deliberate exclusions, so nobody "fixes" them
+
+**The `tests` family has no survey branch on purpose.** The reason is recorded at `apps/server/workflows/pr-review.yaml:406-416`: the family is dead at both ends — no seeder function exists in `code-facts`, and the `coverage` extractor it would read needs a report only `prepare` can produce. Measured: 0 artifacts across 50 corpus cases and all 8 gate cases, in every run ever taken. Running it paid a sixth of the fan-out to write NOT MEASURED. Reinstating it is a seeder plus that entry, and it should ride E4 or not happen. (The in-repo reason is this, not sandbox memory — worth knowing which argument is the load-bearing one if it is ever revisited.)
+
+Two harmless leftovers, confirmed: `obligations/tests.md` **is** still written on every run — `cli.ts:493` loops `SEEDABLE_FAMILIES`, which includes `tests` (`seed.ts:75`), and `renderFamilyBlock` returns a non-empty NOT MEASURED block (`seed-render.ts:472-480`), so the `if (block)` guard never suppresses it. And `apps/server/workflows/prompts/survey-tests.md` (99 lines) is referenced by nothing under `workflows/` or `src/`. Neither is read by any branch. Leave them; the `measured: false` row is what keeps the instrument reporting `notMeasured` rather than "did not convert".
+
+## Proposals
+
+**R1 — split `code-review` into a shared core plus per-axis fragments, and give each survey branch core + its own axis.** The core keeps what is genuinely shared: finding tiers, "Not findings", Calibration, and the multi-pass gate carve-out (`SKILL.md:49-72`, which already correctly tells a survey pass that the precision gate does not fire on it). The fragments are the ten "What to check" axes, redistributed to the families that own them. This is subtraction — it removes eight axes from each branch's context, not adds anything — so it is cheap, reversible, and it is what LD9 actually asks for. Risk: prefix-cache fragmentation (above), and the possibility that cross-axis reading is *why* branches find things outside their family, which would show up as an internal-union loss.
+
+**R2 — rewrite `security`'s branch skill for the job it is doing.** It is the only branch already paying the cache cost of an override, and it is paying it for a cron-scan skill. Replace it with a PR-diff-scoped security fragment (untrusted-input inventory, trust boundaries, the "who already has this capability" test from R4). Zero net token cost, and it removes the confound in Problem 2.
+
+**R3 — do not add a skill to `contract`, `enforcement`, `state` or `spec` yet.** Their prompts already carry the family question. Revisit only when there is a question catalogue too long to inline — that is what `references/` is for, and catalogues are the one prompt intervention with a recorded new-gold win (G1).
+
+**R4 — put a trust-boundary predicate in the Critical definition.** "Security issue" alone should not reach Critical; the finding must name a boundary the input crosses and a capability the supplier does not already have. Drafting is $0, but it changes what gets posted and what ranks first, so it ships behind an arm.
+
+**R5 — a smarter family ceiling. Three mechanisms; only one survives its own risk.**
+
+- *Reallocation* — sweep each family's unclaimed slots (`cap − minted`) into a pool and redistribute by rank to families at their ceiling. **Reject as stated.** It reinstates exactly the cross-family ranking of incommensurable mechanism classes that the ceilings were built to kill, and on this run it would have handed the surplus to `contract` — the family that produced nothing — while the three zero-mint families would have contributed their budget and received nothing back. It optimises in the wrong direction.
+- *Shape-sizing* — make each cap a function of the diff (contract's from `consumersOutsideDiff` breadth, security's from scanner hits and new-file count) rather than a constant. Risk: the cap becomes a function of the same signal that already ranks *within* the family, so it double-counts it; and it is unfalsifiable without a per-family conversion rate we have never measured.
+- *Global pool with per-family floors* — the pre-2026-08-25 shape. Already tried, already superseded: floors let the same family swing 17/15/8 on near-identical envelopes because its share depended on where other families' ranks fell.
+
+  **What survives is smaller and closer to the evidence: keep the caps, and first make ceiling pressure visible.** The seeder already writes per-family `dropped[]` reasons (`seed.ts:800-820`), so "family at ceiling while N families minted zero" is computable **for free** over stored envelopes — the same $0 replay that validated the floors. Ship the instrument before the mechanism. If pressure turns out to be rare, this whole problem is a one-PR artifact; if it is common, the measurement tells you which direction to size in, which no amount of reasoning from n=1 will.
+
+**R6 — treat the survey-branch probe as the E4 argument.** The run's two strongest findings came from executing code, in a phase not designed to execute anything, with the oracle disabled. E4 (turning `prepare` on) is already on the lever board; this is the first production evidence that reproduction converts. It also raises a design question worth answering before E4: if survey branches can and do run code, is the generator/checker separation still real, or only nominal?
+
+## What must be measured, and how
+
+Nothing above ships on this run. n=1, no gold, no recall denominator, and `review-pipeline-run-variance` puts the repeat band above most effects worth arguing about.
+
+**Free first ($0, no sign-off):**
+
+1. Replay the seeder over stored envelopes across the 8-case gate set and the Martian tier; report per-family mint, cap-binding and `dropped[]` reasons. Answers "is Problem 1 general or is `937` an outlier?" with no model calls. Same technique that validated the floors.
+2. Mine this run's own transcripts: what did the `security` branch read from `security-review`, and did anything it wrote trace to that skill? Answers whether R2 is a fix or a no-op.
+3. Sweep stored `disposition.json` for severity distribution and for how often a Critical occupied an inline slot ahead of a lower-severity finding. Bounds R4's blast radius before spending on it.
+
+**Then arms, internal-recall-first per LD1** (posted recall is downstream of discovery; read the discovery number before the posted one, every time):
+
+| Arm | Question | Read |
+|---|---|---|
+| R1 skill split | Does removing eight off-family axes cost discovery? | internal union first; then survey branch-seconds and cache-read tokens |
+| R2 security fragment | Does a PR-scoped security skill beat a cron-scan skill on the branch? | security-family internal recall on `1667` (2 of 5 gold are security-family) |
+| R4 severity predicate | Does a trust-boundary gate cost gold? | matched-gold severity distribution and inline occupancy; precision is the win, recall is the guardrail |
+
+Standard discipline from `deterministic-pr-levers.md` applies without exception: 8 cases × 2 repeats minimum, `--keep-workspace`, verify the arm rather than reading its label (`disposition.json` present with the arm's pinned budgets), one variable per arm or say in the write-up that it is a bundle, and paired per-gold comparison (`pairedBand`) over mean deltas. Every arm is human-authorised spend.
+
+The one thing this run argues for that needs no arm at all: **do this again**. Line-by-line verification of a production review against a repo with no gold is the only instrument that has ever caught a hallucinated citation, and it cost nothing but attention.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1175,9 +1175,26 @@ async function cmdSkill(name: string): Promise<void> {
     die(`Usage: lastlight ${name} <owner/repo${repoLevelOnly ? "" : "#N"}>${takesClaim ? ` [-- "<claim or steps>"]` : ""}`);
   }
   const parsed = repoLevelOnly ? null : parseGitHubRef(target);
+  // `pr-review` is PR-SCOPED (`pr_scoped: true` in its workflow YAML), and the
+  // server resolves the `PrState` snapshot only when the dispatch context
+  // carries `prNumber` **as a number**. `issueNumber` alone does not satisfy
+  // that gate, so a CLI-triggered review used to run with no head SHA, no PR
+  // title, no `{{ciSection}}` and no merge decision — the agent had to
+  // rediscover the PR with `list_pull_requests` — and, once the review evidence
+  // pipeline shipped, no `analysisEnabled` either, which made every analysis
+  // phase skip as "trigger rule not satisfied" on a deployment that had turned
+  // the pipeline ON.
+  //
+  // The webhook sets BOTH keys to the same value ("PRs are issues too"), so
+  // mirror it rather than swapping: nothing that reads `issueNumber` changes.
+  // `parsed.type` is only `"pr"` for a full `/pull/N` URL — the `owner/repo#N`
+  // short form is always reported as an issue — so the command name has to be
+  // the authority for `review`, not the ref shape.
+  const prScoped = name === "review" || parsed?.type === "pr";
   let context: Record<string, unknown>;
   if (parsed) {
     context = { repo: `${parsed.owner}/${parsed.repo}`, issueNumber: parsed.number, sender: "cli" };
+    if (prScoped) context.prNumber = parsed.number;
     if (claim) context.commentBody = claim;
     if (!JSON_OUT) console.log(`Triggering ${name} on ${parsed.owner}/${parsed.repo}#${parsed.number}…`);
   } else {

--- a/packages/cli/tests/trigger-context.test.ts
+++ b/packages/cli/tests/trigger-context.test.ts
@@ -1,0 +1,101 @@
+/**
+ * What the trigger commands put in the dispatch CONTEXT.
+ *
+ * `pr-review` is PR-scoped, and the server resolves its `PrState` snapshot only
+ * when the context carries `prNumber` **as a number** — an `issueNumber` alone
+ * does not satisfy that gate. The CLI sent only `issueNumber`, and the failure
+ * was entirely silent: the run still succeeded, the agent just rediscovered the
+ * PR with `list_pull_requests` and reviewed it with no head SHA, no PR title, no
+ * `{{ciSection}}` and no merge decision. Once the review evidence pipeline
+ * shipped it got louder but no clearer — with no `prState` there is no
+ * `analysisEnabled`, so every analysis phase skipped as "trigger rule not
+ * satisfied" on a deployment that had explicitly turned the pipeline on.
+ *
+ * Nothing in the CLI's own output distinguishes either case from success, which
+ * is why this is asserted on the wire rather than on the exit code.
+ */
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { AddressInfo } from "node:net";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+type Captured = { workflow?: string; skill?: string; context: Record<string, unknown> };
+
+/** Run one CLI command against a throwaway server and return what it POSTed. */
+async function capture(args: string[]): Promise<Captured> {
+  const seen: Captured[] = [];
+  const server: Server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      if (body) seen.push(JSON.parse(body) as Captured);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ accepted: true, executionId: "test" }));
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const { port } = server.address() as AddressInfo;
+  try {
+    execFileSync(
+      process.execPath,
+      [join(PACKAGE_ROOT, "node_modules", "tsx", "dist", "cli.mjs"), join(PACKAGE_ROOT, "src", "cli.ts"), ...args],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NO_COLOR: "1",
+          LASTLIGHT_URL: `http://127.0.0.1:${port}`,
+          LASTLIGHT_TOKEN: "test-token",
+        },
+      },
+    );
+  } finally {
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+  expect(seen).toHaveLength(1);
+  return seen[0]!;
+}
+
+describe("trigger context — PR-scoped workflows", () => {
+  it(
+    "sends prNumber for `review`, so the server resolves PrState",
+    { timeout: 60_000 },
+    async () => {
+      const sent = await capture(["review", "acme/widget#941"]);
+      expect(sent.skill ?? sent.workflow).toBe("pr-review");
+      // BOTH, not one or the other — the webhook sets them to the same value
+      // ("PRs are issues too"), and anything already reading `issueNumber`
+      // keeps working.
+      expect(sent.context.prNumber).toBe(941);
+      expect(sent.context.issueNumber).toBe(941);
+    },
+  );
+
+  it("sends prNumber from a full pull-request URL too", { timeout: 60_000 }, async () => {
+    const sent = await capture(["review", "https://github.com/acme/widget/pull/941"]);
+    expect(sent.context.prNumber).toBe(941);
+    expect(sent.context.repo).toBe("acme/widget");
+  });
+
+  it(
+    "does NOT send prNumber for `triage` — issue-triage is not PR-scoped",
+    { timeout: 60_000 },
+    async () => {
+      const sent = await capture(["triage", "acme/widget#941"]);
+      expect(sent.skill ?? sent.workflow).toBe("issue-triage");
+      expect(sent.context.issueNumber).toBe(941);
+      expect(sent.context.prNumber).toBeUndefined();
+    },
+  );
+
+  it("omits both numbers for a repo-wide scan", { timeout: 60_000 }, async () => {
+    const sent = await capture(["review", "acme/widget"]);
+    expect(sent.context.repo).toBe("acme/widget");
+    expect(sent.context.prNumber).toBeUndefined();
+    expect(sent.context.issueNumber).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/trigger-context.test.ts
+++ b/packages/cli/tests/trigger-context.test.ts
@@ -15,7 +15,8 @@
  * is why this is asserted on the wire rather than on the exit code.
  */
 import { describe, it, expect } from "vitest";
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { createServer, type Server } from "node:http";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
@@ -25,7 +26,17 @@ const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
 type Captured = { workflow?: string; skill?: string; context: Record<string, unknown> };
 
-/** Run one CLI command against a throwaway server and return what it POSTed. */
+const run = promisify(execFile);
+
+/**
+ * Run one CLI command against a throwaway server and return what it POSTed.
+ *
+ * `execFile`, NOT `execFileSync`. The server lives in THIS process, so a
+ * synchronous spawn blocks the event loop that would have to answer the
+ * request: the child waits forever for a response and the parent waits forever
+ * for the child. That deadlock does not fail, it hangs — the suite sits there
+ * until something outside kills it.
+ */
 async function capture(args: string[]): Promise<Captured> {
   const seen: Captured[] = [];
   const server: Server = createServer((req, res) => {
@@ -40,7 +51,7 @@ async function capture(args: string[]): Promise<Captured> {
   await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
   const { port } = server.address() as AddressInfo;
   try {
-    execFileSync(
+    await run(
       process.execPath,
       [join(PACKAGE_ROOT, "node_modules", "tsx", "dist", "cli.mjs"), join(PACKAGE_ROOT, "src", "cli.ts"), ...args],
       {
@@ -54,6 +65,9 @@ async function capture(args: string[]): Promise<Captured> {
       },
     );
   } finally {
+    // `close()` alone waits for keep-alive sockets the CLI's fetch leaves open,
+    // so the callback would not fire and the hang would simply move here.
+    server.closeAllConnections();
     await new Promise<void>((r) => server.close(() => r()));
   }
   expect(seen).toHaveLength(1);


### PR DESCRIPTION
Everything here came out of putting the v0.27.0 review evidence pipeline in front of real pull requests on `drizby` for the first time. Each fix is a thing that run exposed.

## The CLI could never reach the pipeline at all

`lastlight review owner/repo#N` sent `issueNumber`, but the server resolves the `PrState` snapshot only when the dispatch context carries `prNumber` **as a number**. So a CLI-triggered review ran with no head SHA, no PR title, no `{{ciSection}}` and no merge decision — the agent rediscovered the PR with `list_pull_requests` — and, once the evidence pipeline shipped, with no `analysisEnabled`, so every analysis phase skipped as "trigger rule not satisfied" on a deployment that had explicitly turned the pipeline on.

This was silent in both directions: the run still reported success. The webhook path was unaffected, which is why it went unnoticed. Asserted on the wire in `packages/cli/tests/trigger-context.test.ts`, because nothing in the CLI's output distinguishes the broken case.

## A review the bot itself opened ran for ten minutes and then 422'd

GitHub refuses `APPROVE` and `REQUEST_CHANGES` on your own pull request, and `resolveEvent` produces one or the other for every review — so posting could not succeed in either direction. `resolveReviewTrigger` now skips a self-authored PR at the dispatch gate, before any sandbox starts.

`authorIsOurs` is deliberately **not** `headIsOurs`: that one asks who pushed the head *commit*, so it is true whenever a fix run landed on someone else's PR, and keying on it would have suppressed reviews of human PRs the agent had merely touched — a worse bug than the one being fixed. Both cases are pinned in the tests.

The notice replies only to an explicit request. A PR we opened is re-examined on every push, check and review cron, so notifying on those would be a comment per event forever.

## Explicit re-reviews were built, then thrown away

The sharpest one. An explicitly requested re-review of an already-reviewed head ran the full pipeline, produced a complete findings document (9 findings, `REQUEST_CHANGES`), and was then discarded — reporting `succeeded` and posting nothing.

The head-SHA predicate lived in **three** places that disagreed: the dispatch gate (correctly treating an explicit ask as an override), the `pr-review` skill (writing `{"skip": true}`), and `post-review`'s own ungated guard. Fixing any one of them alone leaves the review unposted.

`resolveReviewPost` now owns the posting half beside `resolveReviewTrigger`, and the split between them is the point: the gate asks *may we spend a run*, where a prior review is dedup an explicit ask can override; the new function asks *may we publish what we already paid for*, where a prior review is not dedup at all but re-entry protection.

Re-entry is told from a deliberate re-request by whether the review at head is the one the dispatch snapshot saw, using `botReviewAtHead.submittedAt` — which `getBotReviewHistory` already returned and `pr-state.ts` was dropping. Derived from GitHub rather than a marker we write on the way past, so it still holds when a run dies *between* the POST and its own bookkeeping, which is exactly when a resume happens.

`repeatOfLastReview` was a second silent swallower of the same case. `spec/05-router.md` and `spec/06-workflow-engine.md` both claimed posting was idempotent when a review exists on the head SHA; that was wrong and is corrected.

## You could not see any of this in the UI

Three separate blind spots, all of which made a broken run look healthy:

- **A failed run showed no reason.** A handler phase that throws before writing an `executions` row leaves nothing in the graph, so the run rendered as every-phase-green with `status: failed` and the reason reachable only from the API.
- **A phase that did nothing looked like one that did a lot.** `post-review` returns `skipped: …` / `already reviewed head …` / a summary of what it posted, and all three were the same green tick. The text was already persisted on `phase_history[].summary` and already served — the dashboard read the entry for a status colour and discarded it. That field is the generic vehicle across every phase type, so this is not a `post-review` special case.
- **Fan-out branches were drawn as a chain.** Five concurrent surveys rendered as a five-deep ladder — the one claim the picture makes about a fan-out, made backwards. Branches now edge from the parent, each branch's gate nests under its own branch, derived names render as `contract` / `#1` instead of overflowing a 110px card with `survey_branch_contract`, and fan-out duration is wall clock rather than the sum of its branches (a real run measured 161+59+235+233+194s, which summed to 882s for a phase that took 235).

Also: expanded tool calls in the session timeline now show input and output side by side with a full-screen view. The results were already reaching the client, hidden behind a second easy-to-miss collapse.

## Doc

`docs/plans/review-pipeline-improvements.md` records what the first production run established and what it did not. The pipeline produced 7 postable findings, all verified true against source at that head, two executably reproduced, with zero verification-report noise reaching the maintainer — and it caught a hallucinated `src/cli/CLAUDE.md` citation in the bot's own prior APPROVE of the same head.

It is explicit that this is **n=1** with no gold, so 7/7 is precision with no recall denominator, and against a known 0.320→0.080 repeat band nothing in it ships on this evidence. The open problems it argues: obligation allocation is inverted (contract capped at 12 while three families minted zero and 35 of 48 slots went unclaimed), every branch reads the same generic rubric, and severity is inflated.

## Verification

Full server suite green — 3816 passed, 209 skipped, 0 failed. `lastlight-core` and `@lastlight/dashboard` typecheck clean, including the import-boundary and floating-promise lints.

The new tests are written to fail against the old code *and* against a naive delete-the-guard fix; the explicit-request case posts 0 reviews before this change, and the two re-entry cases double-post if the guard is simply removed.

## Not done

`staleAgainstCurrentHead` is untouched: an explicit request whose head moves *during* the run still defers to the new head's review. Defensible, since a material push gets its own dispatch — but it is a third way an explicit ask can end in silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
