### PR TITLE
Activity log: one append-only stream of who did what (#206)

### DIFF
--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -323,7 +323,7 @@ src/
   state/
     db.ts               `StateDb` — the ASYNC factory (`await StateDb.open(url)`
                         / `StateDb.fromClient(client, dialect)`; no public
-                        constructor) that wires the seven stores together and
+                        constructor) that wires the eight stores together and
                         is the single import surface for their types. Every
                         store method returns a Promise. `open()` picks the
                         engine off the URL: libsql for `file:`/`:memory:`/a
@@ -347,10 +347,10 @@ src/
                         ships in the agent image — what `lastlight server db`
                         runs inside the container, since the CLI may never gain
                         an edge to core.
-    schema/sqlite.ts    Drizzle schema — the source of truth for all fifteen
+    schema/sqlite.ts    Drizzle schema — the source of truth for all sixteen
                         tables (executions, workflow_runs, workflow_approvals,
                         cron_runs, cron_overrides, workflow_overrides, users,
-                        messaging_*, feedback_*, github_team*).
+                        activity_log, messaging_*, feedback_*, github_team*).
     schema/pg.ts        The name-parity pgTable mirror. NOTHING under src/ may
                         import it — it exists for drizzle-kit and the PGlite
                         test leg. A schema change means editing BOTH files and
@@ -377,6 +377,17 @@ src/
                         only record that it ran at all. Keyed on the cron
                         rather than the workflow so a run dispatched by
                         `/api/run` or a comment cannot skew a cron's health.
+    activity-store.ts   The `activity_log` audit stream (issue #206) — one
+                        append-only row per USER-INITIATED action, across the
+                        dashboard, CLI, Slack, GitHub and cron. Complements
+                        #205's per-run `triggered_by` columns rather than
+                        replacing them: those stay the hot-path attribution, and
+                        this is the chronological stream that answers "what has
+                        this person done?" without joining five ledgers. System
+                        fan-out is deliberately NOT recorded per dispatch — a
+                        cron fires once and is logged once (`cron.fire`), the
+                        same reason `cron_runs` keys on the cron rather than the
+                        workflow.
     team-store.ts       The dashboard's per-repo visibility CACHE (issue #169):
                         github_teams / _team_repos / _team_members /
                         github_visibility_sync. Not a mirror of the org — rows

--- a/apps/server/dashboard/src/App.tsx
+++ b/apps/server/dashboard/src/App.tsx
@@ -29,6 +29,7 @@ const RouterPlayground = lazy(() =>
   import("./components/RouterPlayground").then((m) => ({ default: m.RouterPlayground })),
 );
 import { FeedbackPage } from "./components/FeedbackPage";
+import { ActivityPage } from "./components/ActivityPage";
 import {
   HomeIcon,
   PlayCircleIcon,
@@ -41,6 +42,7 @@ import {
   CommandLineIcon,
   ShareIcon,
   HandThumbUpIcon,
+  ListBulletIcon,
 } from "@heroicons/react/24/outline";
 import {
   useUrlState,
@@ -53,11 +55,11 @@ import {
 } from "./hooks/useUrlState";
 
 type AuthState = "checking" | "required" | "ok";
-type Tab = "home" | "sessions" | "chat-sessions" | "workflows" | "runs" | "repos" | "crons" | "feedback" | "logs" | "config" | "router-playground";
+type Tab = "home" | "sessions" | "chat-sessions" | "workflows" | "runs" | "repos" | "crons" | "feedback" | "logs" | "config" | "router-playground" | "activity";
 
 const PAGE_SIZE = 50;
 
-const TABS = ["home", "workflows", "runs", "sessions", "chat-sessions", "repos", "crons", "feedback", "logs", "config", "router-playground"] as const;
+const TABS = ["home", "workflows", "runs", "sessions", "chat-sessions", "repos", "crons", "feedback", "activity", "logs", "config", "router-playground"] as const;
 
 const SESSION_SOURCE_PATHS: Record<"sessions" | "chat-sessions", string> = {
   sessions: "/admin/api/sessions",
@@ -305,6 +307,7 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
               { id: "repos", label: "Repos", Icon: FolderIcon },
               { id: "crons", label: "Crons", Icon: ClockIcon },
               { id: "feedback", label: "Feedback", Icon: HandThumbUpIcon },
+              { id: "activity", label: "Activity", Icon: ListBulletIcon },
               { id: "logs", label: "Logs", Icon: CommandLineIcon },
               { id: "router-playground", label: "Router Playground", Icon: ShareIcon },
               { id: "config", label: "Config", Icon: Cog6ToothIcon },
@@ -402,6 +405,8 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
         <LogsPage />
       ) : tab === "feedback" ? (
         <FeedbackPage />
+      ) : tab === "activity" ? (
+        <ActivityPage />
       ) : tab === "config" ? (
         <ConfigPage />
       ) : tab === "repos" ? (

--- a/apps/server/dashboard/src/api.ts
+++ b/apps/server/dashboard/src/api.ts
@@ -571,6 +571,34 @@ export interface DailyStat extends OutcomeCounts {
 // copied here by hand.
 
 /** One 👍/👎 on something the bot wrote, scored against the run that wrote it. */
+/**
+ * One row of the audit stream (issue #206).
+ *
+ * HAND-MIRRORED from `src/state/activity-store.ts` — the dashboard has no
+ * import edge to core. `tests/admin/dashboard-activity-mirror.test.ts` pins the
+ * two together, because a mirror like this drifted once before and hid three
+ * config blocks for a release.
+ *
+ * `actorLogin` is optional on purpose: a password session and an auth-disabled
+ * instance both write a row with no verified login. Render that as "no login",
+ * never as an empty cell — the row is not missing data, the login genuinely
+ * does not exist.
+ */
+export interface ActivityRecord {
+  id: string;
+  createdAt: string;
+  actorLogin?: string;
+  actorType?: "github" | "slack" | "cli" | "cron" | "admin" | "system";
+  action: string;
+  targetType?: string;
+  targetId?: string;
+  outcome: "ok" | "denied" | "error";
+  detail?: Record<string, string | number | boolean>;
+}
+
+/** `users.login` → identity, for avatar + real name. Absent when unresolved. */
+export type ActivityUsers = Record<string, { login?: string; name?: string; avatarUrl?: string }>;
+
 export interface FeedbackSignal {
   id: string;
   anchorId: string;
@@ -856,6 +884,31 @@ export const api = {
   dailyStats: (days = 30) => req<{ daily: DailyStat[] }>(`/stats/daily?days=${days}`),
   hourlyStats: (hours = 24) =>
     req<{ hourly: DailyStat[] }>(`/stats/hourly?hours=${hours}`),
+  activity: (
+    opts: {
+      limit?: number;
+      offset?: number;
+      actor?: string;
+      action?: string;
+      /** `<type>:<id>` — e.g. `workflow_run:4f3a…`. Also serves the per-run strip. */
+      target?: string;
+      since?: string;
+    } = {},
+  ) => {
+    const qs = new URLSearchParams();
+    if (opts.limit) qs.set("limit", String(opts.limit));
+    if (opts.offset) qs.set("offset", String(opts.offset));
+    if (opts.actor) qs.set("actor", opts.actor);
+    if (opts.action) qs.set("action", opts.action);
+    if (opts.target) qs.set("target", opts.target);
+    if (opts.since) qs.set("since", opts.since);
+    const q = qs.toString();
+    return req<{ activity: ActivityRecord[]; total: number; users: ActivityUsers }>(
+      `/activity${q ? `?${q}` : ""}`,
+    );
+  },
+  activityActions: () => req<{ actions: string[] }>("/activity/actions"),
+
   feedbackSignals: (opts: { limit?: number; workflow?: string; source?: string } = {}) => {
     const qs = new URLSearchParams();
     if (opts.limit) qs.set("limit", String(opts.limit));

--- a/apps/server/dashboard/src/components/ActivityPage.tsx
+++ b/apps/server/dashboard/src/components/ActivityPage.tsx
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, type ActivityRecord, type ActivityUsers } from "../api";
+import { ActorChip } from "./ActorChip";
+import { STATUS } from "../lib/status-colors";
+import { useUrlState, nullableStringParser, nullableStringSerializer } from "../hooks/useUrlState";
+
+const PAGE = 50;
+
+/**
+ * Outcome → the shared status palette. Never local hex: the palette is the one
+ * place these hues are decided, and a second opinion here would drift from the
+ * rest of the dashboard.
+ */
+const OUTCOME_COLOR: Record<ActivityRecord["outcome"], string> = {
+  ok: STATUS.good,
+  denied: STATUS.info,
+  error: STATUS.bad,
+};
+
+/** Relative time, matching how the home page's live rows read. */
+function timeAgo(iso: string): string {
+  const diff = Date.now() - Date.parse(iso);
+  const sec = Math.round(diff / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.round(hr / 24)}d ago`;
+}
+
+/** `detail` rendered as `k=v` pairs — a summary, so it is always short. */
+function renderDetail(detail?: Record<string, string | number | boolean>): string {
+  if (!detail) return "";
+  return Object.entries(detail)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("  ");
+}
+
+export function ActivityRow({ row, users }: { row: ActivityRecord; users: ActivityUsers }) {
+  const user = row.actorLogin ? users[row.actorLogin] : undefined;
+  return (
+    <tr className="hover:bg-base-200/40">
+      <td className="whitespace-nowrap text-base-content/50 text-xs">{timeAgo(row.createdAt)}</td>
+      <td className="whitespace-nowrap">
+        {row.actorLogin ? (
+          <ActorChip login={row.actorLogin} actorType={row.actorType} user={user ?? null} />
+        ) : (
+          // NOT an empty cell: the row is complete, the login genuinely does
+          // not exist (a password session, or auth disabled entirely).
+          <span className="text-base-content/40 italic text-xs" title="No verified login on this session">
+            no login
+            {row.actorType ? ` · ${row.actorType}` : ""}
+          </span>
+        )}
+      </td>
+      <td className="whitespace-nowrap font-mono text-xs">{row.action}</td>
+      <td className="text-xs text-base-content/70 max-w-[22rem] truncate" title={row.targetId}>
+        {row.targetType ? (
+          <>
+            <span className="text-base-content/40">{row.targetType}:</span>
+            {row.targetId}
+          </>
+        ) : null}
+      </td>
+      <td className="whitespace-nowrap text-xs">
+        <span style={{ color: OUTCOME_COLOR[row.outcome] }}>● </span>
+        {row.outcome}
+      </td>
+      <td className="text-xs text-base-content/50 font-mono truncate max-w-[18rem]">
+        {renderDetail(row.detail)}
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * The global audit feed (issue #206) — who did what, across every surface.
+ *
+ * Plain `fetch` + `useState` + an interval, like every other page here; there
+ * is no React Query in this app. Filter state rides the URL so a filtered feed
+ * is linkable.
+ */
+export function ActivityPage() {
+  const [rows, setRows] = useState<ActivityRecord[]>([]);
+  const [users, setUsers] = useState<ActivityUsers>({});
+  const [total, setTotal] = useState(0);
+  const [limit, setLimit] = useState(PAGE);
+  const [actions, setActions] = useState<string[]>([]);
+  const [actor, setActor] = useUrlState<string | null>(
+    "actor",
+    null,
+    nullableStringParser,
+    nullableStringSerializer,
+  );
+  const [action, setAction] = useUrlState<string | null>(
+    "action",
+    null,
+    nullableStringParser,
+    nullableStringSerializer,
+  );
+
+  // A filter change resets paging — otherwise "load more" keeps a limit that
+  // belonged to a different result set.
+  useEffect(() => {
+    setLimit(PAGE);
+  }, [actor, action]);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await api.activity({
+        limit,
+        actor: actor ?? undefined,
+        action: action ?? undefined,
+      });
+      setRows(data.activity);
+      setUsers(data.users ?? {});
+      setTotal(data.total);
+    } catch {
+      // Leave the last good render in place — a transient admin-API blip
+      // should not blank the page.
+    }
+  }, [limit, actor, action]);
+
+  useEffect(() => {
+    load();
+    const timer = setInterval(load, 15_000);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  useEffect(() => {
+    api
+      .activityActions()
+      .then((d) => setActions(d.actions))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="p-4 space-y-3 overflow-auto">
+      <div className="flex items-center gap-2 flex-wrap">
+        <h2 className="text-lg font-semibold">Activity</h2>
+        <span className="text-xs text-base-content/50">
+          every user-initiated action, newest first
+        </span>
+        <div className="grow" />
+        <input
+          className="input input-sm input-bordered w-44"
+          placeholder="Filter by actor…"
+          value={actor ?? ""}
+          onChange={(e) => setActor(e.target.value || null)}
+        />
+        <select
+          className="select select-sm select-bordered w-52"
+          value={action ?? ""}
+          onChange={(e) => setAction(e.target.value || null)}
+        >
+          <option value="">All actions</option>
+          {actions.map((a) => (
+            <option key={a} value={a}>
+              {a}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="table table-sm">
+          <thead>
+            <tr className="text-xs">
+              <th>When</th>
+              <th>Actor</th>
+              <th>Action</th>
+              <th>Target</th>
+              <th>Outcome</th>
+              <th>Detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <ActivityRow key={row.id} row={row} users={users} />
+            ))}
+          </tbody>
+        </table>
+        {rows.length === 0 && (
+          <div className="text-center text-base-content/50 text-sm py-8">
+            No activity recorded yet.
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 text-xs text-base-content/50">
+        <span>
+          {rows.length} of {total}
+        </span>
+        {rows.length < total && (
+          <button className="btn btn-xs" onClick={() => setLimit((l) => l + PAGE)}>
+            Load more
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The per-run activity strip.
+ *
+ * Renders NOTHING when the run has no activity — the same self-hiding rule
+ * `PrStatePanel` follows, which is what keeps the run detail panel from filling
+ * with empty sections. Fetched once on selection rather than polled, like
+ * `FeedbackBadge`.
+ */
+export function RunActivityStrip({ runId }: { runId: string }) {
+  const [rows, setRows] = useState<ActivityRecord[]>([]);
+  const [users, setUsers] = useState<ActivityUsers>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .activity({ target: `workflow_run:${runId}`, limit: 20 })
+      .then((d) => {
+        if (cancelled) return;
+        setRows(d.activity);
+        setUsers(d.users ?? {});
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [runId]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="border-t border-base-300 px-4 py-2">
+      <div className="text-xs font-semibold text-base-content/60 mb-1">Activity</div>
+      <ul className="space-y-1">
+        {rows.map((row) => (
+          <li key={row.id} className="flex items-center gap-2 text-xs">
+            <span style={{ color: OUTCOME_COLOR[row.outcome] }}>●</span>
+            <span className="font-mono">{row.action}</span>
+            {row.actorLogin ? (
+              <ActorChip
+                login={row.actorLogin}
+                actorType={row.actorType}
+                user={users[row.actorLogin] ?? null}
+              />
+            ) : (
+              <span className="text-base-content/40 italic">no login</span>
+            )}
+            <span className="text-base-content/40">{timeAgo(row.createdAt)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/server/dashboard/src/components/WorkflowList.tsx
+++ b/apps/server/dashboard/src/components/WorkflowList.tsx
@@ -24,6 +24,7 @@ import { WorkflowPipeline } from "./WorkflowPipeline";
 import { ApprovalBanner } from "./ApprovalBanner";
 import { PhaseDetailPanel } from "./PhaseDetailPanel";
 import { PrStatePanel } from "./PrStatePanel";
+import { RunActivityStrip } from "./ActivityPage";
 import { MessageFeed, type MessageOrder } from "./MessageFeed";
 import {
   useUrlState,
@@ -555,6 +556,10 @@ function DetailPanel({ run, triggeredByUser, approvals, onCancel, onRetry, onApp
           itself away on any run that carries none — i.e. every non-PR-scoped
           workflow — so there is no workflow-name list here to keep in step. */}
       <PrStatePanel run={run} />
+
+      {/* Who acted on this run, and what came of it (issue #206). Self-hiding
+          on a run nobody has touched, same rule as PrStatePanel above. */}
+      <RunActivityStrip runId={run.id} />
 
       <ResizablePipeline
         run={run}

--- a/apps/server/drizzle/pg/0001_brief_gargoyle.sql
+++ b/apps/server/drizzle/pg/0001_brief_gargoyle.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "activity_log" (
+	"id" text PRIMARY KEY NOT NULL,
+	"created_at" text NOT NULL,
+	"actor_login" text,
+	"actor_type" text,
+	"action" text NOT NULL,
+	"target_type" text,
+	"target_id" text,
+	"outcome" text NOT NULL,
+	"detail" jsonb
+);
+--> statement-breakpoint
+CREATE INDEX "idx_activity_created" ON "activity_log" USING btree ("created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_activity_actor_created" ON "activity_log" USING btree ("actor_login","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_activity_target" ON "activity_log" USING btree ("target_type","target_id");

--- a/apps/server/drizzle/pg/meta/0001_snapshot.json
+++ b/apps/server/drizzle/pg/meta/0001_snapshot.json
@@ -1,0 +1,1876 @@
+{
+  "id": "5b76b6e5-b078-443b-8e0b-3d0b15586c49",
+  "prevId": "727025fc-a957-4813-8410-8ce1ae84c4d0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_login": {
+          "name": "actor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_activity_created": {
+          "name": "idx_activity_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_actor_created": {
+          "name": "idx_activity_actor_created",
+          "columns": [
+            {
+              "expression": "actor_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_target": {
+          "name": "idx_activity_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_overrides": {
+      "name": "cron_overrides",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_runs": {
+      "name": "cron_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cron_name": {
+          "name": "cron_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handler": {
+          "name": "handler",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "repos_eligible": {
+          "name": "repos_eligible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repos_scanned": {
+          "name": "repos_scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovered": {
+          "name": "discovered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched": {
+          "name": "dispatched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failures": {
+          "name": "failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cron_runs_name_started": {
+          "name": "idx_cron_runs_name_started",
+          "columns": [
+            {
+              "expression": "cron_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.executions": {
+      "name": "executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_actor_type": {
+          "name": "trigger_actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_duration_ms": {
+          "name": "api_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_text": {
+          "name": "output_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extension_status": {
+          "name": "extension_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills_status": {
+          "name": "skills_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_executions_trigger": {
+          "name": "idx_executions_trigger",
+          "columns": [
+            {
+              "expression": "trigger_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executions_skill": {
+          "name": "idx_executions_skill",
+          "columns": [
+            {
+              "expression": "skill",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executions_workflow_run": {
+          "name": "idx_executions_workflow_run",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_anchors": {
+      "name": "feedback_anchors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_session_id": {
+          "name": "messaging_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_feedback_anchors_lookup": {
+          "name": "idx_feedback_anchors_lookup",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_anchors_run": {
+          "name": "idx_feedback_anchors_run",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_anchors_poll": {
+          "name": "idx_feedback_anchors_poll",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_polled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feedback_anchors_source_channel_external_id_unique": {
+          "name": "feedback_anchors_source_channel_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source",
+            "channel",
+            "external_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_signals": {
+      "name": "feedback_signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anchor_id": {
+          "name": "anchor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_session_id": {
+          "name": "messaging_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reactor": {
+          "name": "reactor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reacted_at": {
+          "name": "reacted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exported_at": {
+          "name": "exported_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_feedback_signals_anchor": {
+          "name": "idx_feedback_signals_anchor",
+          "columns": [
+            {
+              "expression": "anchor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_signals_run": {
+          "name": "idx_feedback_signals_run",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_signals_observed": {
+          "name": "idx_feedback_signals_observed",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_signals_workflow": {
+          "name": "idx_feedback_signals_workflow",
+          "columns": [
+            {
+              "expression": "workflow_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_signals_export": {
+          "name": "idx_feedback_signals_export",
+          "columns": [
+            {
+              "expression": "exported_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feedback_signals_anchor_id_reactor_emoji_unique": {
+          "name": "feedback_signals_anchor_id_reactor_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "anchor_id",
+            "reactor",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_team_members": {
+      "name": "github_team_members",
+      "schema": "",
+      "columns": {
+        "org": {
+          "name": "org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_slug": {
+          "name": "team_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_github_team_members_login": {
+          "name": "idx_github_team_members_login",
+          "columns": [
+            {
+              "expression": "login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_team_members_org_team_slug_login_pk": {
+          "name": "github_team_members_org_team_slug_login_pk",
+          "columns": [
+            "org",
+            "team_slug",
+            "login"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_team_repos": {
+      "name": "github_team_repos",
+      "schema": "",
+      "columns": {
+        "org": {
+          "name": "org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_slug": {
+          "name": "team_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_team_repos_org_team_slug_repo_pk": {
+          "name": "github_team_repos_org_team_slug_repo_pk",
+          "columns": [
+            "org",
+            "team_slug",
+            "repo"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_teams": {
+      "name": "github_teams",
+      "schema": "",
+      "columns": {
+        "org": {
+          "name": "org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repos_synced_at": {
+          "name": "repos_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_teams_org_slug_pk": {
+          "name": "github_teams_org_slug_pk",
+          "columns": [
+            "org",
+            "slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_visibility_sync": {
+      "name": "github_visibility_sync",
+      "schema": "",
+      "columns": {
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_messages": {
+      "name": "messaging_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "messaging_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_msg_messages_session": {
+          "name": "idx_msg_messages_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_messages_session_id_messaging_sessions_id_fk": {
+          "name": "messaging_messages_session_id_messaging_sessions_id_fk",
+          "tableFrom": "messaging_messages",
+          "tableTo": "messaging_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_sessions": {
+      "name": "messaging_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_msg_sessions_lookup": {
+          "name": "idx_msg_sessions_lookup",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_msg_sessions_unique_active": {
+          "name": "idx_msg_sessions_unique_active",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "active",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_blocked": {
+          "name": "is_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_is_placeholder": {
+          "name": "email_is_placeholder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_login": {
+          "name": "idx_users_login",
+          "columns": [
+            {
+              "expression": "login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_slack": {
+          "name": "idx_users_slack",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_login_unique": {
+          "name": "users_login_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "login"
+          ]
+        },
+        "users_slack_user_id_unique": {
+          "name": "users_slack_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slack_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_approvals": {
+      "name": "workflow_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gate": {
+          "name": "gate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by": {
+          "name": "responded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approve'"
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_approvals_workflow": {
+          "name": "idx_approvals_workflow",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_approvals_status": {
+          "name": "idx_approvals_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_overrides": {
+      "name": "workflow_overrides",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_history": {
+          "name": "phase_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_actor_type": {
+          "name": "trigger_actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scratch": {
+          "name": "scratch",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restart_count": {
+          "name": "restart_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workflow_runs_trigger": {
+          "name": "idx_workflow_runs_trigger",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_runs_status": {
+          "name": "idx_workflow_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_runs_started_at": {
+          "name": "idx_workflow_runs_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_runs_name_started": {
+          "name": "idx_workflow_runs_name_started",
+          "columns": [
+            {
+              "expression": "workflow_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/drizzle/pg/meta/_journal.json
+++ b/apps/server/drizzle/pg/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1787046729665,
       "tag": "0000_init",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1787758572642,
+      "tag": "0001_brief_gargoyle",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/drizzle/sqlite/0002_aromatic_vector.sql
+++ b/apps/server/drizzle/sqlite/0002_aromatic_vector.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `activity_log` (
+	`id` text PRIMARY KEY NOT NULL,
+	`created_at` text NOT NULL,
+	`actor_login` text,
+	`actor_type` text,
+	`action` text NOT NULL,
+	`target_type` text,
+	`target_id` text,
+	`outcome` text NOT NULL,
+	`detail` text
+);
+--> statement-breakpoint
+CREATE INDEX `idx_activity_created` ON `activity_log` ("created_at" DESC);--> statement-breakpoint
+CREATE INDEX `idx_activity_actor_created` ON `activity_log` (`actor_login`,"created_at" DESC);--> statement-breakpoint
+CREATE INDEX `idx_activity_target` ON `activity_log` (`target_type`,`target_id`);

--- a/apps/server/drizzle/sqlite/meta/0002_snapshot.json
+++ b/apps/server/drizzle/sqlite/meta/0002_snapshot.json
@@ -1,0 +1,1704 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f9d50c1d-ebf4-4dcd-b6d3-7c8f7fbf521a",
+  "prevId": "a6d9d049-d1e0-446e-bb4f-8585ecc2ec07",
+  "tables": {
+    "activity_log": {
+      "name": "activity_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_login": {
+          "name": "actor_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_activity_created": {
+          "name": "idx_activity_created",
+          "columns": [
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "idx_activity_actor_created": {
+          "name": "idx_activity_actor_created",
+          "columns": [
+            "actor_login",
+            "\"created_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "idx_activity_target": {
+          "name": "idx_activity_target",
+          "columns": [
+            "target_type",
+            "target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cron_overrides": {
+      "name": "cron_overrides",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cron_runs": {
+      "name": "cron_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron_name": {
+          "name": "cron_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handler": {
+          "name": "handler",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "repos_eligible": {
+          "name": "repos_eligible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repos_scanned": {
+          "name": "repos_scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovered": {
+          "name": "discovered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dispatched": {
+          "name": "dispatched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failures": {
+          "name": "failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cron_runs_name_started": {
+          "name": "idx_cron_runs_name_started",
+          "columns": [
+            "cron_name",
+            "\"started_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "executions": {
+      "name": "executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_actor_type": {
+          "name": "trigger_actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_duration_ms": {
+          "name": "api_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_text": {
+          "name": "output_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extension_status": {
+          "name": "extension_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skills_status": {
+          "name": "skills_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_executions_trigger": {
+          "name": "idx_executions_trigger",
+          "columns": [
+            "trigger_type",
+            "trigger_id"
+          ],
+          "isUnique": false
+        },
+        "idx_executions_skill": {
+          "name": "idx_executions_skill",
+          "columns": [
+            "skill",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_executions_workflow_run": {
+          "name": "idx_executions_workflow_run",
+          "columns": [
+            "workflow_run_id",
+            "skill"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback_anchors": {
+      "name": "feedback_anchors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "messaging_session_id": {
+          "name": "messaging_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_feedback_anchors_lookup": {
+          "name": "idx_feedback_anchors_lookup",
+          "columns": [
+            "source",
+            "channel",
+            "external_id"
+          ],
+          "isUnique": false
+        },
+        "idx_feedback_anchors_run": {
+          "name": "idx_feedback_anchors_run",
+          "columns": [
+            "workflow_run_id"
+          ],
+          "isUnique": false
+        },
+        "idx_feedback_anchors_poll": {
+          "name": "idx_feedback_anchors_poll",
+          "columns": [
+            "source",
+            "created_at",
+            "last_polled_at"
+          ],
+          "isUnique": false
+        },
+        "feedback_anchors_source_channel_external_id_unique": {
+          "name": "feedback_anchors_source_channel_external_id_unique",
+          "columns": [
+            "source",
+            "channel",
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback_signals": {
+      "name": "feedback_signals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchor_id": {
+          "name": "anchor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "messaging_session_id": {
+          "name": "messaging_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reactor": {
+          "name": "reactor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reacted_at": {
+          "name": "reacted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exported_at": {
+          "name": "exported_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_feedback_signals_anchor": {
+          "name": "idx_feedback_signals_anchor",
+          "columns": [
+            "anchor_id"
+          ],
+          "isUnique": false
+        },
+        "idx_feedback_signals_run": {
+          "name": "idx_feedback_signals_run",
+          "columns": [
+            "workflow_run_id"
+          ],
+          "isUnique": false
+        },
+        "idx_feedback_signals_observed": {
+          "name": "idx_feedback_signals_observed",
+          "columns": [
+            "\"observed_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "idx_feedback_signals_workflow": {
+          "name": "idx_feedback_signals_workflow",
+          "columns": [
+            "workflow_name",
+            "\"observed_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "idx_feedback_signals_export": {
+          "name": "idx_feedback_signals_export",
+          "columns": [
+            "exported_at"
+          ],
+          "isUnique": false
+        },
+        "feedback_signals_anchor_id_reactor_emoji_unique": {
+          "name": "feedback_signals_anchor_id_reactor_emoji_unique",
+          "columns": [
+            "anchor_id",
+            "reactor",
+            "emoji"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_team_members": {
+      "name": "github_team_members",
+      "columns": {
+        "org": {
+          "name": "org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_slug": {
+          "name": "team_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_github_team_members_login": {
+          "name": "idx_github_team_members_login",
+          "columns": [
+            "login"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_team_members_org_team_slug_login_pk": {
+          "columns": [
+            "org",
+            "team_slug",
+            "login"
+          ],
+          "name": "github_team_members_org_team_slug_login_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_team_repos": {
+      "name": "github_team_repos",
+      "columns": {
+        "org": {
+          "name": "org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_slug": {
+          "name": "team_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_team_repos_org_team_slug_repo_pk": {
+          "columns": [
+            "org",
+            "team_slug",
+            "repo"
+          ],
+          "name": "github_team_repos_org_team_slug_repo_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_teams": {
+      "name": "github_teams",
+      "columns": {
+        "org": {
+          "name": "org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repos_synced_at": {
+          "name": "repos_synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_teams_org_slug_pk": {
+          "columns": [
+            "org",
+            "slug"
+          ],
+          "name": "github_teams_org_slug_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_visibility_sync": {
+      "name": "github_visibility_sync",
+      "columns": {
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messaging_messages": {
+      "name": "messaging_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_msg_messages_session": {
+          "name": "idx_msg_messages_session",
+          "columns": [
+            "session_id",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messaging_messages_session_id_messaging_sessions_id_fk": {
+          "name": "messaging_messages_session_id_messaging_sessions_id_fk",
+          "tableFrom": "messaging_messages",
+          "tableTo": "messaging_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messaging_sessions": {
+      "name": "messaging_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_msg_sessions_lookup": {
+          "name": "idx_msg_sessions_lookup",
+          "columns": [
+            "platform",
+            "channel_id",
+            "thread_id",
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_msg_sessions_unique_active": {
+          "name": "idx_msg_sessions_unique_active",
+          "columns": [
+            "platform",
+            "channel_id",
+            "thread_id",
+            "user_id"
+          ],
+          "isUnique": true,
+          "where": "active = 1"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_blocked": {
+          "name": "is_blocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "email_is_placeholder": {
+          "name": "email_is_placeholder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": true
+        },
+        "users_login_unique": {
+          "name": "users_login_unique",
+          "columns": [
+            "login"
+          ],
+          "isUnique": true
+        },
+        "users_slack_user_id_unique": {
+          "name": "users_slack_user_id_unique",
+          "columns": [
+            "slack_user_id"
+          ],
+          "isUnique": true
+        },
+        "idx_users_login": {
+          "name": "idx_users_login",
+          "columns": [
+            "login"
+          ],
+          "isUnique": false
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_users_slack": {
+          "name": "idx_users_slack",
+          "columns": [
+            "slack_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workflow_approvals": {
+      "name": "workflow_approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gate": {
+          "name": "gate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "responded_by": {
+          "name": "responded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'approve'"
+        },
+        "artifact": {
+          "name": "artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_approvals_workflow": {
+          "name": "idx_approvals_workflow",
+          "columns": [
+            "workflow_run_id"
+          ],
+          "isUnique": false
+        },
+        "idx_approvals_status": {
+          "name": "idx_approvals_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workflow_overrides": {
+      "name": "workflow_overrides",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workflow_runs": {
+      "name": "workflow_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase_history": {
+          "name": "phase_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_actor_type": {
+          "name": "trigger_actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scratch": {
+          "name": "scratch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "restart_count": {
+          "name": "restart_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_workflow_runs_trigger": {
+          "name": "idx_workflow_runs_trigger",
+          "columns": [
+            "trigger_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_workflow_runs_status": {
+          "name": "idx_workflow_runs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_workflow_runs_started_at": {
+          "name": "idx_workflow_runs_started_at",
+          "columns": [
+            "\"started_at\" DESC"
+          ],
+          "isUnique": false
+        },
+        "idx_workflow_runs_name_started": {
+          "name": "idx_workflow_runs_name_started",
+          "columns": [
+            "workflow_name",
+            "\"started_at\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_activity_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_activity_actor_created": {
+        "columns": {
+          "\"created_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_cron_runs_name_started": {
+        "columns": {
+          "\"started_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_feedback_signals_observed": {
+        "columns": {
+          "\"observed_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_feedback_signals_workflow": {
+        "columns": {
+          "\"observed_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workflow_runs_started_at": {
+        "columns": {
+          "\"started_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_workflow_runs_name_started": {
+        "columns": {
+          "\"started_at\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/server/drizzle/sqlite/meta/_journal.json
+++ b/apps/server/drizzle/sqlite/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1787040069970,
       "tag": "0001_backfill_repo_refs",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1787758571818,
+      "tag": "0002_aromatic_vector",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/scripts/lint-floating-promises.mjs
+++ b/apps/server/scripts/lint-floating-promises.mjs
@@ -46,9 +46,14 @@ import { join, resolve, relative } from "node:path";
 // the better code, but it changes the behaviour of a live streaming endpoint
 // and predates this gate by four months (21c6cb0, 2026-04-06). Fix it in a
 // change that is about SSE, not as a drive-by. Remove the entry when you do.
+//
+// NOTE: these are keyed by LINE NUMBER, so any edit that adds or removes lines
+// above them in `routes.ts` silently un-allowlists them and the gate fails
+// pointing at code the change never touched. Shifted by +2 in #206 (two added
+// imports). If that happens again, consider keying on the expression text.
 const ALLOWED = new Set([
-  "src/admin/routes.ts:452",
-  "src/admin/routes.ts:458",
+  "src/admin/routes.ts:454",
+  "src/admin/routes.ts:460",
 ]);
 
 const projectDirs = process.argv.slice(2);

--- a/apps/server/spec/10-state.md
+++ b/apps/server/spec/10-state.md
@@ -532,6 +532,14 @@ actor is a truer statement than the literal `"admin"` the `updated_by` columns
 fall back to. No FK because the join to `users` is the same additive enrichment
 #205 chose, so a row survives an actor who never logged into the dashboard.
 
+**Read surface.** `GET /admin/api/activity` (paginated, filterable by
+`actor` / `action` / `target` / `since`, envelope `{ activity, total, users }`)
+plus `GET /admin/api/activity/actions` for the filter dropdown. The dashboard's
+Activity tab and its per-run strip are both that one endpoint — the strip is
+`?target=workflow_run:<id>`. Deliberately NOT repo-scoped: `?repos=` on
+`/workflow-runs` is UI declutter rather than authorization, and an audit stream
+silently narrowed by team membership would mislead in a way a run list does not.
+
 Reads tie-break on `id`, which is minted in creation order
 (`activity-store.ts` → `creationOrderedId`, the same helper shape as
 `cron-run-store.ts`). Postgres has no `rowid`, and a merely arbitrary tiebreak

--- a/apps/server/spec/10-state.md
+++ b/apps/server/spec/10-state.md
@@ -27,7 +27,7 @@ into the resume state read by every dashboard query.
 ## State tables
 
 The schema is **declared in Drizzle**, not in DDL: `src/state/schema/sqlite.ts`
-is the source of truth for fifteen tables, with `src/state/schema/pg.ts` as its
+is the source of truth for sixteen tables, with `src/state/schema/pg.ts` as its
 name-parity Postgres mirror (see "Dialect posture" below). The per-table stores
 in `src/state/*-store.ts` operate on them; `src/state/db.ts` wires the stores
 together. All rows are append-only unless marked mutable. Migrations are
@@ -478,6 +478,65 @@ routes attribute an action to a real person. **Actor semantics:** a run's
 `triggered_by` is the ORIGINAL trigger; retry / cancel / approve actors land on
 the append-only `executions` ledger (and `workflow_approvals.responded_by`),
 never overwriting the run's origin value. See `src/state/user-store.ts`.
+
+### `activity_log`
+
+One row per **user-initiated action**, across the dashboard, CLI, Slack, GitHub
+and cron (issue #206). Append-only: never updated, never deleted.
+
+```sql
+CREATE TABLE activity_log (
+  id TEXT PRIMARY KEY,                  -- creation-ordered; see the tiebreak note
+  created_at TEXT NOT NULL,
+  actor_login TEXT,                     -- soft join to users.login; null without a verified login
+  actor_type TEXT,                      -- reuses TriggerActorType (#205)
+  action TEXT NOT NULL,                 -- the verb: login, cron.toggle, workflow.cancel, …
+  target_type TEXT,                     -- workflow_run | cron | workflow | repo | approval | pr | container
+  target_id TEXT,                       -- the bare id: a run id, a cron name, owner/repo
+  outcome TEXT NOT NULL,                -- ok | denied | error
+  detail TEXT                           -- small flat JSON summary; jsonb on Postgres
+);
+CREATE INDEX idx_activity_created ON activity_log(created_at DESC);
+CREATE INDEX idx_activity_actor_created ON activity_log(actor_login, created_at DESC);
+CREATE INDEX idx_activity_target ON activity_log(target_type, target_id);
+```
+
+**Why it exists.** #205 put a real actor on every run and execution, but the
+answer to "what has this person done?" was spread across five ledgers —
+`workflow_runs.triggered_by`, `executions`, `workflow_approvals.responded_by`,
+`cron_overrides.updated_by`, `workflow_overrides.updated_by` — and several
+actions (login, config edits, container kills, artifact edits) wrote to none of
+them. This is the chronological stream that answers it without a five-way join.
+
+**It complements #205's columns; it does not replace them.** `triggered_by`
+stays the hot-path per-run attribution the run detail view reads. This is the
+audit stream layered on top, joined to `users` on `login`.
+
+**Why not overload `executions`.** The same three reasons `cron_runs` did not
+(above): `executions` carries no column for an action that is not an agent
+invocation, its `success` flag is binary so `denied` has nowhere to live, and
+its `success = 0` population is dominated by DAG-cascade skips and quota
+deferrals that must stay `success = 0`.
+
+**Why only user-initiated actions.** A cron fan-out dispatches once per repo, so
+recording each as an action would make the dominant row source a thing no human
+did — the same confusion `cron_runs` avoids by keying on `cron_name` rather than
+the workflow. `workflow.trigger` is therefore written only for a human actor
+type (`github` / `slack` / `cli` / `admin`), and a cron fire is recorded once, at
+its cause, as `cron.fire`. The result grows more slowly than `workflow_runs`
+itself, which is what makes deferring a retention policy safe.
+
+**`actor_login` is nullable and has no foreign key.** Nullable because a
+password login and an auth-disabled instance carry no verified login — a null
+actor is a truer statement than the literal `"admin"` the `updated_by` columns
+fall back to. No FK because the join to `users` is the same additive enrichment
+#205 chose, so a row survives an actor who never logged into the dashboard.
+
+Reads tie-break on `id`, which is minted in creation order
+(`activity-store.ts` → `creationOrderedId`, the same helper shape as
+`cron-run-store.ts`). Postgres has no `rowid`, and a merely arbitrary tiebreak
+is not enough for a **paged** read: a page boundary falling inside a
+same-millisecond run of rows would skip or repeat them between pages.
 
 ### `messaging_sessions` + `messaging_messages`
 
@@ -1050,6 +1109,7 @@ precisely because of that.
 | `ApprovalStore` — `workflow_approvals` | `src/state/approval-store.ts` |
 | `CronRunStore` — `cron_runs`, one row per cron fire (issues #341/#327) | `src/state/cron-run-store.ts` |
 | `UserStore` — `users` identity + Slack/email matching | `src/state/user-store.ts` |
+| `ActivityStore` — `activity_log`, one row per user action (issue #206) | `src/state/activity-store.ts` |
 | `FeedbackStore` — `feedback_anchors` + `feedback_signals` (issue #255) | `src/state/feedback-store.ts` |
 | `TeamStore` — the four `github_team*` / `github_visibility_sync` tables (issue #169) | `src/state/team-store.ts` |
 | Lazy per-user team→repo resolver (budgets, fail-open, stale-while-revalidate) | `src/engine/github/team-visibility.ts` |

--- a/apps/server/src/activity.ts
+++ b/apps/server/src/activity.ts
@@ -1,0 +1,29 @@
+import { logger } from "./logging/logger.js";
+import type { ActivityEntry, StateDb } from "./state/db.js";
+
+const log = logger("activity");
+
+/**
+ * Append one activity row, BEST-EFFORT (issue #206).
+ *
+ * This is the entire best-effort contract, and it lives here rather than in
+ * `ActivityStore.record` on purpose: the store throws like any other store
+ * method, so a test can still observe a write failing. Swallowing inside the
+ * store would make "a logging failure never fails the action" unfalsifiable.
+ *
+ * The rule it enforces: **recording that something happened must never stop it
+ * from happening.** Same posture as #205's identity capture and every read in
+ * `pr-state.ts` — an audit trail is worth less than the action it describes.
+ *
+ * Lives at `src/` rather than under `admin/` because every layer writes to it:
+ * the admin routes, `dispatchWorkflow` in `index.ts`, the dispatcher's approval
+ * seam and the cron runner. `admin/activity.ts` adds the Hono-flavoured wrapper
+ * on top for the request-scoped case.
+ */
+export async function recordActivity(db: StateDb, entry: ActivityEntry): Promise<void> {
+  try {
+    await db.activity.record(entry);
+  } catch (err) {
+    log.warn("activity write failed", { err, action: entry.action, target: entry.targetId });
+  }
+}

--- a/apps/server/src/admin/activity.ts
+++ b/apps/server/src/admin/activity.ts
@@ -1,0 +1,27 @@
+import type { Context } from "hono";
+import { recordActivity } from "../activity.js";
+import type { ActivityEntry, StateDb, TriggerActorType } from "../state/db.js";
+import { actorFromContext, actorTypeFromContext } from "./auth.js";
+
+/**
+ * {@link recordActivity} with the actor filled in from the request — the
+ * request-scoped half of the activity seam (issue #206).
+ *
+ * `actorLogin` is left NULL when the session carries no verified login: a
+ * password login and an auth-disabled instance both produce that. Deliberately
+ * NOT defaulted to `"admin"` the way the `updated_by` columns are — in an audit
+ * stream `"admin"` reads as a person, and "we do not know who" is the truer
+ * statement. `actor_type` still records `admin`, so the row is not anonymous
+ * about HOW it happened, only about who.
+ */
+export async function recordActivityFor(
+  c: Context,
+  db: StateDb,
+  entry: Omit<ActivityEntry, "actorLogin" | "actorType"> & { actorType?: TriggerActorType },
+): Promise<void> {
+  await recordActivity(db, {
+    ...entry,
+    actorLogin: actorFromContext(c) ?? null,
+    actorType: entry.actorType ?? actorTypeFromContext(c) ?? null,
+  });
+}

--- a/apps/server/src/admin/auth.ts
+++ b/apps/server/src/admin/auth.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import type { Context, Next } from "hono";
+import type { TriggerActorType } from "../state/db.js";
 
 const TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
 
@@ -152,7 +153,10 @@ export function authMiddleware(enabled: boolean, secret: string) {
     }
     // Surface the verified identity to downstream routes (issue #205). The
     // single seam every actor-hardcoded route reads via {@link actorFromContext}.
-    c.set("actorLogin", decodeToken(token)?.login);
+    const decoded = decodeToken(token);
+    c.set("actorLogin", decoded?.login);
+    // How they authenticated, for the activity log's `actor_type` (issue #206).
+    c.set("actorMethod", decoded?.method);
     return next();
   };
 }
@@ -167,4 +171,20 @@ export function authMiddleware(enabled: boolean, secret: string) {
  */
 export function actorFromContext(c: Context): string | undefined {
   return c.get("actorLogin") as string | undefined;
+}
+
+/**
+ * How the current actor authenticated, as a {@link TriggerActorType} — the
+ * activity log's `actor_type` (issue #206).
+ *
+ * A `password` session maps to `admin`, not to a person: it carries no verified
+ * login, which is exactly why {@link actorFromContext} returns undefined
+ * alongside it. Undefined here means auth is disabled entirely.
+ */
+export function actorTypeFromContext(c: Context): TriggerActorType | undefined {
+  const method = c.get("actorMethod") as TokenPayload["method"] | undefined;
+  if (method === "github") return "github";
+  if (method === "slack") return "slack";
+  if (method === "password") return "admin";
+  return undefined;
 }

--- a/apps/server/src/admin/routes.ts
+++ b/apps/server/src/admin/routes.ts
@@ -1627,6 +1627,54 @@ export function createAdminRoutes(
     return c.json({ names: await db.runs.distinctNames() });
   });
 
+  // ── Activity log — the audit feed (issue #206) ────────────────────────────
+  //
+  // Deliberately NOT repo-scoped, unlike `/workflow-runs` and `/sessions`.
+  // Their `?repos=` is UI declutter rather than authorization (see the note at
+  // the top of `/me/repos`), and an audit stream silently filtered by which
+  // teams you happen to belong to would be misleading in a way a run list is
+  // not. Narrowing this one is a real authorization decision, not a copied
+  // query param.
+  app.get("/activity", async (c) => {
+    const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "50", 10) || 50, 1), 200);
+    const offset = Math.max(parseInt(c.req.query("offset") ?? "0", 10) || 0, 0);
+    // `<type>:<id>`, split on the FIRST colon — a target id can contain one
+    // (`repo:acme/widgets#7` does not, but `container:lastlight-sandbox-a:b`
+    // could), and the type never does.
+    const rawTarget = c.req.query("target") || undefined;
+    const sep = rawTarget?.indexOf(":") ?? -1;
+    const targetType = rawTarget ? (sep >= 0 ? rawTarget.slice(0, sep) : rawTarget) : undefined;
+    const targetId = rawTarget && sep >= 0 ? rawTarget.slice(sep + 1) : undefined;
+
+    const { activity, total } = await db.activity.list({
+      limit,
+      offset,
+      actor: c.req.query("actor") || undefined,
+      action: c.req.query("action") || undefined,
+      targetType,
+      targetId,
+      sinceIso: c.req.query("since") || undefined,
+    });
+
+    // Enrich from `users` for name + avatar, the way `GET /workflow-runs/:id`
+    // does for `triggered_by` (issue #205). Resolved ONCE per distinct login
+    // rather than per row: a page of 50 is routinely two or three people.
+    const logins = [...new Set(activity.map((a) => a.actorLogin).filter(Boolean))] as string[];
+    const users: Record<string, { login?: string; name?: string; avatarUrl?: string }> = {};
+    for (const login of logins) {
+      const user = await db.users.findByLogin(login);
+      if (user) users[login] = { login: user.login, name: user.name, avatarUrl: user.avatarUrl };
+    }
+
+    return c.json({ activity, total, users });
+  });
+
+  // The distinct verbs actually present, for the dashboard's filter dropdown —
+  // mirrors `/workflow-names` above.
+  app.get("/activity/actions", async (c) => {
+    return c.json({ actions: await db.activity.actions() });
+  });
+
   app.get("/workflow-runs/:id", async (c) => {
     const id = c.req.param("id");
     const run = await db.runs.getRun(id);

--- a/apps/server/src/admin/routes.ts
+++ b/apps/server/src/admin/routes.ts
@@ -101,6 +101,8 @@ import { BuildAssetStore, buildAssetIssueKey } from "../state/build-assets.js";
 import type { WorkflowApproval } from "../state/approval-store.js";
 import type { PublicConfigBundle, BuildAssetsLocation } from "../config/config.js";
 import { logger } from "../logging/logger.js";
+import { recordActivity } from "../activity.js";
+import { recordActivityFor } from "./activity.js";
 
 const log = logger("admin");
 const oauthLog = logger("oauth");
@@ -982,6 +984,16 @@ export function createAdminRoutes(
     const a = Buffer.from(body.password);
     const b = Buffer.from(config.adminPassword);
     const ok = a.length === b.length && timingSafeEqual(a, b);
+    // A failed password attempt is one of the few things an audit stream is
+    // unambiguously for. `actorType` is passed explicitly because there is no
+    // token yet — the context this route runs in carries no actor at all, and
+    // password login never learns a login.
+    await recordActivity(db, {
+      action: "login",
+      actorType: "admin",
+      outcome: ok ? "ok" : "denied",
+      detail: { method: "password" },
+    });
     if (!ok) {
       return c.json({ error: "invalid password" }, 401);
     }
@@ -1114,6 +1126,15 @@ export function createAdminRoutes(
       }
 
       const token = createToken(config.adminSecret, "slack", matchedLogin);
+      // `actorLogin` is the MATCHED GitHub login, or null when the email did not
+      // resolve to a `users` row — the same degradation #205 documents for the
+      // Slack connector, and the reason this column is nullable.
+      await recordActivity(db, {
+        action: "login",
+        actorLogin: matchedLogin ?? null,
+        actorType: "slack",
+        detail: { method: "slack", matched: !!matchedLogin },
+      });
       // Redirect to dashboard with token in URL; App.tsx strips it immediately.
       // Trailing slash matters: Vite serves the SPA with base "/admin/" so a
       // bare "/admin" 404s in dev. Production static serving accepts both.
@@ -1222,6 +1243,15 @@ export function createAdminRoutes(
           org: config.githubAllowedOrg!,
           memberStatus,
         });
+        // A rejected login names a real, verified GitHub identity — the one
+        // denial in here where we know exactly who was turned away.
+        await recordActivity(db, {
+          action: "login",
+          actorLogin: login,
+          actorType: "github",
+          outcome: "denied",
+          detail: { method: "github", reason: "not_org_member", org: config.githubAllowedOrg! },
+        });
         return fail("github_org");
       }
 
@@ -1271,6 +1301,12 @@ export function createAdminRoutes(
       // Carry the verified login in the token so actor-hardcoded routes
       // attribute to this person.
       const token = createToken(config.adminSecret, "github", login);
+      await recordActivity(db, {
+        action: "login",
+        actorLogin: login,
+        actorType: "github",
+        detail: { method: "github" },
+      });
       return c.redirect(`/admin/?token=${encodeURIComponent(token)}`);
     } catch (err: unknown) {
       oauthLog.error("GitHub OAuth exchange failed", { err });
@@ -1446,8 +1482,23 @@ export function createAdminRoutes(
           await db.executions.recordFinish(e.id, { success: false, error: "terminated via admin dashboard" });
         }
       }
+      await recordActivityFor(c, db, {
+        action: "container.kill",
+        targetType: "container",
+        targetId: name,
+      });
       return c.json({ killed: name });
     } catch (err: any) {
+      // The kill itself failed — record the attempt, since "someone tried to
+      // kill this and could not" is exactly the kind of thing an audit stream
+      // is read for.
+      await recordActivityFor(c, db, {
+        action: "container.kill",
+        targetType: "container",
+        targetId: name,
+        outcome: "error",
+        detail: { error: String(err?.message ?? err).slice(0, 200) },
+      });
       return c.json({ error: err.message }, 500);
     }
   });
@@ -1757,6 +1808,13 @@ export function createAdminRoutes(
         }
       }
     }
+    await recordActivityFor(c, db, {
+      action: "workflow.cancel",
+      targetType: "workflow_run",
+      targetId: id,
+      // The COUNT, not the names — `detail` is a summary, not a payload.
+      detail: { workflow: run.workflowName, killedContainers: killed.length },
+    });
     return c.json({ cancelled: id, killedContainers: killed, reapedWorkspace: reaped });
   });
 
@@ -1780,6 +1838,12 @@ export function createAdminRoutes(
     // atomically, so a second immediate retry click 400s on the status guard.
     config.retryWorkflow(run, actorFromContext(c) ?? "admin").catch((err) =>
       log.error("Retry failed", { id, err }));
+    await recordActivityFor(c, db, {
+      action: "workflow.retry",
+      targetType: "workflow_run",
+      targetId: id,
+      detail: { workflow: run.workflowName, from: run.status },
+    });
     return c.json({ retrying: id });
   });
 
@@ -1865,7 +1929,16 @@ export function createAdminRoutes(
     }
     const current = await db.isWorkflowEnabled(name);
     const next = !current;
-    await db.setWorkflowEnabled(name, next, "admin");
+    // `?? "admin"` matches cancel/retry/respond: the column is an existing wire
+    // contract the dashboard renders, so it keeps its literal fallback. The
+    // activity row does NOT — see recordActivityFor.
+    await db.setWorkflowEnabled(name, next, actorFromContext(c) ?? "admin");
+    await recordActivityFor(c, db, {
+      action: "workflow.toggle",
+      targetType: "workflow",
+      targetId: name,
+      detail: { enabled: next },
+    });
     return c.json({ name, enabled: next });
   });
 
@@ -2266,10 +2339,25 @@ export function createAdminRoutes(
       buildAssetStore.fileFor({ owner, repo, issueKey: key }, doc);
       const metadata = await computeArtifactMetadata(owner, repo, key, doc);
       if (!metadata.editable) {
+        // A refused edit is worth a row: the approval lock is exactly the kind
+        // of guard someone later asks "did anyone try to get around this?".
+        await recordActivityFor(c, db, {
+          action: "artifact.edit",
+          targetType: "repo",
+          targetId: `${owner}/${repo}`,
+          outcome: "denied",
+          detail: { key, doc, reason: "artifact_locked" },
+        });
         return c.json({ error: "artifact_locked", lock: metadata.lock }, 403);
       }
       const body = await c.req.text();
       buildAssetStore.write({ owner, repo, issueKey: key }, doc, body);
+      await recordActivityFor(c, db, {
+        action: "artifact.edit",
+        targetType: "repo",
+        targetId: `${owner}/${repo}`,
+        detail: { key, doc, bytes: body.length },
+      });
       return c.json({ ok: true });
     } catch (err: unknown) {
       return c.json({ error: err instanceof Error ? err.message : String(err) }, 400);
@@ -2362,6 +2450,16 @@ export function createAdminRoutes(
         });
       }
     }
+    await recordActivityFor(c, db, {
+      action: body.decision === "rejected" ? "approval.reject" : "approval.approve",
+      targetType: "approval",
+      targetId: id,
+      detail: {
+        gate: approval.gate,
+        workflowRunId: approval.workflowRunId,
+        ...(body.reason ? { reason: body.reason } : {}),
+      },
+    });
     return c.json({ status: body.decision });
   });
 
@@ -2508,7 +2606,16 @@ export function createAdminRoutes(
     const override = await db.getCronOverride(name);
     const currentlyEnabled = override ? override.enabled : true;
     const nextEnabled = !currentlyEnabled;
-    await db.setCronOverride(name, { enabled: nextEnabled, updatedBy: "admin" });
+    await db.setCronOverride(name, {
+      enabled: nextEnabled,
+      updatedBy: actorFromContext(c) ?? "admin",
+    });
+    await recordActivityFor(c, db, {
+      action: "cron.toggle",
+      targetType: "cron",
+      targetId: name,
+      detail: { enabled: nextEnabled },
+    });
     // Off is "off BY DEFAULT", not "unregistered" (issue #180): a managed repo
     // may opt itself back into a globally-off cron from its `.lastlight/`, and
     // that is resolved at TICK time — so the tick has to keep running. It just
@@ -2553,7 +2660,13 @@ export function createAdminRoutes(
       const msg = err instanceof Error ? err.message : String(err);
       return c.json({ error: `invalid schedule: ${msg}` }, 400);
     }
-    await db.setCronOverride(name, { schedule, updatedBy: "admin" });
+    await db.setCronOverride(name, { schedule, updatedBy: actorFromContext(c) ?? "admin" });
+    await recordActivityFor(c, db, {
+      action: "config.edit",
+      targetType: "cron",
+      targetId: name,
+      detail: { schedule },
+    });
     const override = await db.getCronOverride(name);
     if (override?.enabled !== false) {
       config.cronScheduler.update({
@@ -2575,6 +2688,12 @@ export function createAdminRoutes(
     const def = getCronWorkflows().find((d) => d.name === name);
     if (!def) return c.json({ error: `cron not found: ${name}` }, 404);
     await db.clearCronOverride(name);
+    await recordActivityFor(c, db, {
+      action: "config.edit",
+      targetType: "cron",
+      targetId: name,
+      detail: { cleared: true, schedule: def.schedule },
+    });
     const job = {
       name,
       schedule: def.schedule,
@@ -2598,7 +2717,7 @@ export function createAdminRoutes(
   // even for crons that aren't registered — disabled ones, or the polling crons
   // dropped when webhooks are live — which is exactly what manual testing needs.
   // Bypasses the scheduler's per-job overlap guard (acceptable for a manual fire).
-  app.post("/crons/:name/trigger", (c) => {
+  app.post("/crons/:name/trigger", async (c) => {
     const name = c.req.param("name");
     const def = getCronWorkflows().find((d) => d.name === name);
     if (!def) return c.json({ error: `cron not found: ${name}` }, 404);
@@ -2644,6 +2763,15 @@ export function createAdminRoutes(
       : config.triggerCron!(def.workflow!, context);
     fire.catch((err) => {
       log.error("Cron trigger failed", { name, err });
+    });
+    // The REQUEST, not the fire — `fire` is deliberately not awaited, and the
+    // fire itself writes its own `cron.fire` row from the runner. The pair is
+    // the point: a trigger that never produced a fire is the interesting case.
+    await recordActivityFor(c, db, {
+      action: "cron.trigger",
+      targetType: "cron",
+      targetId: name,
+      detail: def.handler ? { handler: def.handler } : { workflow: def.workflow ?? "" },
     });
     return c.json({ name, workflow: def.workflow, handler: def.handler, triggered: true });
   });
@@ -2751,6 +2879,20 @@ export function createAdminRoutes(
       // `retry-requested` row inside the gate, so the ask is parked and will be
       // honoured by the next event — a 200 with `dispatched: false`.
       const refused = !!(disposition.onHold || disposition.runInFlight || disposition.readDegraded);
+      await recordActivityFor(c, db, {
+        action: "pr.retry",
+        targetType: "pr",
+        targetId: `${repo}#${prNumber}`,
+        // A refusal is `denied`; a parked ask that a later event will honour
+        // still happened, so it is `ok` with `dispatched: false` in the detail.
+        outcome: refused ? "denied" : "ok",
+        detail: {
+          workflow: workflowName,
+          dispatched: false,
+          reason: String(disposition.reason ?? "").slice(0, 200),
+          ...(reason ? { note: reason } : {}),
+        },
+      });
       return c.json(
         {
           repo,
@@ -2783,6 +2925,19 @@ export function createAdminRoutes(
       log.error("retry failed", { workflow: workflowName, repo, prNumber, err });
     });
 
+    // The ASK. The run it starts writes its own `workflow.trigger` row from
+    // `dispatchWorkflow` — the same request/execution pair as cron.trigger and
+    // cron.fire, and worth keeping distinct because the two can disagree.
+    await recordActivityFor(c, db, {
+      action: "pr.retry",
+      targetType: "pr",
+      targetId: `${repo}#${prNumber}`,
+      detail: {
+        workflow: workflowName,
+        dispatched: true,
+        ...(reason ? { note: reason } : {}),
+      },
+    });
     return c.json({
       repo,
       prNumber,

--- a/apps/server/src/admin/routes.ts
+++ b/apps/server/src/admin/routes.ts
@@ -17,7 +17,7 @@ import {
   getContainerLogs,
   streamContainerLogs,
 } from "./docker.js";
-import { authMiddleware, createToken, verifyTokenForRefresh, decodeToken, actorFromContext } from "./auth.js";
+import { authMiddleware, createToken, verifyTokenForRefresh, decodeToken, actorFromContext, actorTypeFromContext } from "./auth.js";
 import { Cron } from "croner";
 import type { CronScheduler } from "../cron/scheduler.js";
 import {
@@ -2756,6 +2756,11 @@ export function createAdminRoutes(
       [CRON_NAME_KEY]: def.name,
       _cronSource: "manual",
       _cronActor: actor ?? null,
+      // …and HOW they authenticated. Without this the fire's own activity row
+      // could only guess, and guessed `admin` — so a GitHub-authenticated
+      // "Run now" wrote `cron.trigger` as `github` and its paired `cron.fire`
+      // as `admin`, two rows for one action disagreeing about the same person.
+      _cronActorType: actorTypeFromContext(c) ?? null,
       sender: actor,
     };
     const fire = def.handler

--- a/apps/server/src/cron/handlers.ts
+++ b/apps/server/src/cron/handlers.ts
@@ -46,6 +46,7 @@ import type { StateDb } from "../state/db.js";
 import { runRepoDigest, type RepoDigestDeps } from "./repo-digest.js";
 import { logger } from "../logging/logger.js";
 import { recordActivity } from "../activity.js";
+import { isTriggerActorType } from "../state/db.js";
 
 const log = logger("cron-handlers");
 
@@ -106,7 +107,15 @@ export function withLedger(db: StateDb, cronName: string, handler: CronHandler):
     // on which kind of cron it is looking at (issue #206).
     await recordActivity(db, {
       actorLogin: actor,
-      actorType: source === "manual" ? "admin" : "cron",
+      // Same rule as `runner.ts`: a manual fire carries how the presser
+      // authenticated, so the `cron.trigger` and `cron.fire` rows for one
+      // action cannot disagree about the same person.
+      actorType:
+        source === "manual"
+          ? isTriggerActorType(context._cronActorType)
+            ? context._cronActorType
+            : "admin"
+          : "cron",
       action: "cron.fire",
       targetType: "cron",
       targetId: cronName,

--- a/apps/server/src/cron/handlers.ts
+++ b/apps/server/src/cron/handlers.ts
@@ -45,6 +45,7 @@
 import type { StateDb } from "../state/db.js";
 import { runRepoDigest, type RepoDigestDeps } from "./repo-digest.js";
 import { logger } from "../logging/logger.js";
+import { recordActivity } from "../activity.js";
 
 const log = logger("cron-handlers");
 
@@ -99,6 +100,18 @@ export function withLedger(db: StateDb, cronName: string, handler: CronHandler):
     // what lets `GET /crons` and the scheduler's alert read ONE ledger and stop
     // branching on which kind of cron they are looking at.
     const id = await db.cronRuns.start({ cronName, handler: cronName, source, actor });
+
+    // One activity row per fire, same shape a `workflow:` cron writes from
+    // `runner.ts` — so the audit stream, like the ledger above, does not branch
+    // on which kind of cron it is looking at (issue #206).
+    await recordActivity(db, {
+      actorLogin: actor,
+      actorType: source === "manual" ? "admin" : "cron",
+      action: "cron.fire",
+      targetType: "cron",
+      targetId: cronName,
+      detail: { source, handler: cronName },
+    });
 
     try {
       await handler(context);

--- a/apps/server/src/cron/runner.ts
+++ b/apps/server/src/cron/runner.ts
@@ -22,12 +22,15 @@ import { logger } from "../logging/logger.js";
 import { recordCronFire, withSpan } from "../telemetry/index.js";
 import type { CronRunStatus } from "../state/cron-run-store.js";
 import { recordActivity } from "../activity.js";
+import { isTriggerActorType } from "../state/db.js";
 
 const log = logger("cron");
 
 /** Context keys the fire path consumes and strips before dispatching. */
 const CRON_SOURCE_KEY = "_cronSource";
 const CRON_ACTOR_KEY = "_cronActor";
+/** How the "Run now" presser authenticated, so the fire's row agrees with the trigger's. */
+const CRON_ACTOR_TYPE_KEY = "_cronActorType";
 
 export type CronDiscoverer = (
   repos: string[],
@@ -102,7 +105,12 @@ export function makeCronRunner(deps: CronRunnerDeps): WorkflowRunner {
     // without this they ride into every dispatched run's context. A dispatched
     // context must stay byte-for-byte what it was before this ledger existed
     // (`fanout.ts` makes the same promise about its own keys).
-    const { [CRON_SOURCE_KEY]: rawSource, [CRON_ACTOR_KEY]: rawActor, ...context } = rawContext;
+    const {
+      [CRON_SOURCE_KEY]: rawSource,
+      [CRON_ACTOR_KEY]: rawActor,
+      [CRON_ACTOR_TYPE_KEY]: rawActorType,
+      ...context
+    } = rawContext;
 
     // No cron name means a caller that built its own context (an eval driver,
     // a direct API call). `resolveCronRepos` already treats that as "use the
@@ -127,7 +135,11 @@ export function makeCronRunner(deps: CronRunnerDeps): WorkflowRunner {
     // login of whoever pressed "Run now".
     await recordActivity(db, {
       actorLogin: actor,
-      actorType: source === "manual" ? "admin" : "cron",
+      // A scheduled fire has no human actor. A MANUAL one carries how the
+      // presser authenticated, threaded from the trigger route — falling back
+      // to `admin` only when that is genuinely unknown (an older context, or a
+      // password session, which is what `admin` actually means).
+      actorType: source === "manual" ? (isTriggerActorType(rawActorType) ? rawActorType : "admin") : "cron",
       action: "cron.fire",
       targetType: "cron",
       targetId: cronName,

--- a/apps/server/src/cron/runner.ts
+++ b/apps/server/src/cron/runner.ts
@@ -21,6 +21,7 @@ import { CRON_GLOBALLY_ENABLED_KEY, CRON_NAME_KEY, resolveCronRepos } from "./re
 import { logger } from "../logging/logger.js";
 import { recordCronFire, withSpan } from "../telemetry/index.js";
 import type { CronRunStatus } from "../state/cron-run-store.js";
+import { recordActivity } from "../activity.js";
 
 const log = logger("cron");
 
@@ -117,6 +118,21 @@ export function makeCronRunner(deps: CronRunnerDeps): WorkflowRunner {
     const actor = typeof rawActor === "string" ? rawActor : null;
 
     const id = await db.cronRuns.start({ cronName, workflow: workflowName, source, actor });
+
+    // The activity log's ONE row for this fire (issue #206). The fan-out below
+    // may dispatch a run per repo, and those dispatches deliberately write no
+    // `workflow.trigger` row — a fan-out is one operational event, not N user
+    // actions, the same reason this ledger is keyed on the cron rather than the
+    // workflow. A scheduled fire has no human actor; a manual one carries the
+    // login of whoever pressed "Run now".
+    await recordActivity(db, {
+      actorLogin: actor,
+      actorType: source === "manual" ? "admin" : "cron",
+      action: "cron.fire",
+      targetType: "cron",
+      targetId: cronName,
+      detail: { source, workflow: workflowName },
+    });
 
     let counts: FireCounts = {
       reposEligible: null,

--- a/apps/server/src/engine/dispatcher.ts
+++ b/apps/server/src/engine/dispatcher.ts
@@ -43,6 +43,7 @@ import {
   type EscalationDeps,
 } from "./pr-escalation.js";
 import { logger } from "../logging/logger.js";
+import { recordActivity } from "../activity.js";
 
 const eventLog = logger("event");
 const dispatchLog = logger("dispatch");
@@ -1077,6 +1078,27 @@ async function handleApprovalResponse(
       `Rejected by ${sender}. Build cycle aborted.${reason ? ` Reason: ${reason}` : ""}`,
     );
   }
+
+  // The activity log's Slack + GitHub approval seam (issue #206). BOTH external
+  // routes land here — a Slack button click and a `@bot approve` comment are
+  // routed to `approval-response` alike — so one call covers them, complementing
+  // the dashboard's own route in `admin/routes.ts`.
+  //
+  // Placed after the branches rather than inside them: every path above that
+  // reaches here actually resolved the gate, and the early `!approval` return
+  // deliberately writes nothing, because nothing was resolved.
+  await recordActivity(deps.db, {
+    actorLogin: sender === "unknown" ? null : sender,
+    actorType: envelope.type === "message" ? "slack" : "github",
+    action: decision === "rejected" ? "approval.reject" : "approval.approve",
+    targetType: "approval",
+    targetId: approval.id,
+    detail: {
+      gate: approval.gate,
+      workflowRunId: approval.workflowRunId,
+      ...(reason ? { reason } : {}),
+    },
+  });
 
   return handled;
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -48,6 +48,7 @@ import { artifactStore } from "./sandbox/artifact-store.js";
 import { writeEgressFirewallConfigs, writeOtelCollectorConfig } from "./sandbox/egress-firewall-config.js";
 import { initTelemetry, shutdownTelemetry } from "./telemetry/index.js";
 import { authMiddleware, authIsEnabled, actorFromContext } from "./admin/auth.js";
+import { recordActivity } from "./activity.js";
 import { readPackageVersion } from "./admin/version.js";
 import { GitHubClient } from "./engine/github/github.js";
 import { setInstallationRepos, isManagedRepo, unmanagedReposInContext } from "./managed-repos.js";
@@ -1134,6 +1135,30 @@ async function main() {
         // what makes it a projection of run state rather than of an in-memory
         // promise, and it is why every terminal path resolves it for free.
         await bindReviewCheck(runId);
+        // The activity log's one workflow seam (issue #206). Here, rather than
+        // at the top of dispatchWorkflow, because this fires only once the run
+        // ROW exists — so every guard has passed and there is a real target to
+        // point at.
+        //
+        // Gated on the actor type: a cron fan-out dispatches once PER REPO, and
+        // those dispatches are not user actions. Logging them would make the
+        // dominant row source a thing no human did, and would bury the actions
+        // somebody actually took. The fire is recorded once, at its cause, as
+        // `cron.fire` from the runner — the same reason `cron_runs` keys on the
+        // cron rather than the workflow (spec/10-state.md → `cron_runs`).
+        if (triggerActorType !== "cron" && triggerActorType !== "system") {
+          await recordActivity(db, {
+            actorLogin: triggeredBy ?? null,
+            actorType: triggerActorType,
+            action: "workflow.trigger",
+            targetType: "workflow_run",
+            targetId: runId,
+            detail: {
+              workflow: workflowName,
+              ...(repoStr ? { repo: repoStr } : {}),
+            },
+          });
+        }
         if (onRunStart) await onRunStart(runId);
       },
     };

--- a/apps/server/src/state/CLAUDE.md
+++ b/apps/server/src/state/CLAUDE.md
@@ -1,7 +1,8 @@
 # State layer — schema, migrations, and the two dialects
 
-This is the harness's own database: fifteen tables holding workflow runs,
-executions, approvals, cron history, users, chat sessions and feedback signals.
+This is the harness's own database: sixteen tables holding workflow runs,
+executions, approvals, cron history, users, chat sessions, feedback signals and
+the activity log.
 It is written **once** and runs on **two dialects** — SQLite (via libsql) by
 default, Postgres (node-postgres or Neon) when `DATABASE_URL` says so. Both are
 supported production stores.
@@ -37,6 +38,7 @@ and the PGlite leg replays the entire behavioural suite against real Postgres.
 | `data-migrate.ts` | One-way SQLite → Postgres row copy, FK-ordered and batched. `TABLE_ORDER` is the FK order; the coverage check is what stops a sixteenth table being silently skipped. |
 | `state-cli.ts` | The `lastlight-state` bin (`check` / `migrate`) shipped in the agent image — what `lastlight server db` runs inside the container, since the CLI may never gain an edge to core. |
 | `*-store.ts` | One store class per table, over one shared client. Each destructures its tables from `tablesOf(client)`. |
+| `activity-store.ts` | The `activity_log` audit stream (issue #206) — one row per user-initiated action, append-only. Complements #205's per-run actor columns rather than replacing them. |
 | `repo-ref.ts` | The single expression of the `(owner, BARE repo)` ↔ `owner/repo` join. |
 
 Generated migrations live **outside** `src/`, in
@@ -132,13 +134,28 @@ process.
 
 ### 6. If you added a table
 
-Three places do not update themselves:
+Six places do not update themselves. The first three fail loudly; the rest are
+hardcoded counts that fail as an unhelpful off-by-one, so know them in advance:
 
 1. **`data-migrate.ts`'s `TABLE_ORDER`** — the SQLite→Postgres copy refuses to
    start if a schema export is missing from it, so this fails loudly rather than
    losing data. Place it after anything it references by foreign key.
 2. **`db.ts`** — wire the store in.
 3. **`spec/10-state.md`** — the table inventory and the count.
+4. **`tests/state/schema-equivalence.test.ts`** — add the table to
+   `POST_BASELINE_TABLES` (plus its named indexes to `POST_BASELINE_INDEXES`),
+   and bump `MIGRATION_COUNT`. **Do not add it to `LEGACY_TABLES`**: that list is
+   the pre-Drizzle production shape, and the whole point of the first test is
+   that the baseline no-ops over it. A new table is a *difference* between
+   `before` and `after`, which is why those two lists exist separately at all.
+5. **`tests/state/schema-parity.test.ts`** — the `covers all N tables` count.
+6. **`tests/state/data-migrate.test.ts`** — two counts (`TABLE_ORDER` length and
+   `result.tables` length), and ideally a row in `seed()` so the copy is actually
+   exercised for the new table rather than merely counted.
+
+`schema-parity.test.ts` otherwise derives its table list from the schema
+exports, so the per-column and per-index parity checks cover a new table for
+free once both declarations exist.
 
 ## Why `db.pg-server.test.ts` exists
 

--- a/apps/server/src/state/CLAUDE.md
+++ b/apps/server/src/state/CLAUDE.md
@@ -134,28 +134,35 @@ process.
 
 ### 6. If you added a table
 
-Six places do not update themselves. The first three fail loudly; the rest are
-hardcoded counts that fail as an unhelpful off-by-one, so know them in advance:
+Three places do not update themselves, and all three fail loudly:
 
 1. **`data-migrate.ts`'s `TABLE_ORDER`** — the SQLite→Postgres copy refuses to
    start if a schema export is missing from it, so this fails loudly rather than
    losing data. Place it after anything it references by foreign key.
 2. **`db.ts`** — wire the store in.
 3. **`spec/10-state.md`** — the table inventory and the count.
-4. **`tests/state/schema-equivalence.test.ts`** — add the table to
-   `POST_BASELINE_TABLES` (plus its named indexes to `POST_BASELINE_INDEXES`),
-   and bump `MIGRATION_COUNT`. **Do not add it to `LEGACY_TABLES`**: that list is
-   the pre-Drizzle production shape, and the whole point of the first test is
-   that the baseline no-ops over it. A new table is a *difference* between
-   `before` and `after`, which is why those two lists exist separately at all.
-5. **`tests/state/schema-parity.test.ts`** — the `covers all N tables` count.
-6. **`tests/state/data-migrate.test.ts`** — two counts (`TABLE_ORDER` length and
-   `result.tables` length), and ideally a row in `seed()` so the copy is actually
-   exercised for the new table rather than merely counted.
 
-`schema-parity.test.ts` otherwise derives its table list from the schema
-exports, so the per-column and per-index parity checks cover a new table for
-free once both declarations exist.
+Plus **`MIGRATION_COUNT`** in `tests/state/schema-equivalence.test.ts`, since
+adding a table means adding a migration. That one is deliberately not derived
+from the journal — see its comment.
+
+**The test suite otherwise learns about a new table by itself**, and that is a
+property worth preserving rather than a coincidence:
+
+- `schema-parity.test.ts` derives its table list from the schema exports, so
+  every per-column and per-index parity check covers a new table for free.
+- `schema-equivalence.test.ts` applies the **baseline alone** when it asserts
+  "nothing changed", then checks the full migration set against the tables
+  `schema/sqlite.ts` declares. So later migrations are free to add things
+  without the test needing a list of what they were allowed to add.
+- `data-migrate.test.ts` leans on `assertCoversEveryTable()`, which already
+  checks both directions (missing from `TABLE_ORDER`, and stale in it).
+
+If you find yourself adding a table name or a count to a test, check whether the
+assertion above it already proves the thing — several used to, and the counts
+were removed in #206 for exactly that reason. Do add a row to `data-migrate`'s
+`seed()` though: that one is not bookkeeping, it is what makes the sqlite→pg
+copy actually exercise your columns instead of merely counting them.
 
 ## Why `db.pg-server.test.ts` exists
 

--- a/apps/server/src/state/activity-store.ts
+++ b/apps/server/src/state/activity-store.ts
@@ -1,0 +1,240 @@
+import { randomUUID } from "crypto";
+import { and, asc, count, desc, eq, gte, type SQL } from "drizzle-orm";
+import { nullsToUndefined, tablesOf, type StateClient, type StateTables } from "./client.js";
+import type { TriggerActorType } from "./user-store.js";
+
+/**
+ * A lexicographically-sortable row id: a fixed-width millisecond stamp, a
+ * per-process counter, then a uuid.
+ *
+ * `created_at` has millisecond resolution, so rows written in the same tick tie
+ * — and this table's whole purpose is a chronological read. Under sqlite the
+ * tiebreak would have been `rowid` (INSERTION ORDER), which PostgreSQL has no
+ * equivalent of; a plain `randomUUID()` is a total order but an ARBITRARY one,
+ * and arbitrary is not good enough for a PAGED read. A page boundary landing
+ * inside a same-millisecond tie under one ordering and outside it under
+ * another silently skips or repeats rows between page 1 and page 2.
+ *
+ * Same reasoning, and the same shape, as `cron-run-store.ts` — see its copy of
+ * this comment for the failure it was written against.
+ */
+let idSeq = 0;
+function creationOrderedId(): string {
+  const stamp = Date.now().toString(16).padStart(12, "0");
+  idSeq = (idSeq + 1) & 0xffffff;
+  return `${stamp}-${idSeq.toString(16).padStart(6, "0")}-${randomUUID()}`;
+}
+
+/**
+ * The verb vocabulary (issue #206). A closed union on purpose: these strings
+ * become data, so a typo at a call site should be a compile error rather than a
+ * row nobody can filter for. Adding a verb is a deliberate edit here.
+ */
+export const ACTIVITY_ACTIONS = [
+  "login",
+  "workflow.trigger",
+  "workflow.retry",
+  "workflow.cancel",
+  "workflow.toggle",
+  "approval.approve",
+  "approval.reject",
+  "cron.fire",
+  "cron.trigger",
+  "cron.toggle",
+  "config.edit",
+  "container.kill",
+  "artifact.edit",
+  "pr.retry",
+] as const;
+
+export type ActivityAction = (typeof ACTIVITY_ACTIONS)[number];
+
+/** Did the action happen, get refused, or blow up. */
+export const ACTIVITY_OUTCOMES = ["ok", "denied", "error"] as const;
+
+export type ActivityOutcome = (typeof ACTIVITY_OUTCOMES)[number];
+
+/**
+ * A short, flat summary — the new value of a toggle, the schedule that was set.
+ * Deliberately NOT a payload: no request bodies, no prompt text, no tokens.
+ * See the PII non-goal in `docs/plans/activity-log/README.md`.
+ */
+export type ActivityDetail = Record<string, string | number | boolean>;
+
+/**
+ * One recorded action. `actorLogin` is absent when the session carries no
+ * verified login — password logins and auth-disabled instances both produce
+ * that, and a null actor is a truer statement than the literal `"admin"` the
+ * `updated_by` columns fall back to.
+ */
+export interface ActivityRecord {
+  id: string;
+  createdAt: string;
+  actorLogin?: string;
+  actorType?: TriggerActorType;
+  action: ActivityAction;
+  /** `workflow_run` | `cron` | `workflow` | `repo` | `approval` | `pr` | `container`. */
+  targetType?: string;
+  /** The bare identifier — a run id, a cron name, `owner/repo`, `owner/repo#7`. */
+  targetId?: string;
+  outcome: ActivityOutcome;
+  detail?: ActivityDetail;
+}
+
+/** What a writer supplies. `id` and `createdAt` are minted here, never passed in. */
+export interface ActivityEntry {
+  actorLogin?: string | null;
+  actorType?: TriggerActorType | null;
+  action: ActivityAction;
+  targetType?: string | null;
+  targetId?: string | null;
+  /** Defaults to `ok` — the overwhelmingly common case. */
+  outcome?: ActivityOutcome;
+  detail?: ActivityDetail | null;
+}
+
+export interface ActivityListOptions {
+  limit?: number;
+  offset?: number;
+  /** Exact `actor_login`. */
+  actor?: string;
+  /** Exact `action` verb. */
+  action?: string;
+  targetType?: string;
+  targetId?: string;
+  /** `created_at >= sinceIso`. */
+  sinceIso?: string;
+}
+
+/** The row shape the builder returns for this table, before normalization. */
+type ActivityRow = StateTables["activityLog"]["$inferSelect"];
+
+/**
+ * Owns the `activity_log` ledger — one row per user-initiated action, across
+ * the dashboard, CLI, Slack, GitHub and cron (issue #206).
+ *
+ * COMPLEMENTS #205's per-run actor columns rather than replacing them:
+ * `workflow_runs.triggered_by` stays the hot-path attribution a run's detail
+ * view reads, and this is the cross-cutting stream that answers "what has this
+ * person done?" without joining five ledgers.
+ *
+ * Append-only. There is no update and no delete, by design — an audit row that
+ * can be rewritten is not evidence of anything.
+ *
+ * Pure single-table CRUD: it opens no transaction and takes no `dbc`, so every
+ * method runs against the root client.
+ */
+export class ActivityStore {
+  /**
+   * Table objects for THIS client's dialect. Every method destructures what it
+   * needs off this instead of importing from `schema/sqlite.js` — see
+   * `client.ts` → {@link tablesOf} for why the cast alone cannot do it.
+   */
+  private readonly t: StateTables;
+
+  constructor(private client: StateClient) {
+    this.t = tablesOf(client);
+  }
+
+  /**
+   * Append one row.
+   *
+   * `createdAt` is stamped here rather than accepted, so no caller can supply a
+   * clock and no two writers can disagree about what "now" was.
+   *
+   * This throws on a store failure like any other method — the best-effort
+   * contract (#206: "a store failure never fails the underlying action") lives
+   * one level up, in `recordActivity()`, so that a test CAN still assert this
+   * rejects.
+   */
+  async record(entry: ActivityEntry): Promise<string> {
+    const { activityLog } = this.t;
+    const id = creationOrderedId();
+    await this.client.insert(activityLog).values({
+      id,
+      createdAt: new Date().toISOString(),
+      actorLogin: entry.actorLogin ?? null,
+      actorType: entry.actorType ?? null,
+      action: entry.action,
+      targetType: entry.targetType ?? null,
+      targetId: entry.targetId ?? null,
+      outcome: entry.outcome ?? "ok",
+      detail: entry.detail ?? null,
+    });
+    return id;
+  }
+
+  /**
+   * A page of the feed, newest first, plus the post-filter total so the caller
+   * knows how many remain.
+   *
+   * The `desc(id)` tiebreak is load-bearing, not decoration: without it a page
+   * boundary falling inside a same-millisecond run of rows skips or repeats
+   * them. See {@link creationOrderedId}.
+   */
+  async list(
+    opts: ActivityListOptions = {},
+  ): Promise<{ activity: ActivityRecord[]; total: number }> {
+    const { activityLog } = this.t;
+    const limit = opts.limit ?? 50;
+    const offset = opts.offset ?? 0;
+
+    const where: SQL[] = [];
+    if (opts.actor) where.push(eq(activityLog.actorLogin, opts.actor));
+    if (opts.action) where.push(eq(activityLog.action, opts.action as ActivityAction));
+    if (opts.targetType) where.push(eq(activityLog.targetType, opts.targetType));
+    if (opts.targetId) where.push(eq(activityLog.targetId, opts.targetId));
+    if (opts.sinceIso) where.push(gte(activityLog.createdAt, opts.sinceIso));
+    const whereClause = where.length > 0 ? and(...where) : undefined;
+
+    const [counted] = await this.client
+      .select({ c: count() })
+      .from(activityLog)
+      .where(whereClause);
+
+    // Every column here is small by construction (`detail` is a flat summary,
+    // not a payload), so unlike `WorkflowRunStore.list` this needs no explicit
+    // projection to keep a page cheap.
+    const page = await this.client
+      .select()
+      .from(activityLog)
+      .where(whereClause)
+      .orderBy(desc(activityLog.createdAt), desc(activityLog.id))
+      .limit(limit)
+      .offset(offset);
+
+    return { activity: page.map(deserialize), total: counted?.c ?? 0 };
+  }
+
+  /**
+   * The distinct verbs actually present, for the dashboard's filter dropdown.
+   *
+   * Read from the data rather than returned from {@link ACTIVITY_ACTIONS} so
+   * the dropdown offers only filters that can match something — and so a row
+   * written by an older deployment whose verb has since been retired still
+   * shows up as filterable.
+   */
+  async actions(): Promise<string[]> {
+    const { activityLog } = this.t;
+    const rows = await this.client
+      .selectDistinct({ action: activityLog.action })
+      .from(activityLog)
+      .orderBy(asc(activityLog.action));
+    return rows.map((r) => r.action);
+  }
+}
+
+function deserialize(row: ActivityRow): ActivityRecord {
+  const r = nullsToUndefined(row);
+  return {
+    id: r.id,
+    createdAt: r.createdAt,
+    actorLogin: r.actorLogin,
+    actorType: r.actorType,
+    action: r.action,
+    targetType: r.targetType,
+    targetId: r.targetId,
+    outcome: r.outcome,
+    detail: r.detail,
+  };
+}

--- a/apps/server/src/state/data-migrate.ts
+++ b/apps/server/src/state/data-migrate.ts
@@ -66,6 +66,9 @@ export const TABLE_ORDER: readonly TableSpec[] = [
   { key: "cronRuns", orderBy: ["id"] },
   { key: "workflowOverrides", orderBy: ["name"] },
   { key: "users", orderBy: ["id"] },
+  // No foreign key — `actor_login` is a SOFT join to `users.login` — but placed
+  // after `users` to match how it reads.
+  { key: "activityLog", orderBy: ["id"] },
   { key: "feedbackAnchors", orderBy: ["id"] },
   { key: "feedbackSignals", orderBy: ["id"] },
   { key: "githubTeams", orderBy: ["org", "slug"] },

--- a/apps/server/src/state/db.ts
+++ b/apps/server/src/state/db.ts
@@ -16,6 +16,7 @@ import {
 } from "./client.js";
 import { ExecutionStore } from "./execution-store.js";
 import { CronRunStore } from "./cron-run-store.js";
+import { ActivityStore } from "./activity-store.js";
 import { ApprovalStore } from "./approval-store.js";
 import { WorkflowRunStore } from "./workflow-run-store.js";
 import { UserStore } from "./user-store.js";
@@ -32,6 +33,14 @@ export type { WorkflowApproval } from "./approval-store.js";
 export type { WorkflowRun, PhaseHistoryEntry, PhaseMarker } from "./workflow-run-store.js";
 export type { User, TriggerActorType } from "./user-store.js";
 export type { CronRunRecord, CronRunSource, CronRunStatus } from "./cron-run-store.js";
+export type {
+  ActivityAction,
+  ActivityDetail,
+  ActivityEntry,
+  ActivityListOptions,
+  ActivityOutcome,
+  ActivityRecord,
+} from "./activity-store.js";
 export type {
   ResolvedTeam,
   CachedVisibility,
@@ -54,6 +63,7 @@ export { UserStore, TRIGGER_ACTOR_TYPES, isTriggerActorType } from "./user-store
 export { TeamStore } from "./team-store.js";
 export { FeedbackStore } from "./feedback-store.js";
 export { CronRunStore } from "./cron-run-store.js";
+export { ActivityStore, ACTIVITY_ACTIONS, ACTIVITY_OUTCOMES } from "./activity-store.js";
 
 const DEFAULT_DB_PATH = "lastlight.db";
 
@@ -135,6 +145,12 @@ export class StateDb {
    * `workflow_runs` and no `executions` row.
    */
   readonly cronRuns: CronRunStore;
+  /**
+   * One row per user-initiated action, across every surface (issue #206). The
+   * audit stream layered on top of #205's per-run actor columns — which stay
+   * where they are as the hot-path attribution.
+   */
+  readonly activity: ActivityStore;
 
   /**
    * Table objects for THIS client's dialect. Every method destructures what it
@@ -162,6 +178,7 @@ export class StateDb {
     this.teams = new TeamStore(_client, { serialize });
     this.feedback = new FeedbackStore(_client);
     this.cronRuns = new CronRunStore(_client);
+    this.activity = new ActivityStore(_client);
   }
 
   /**

--- a/apps/server/src/state/schema/pg.ts
+++ b/apps/server/src/state/schema/pg.ts
@@ -41,6 +41,12 @@ import {
 // The same origin modules `sqlite.ts` imports these from — it does not
 // re-export them, and neither does this file. Type-only, so no runtime edge.
 import type { ExtensionStatusMap, SkillsStatus } from "lastlight-workflow-engine";
+import type {
+  ActivityAction,
+  ActivityDetail,
+  ActivityOutcome,
+} from "../activity-store.js";
+import type { TriggerActorType } from "../user-store.js";
 import type { PhaseHistoryEntry } from "../workflow-run-store.js";
 
 /** @see sqlite.ts → `executions` */
@@ -206,6 +212,27 @@ export const users = pgTable(
     index("idx_users_login").on(t.login),
     index("idx_users_email").on(t.email),
     index("idx_users_slack").on(t.slackUserId),
+  ],
+);
+
+/** @see sqlite.ts → `activityLog` */
+export const activityLog = pgTable(
+  "activity_log",
+  {
+    id: text("id").primaryKey(),
+    createdAt: text("created_at").notNull(),
+    actorLogin: text("actor_login"),
+    actorType: text("actor_type").$type<TriggerActorType>(),
+    action: text("action").notNull().$type<ActivityAction>(),
+    targetType: text("target_type"),
+    targetId: text("target_id"),
+    outcome: text("outcome").notNull().$type<ActivityOutcome>(),
+    detail: jsonb("detail").$type<ActivityDetail>(),
+  },
+  (t) => [
+    index("idx_activity_created").on(t.createdAt.desc()),
+    index("idx_activity_actor_created").on(t.actorLogin, t.createdAt.desc()),
+    index("idx_activity_target").on(t.targetType, t.targetId),
   ],
 );
 

--- a/apps/server/src/state/schema/sqlite.ts
+++ b/apps/server/src/state/schema/sqlite.ts
@@ -43,6 +43,12 @@ import {
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 import type { ExtensionStatusMap, SkillsStatus } from "lastlight-workflow-engine";
+import type {
+  ActivityAction,
+  ActivityDetail,
+  ActivityOutcome,
+} from "../activity-store.js";
+import type { TriggerActorType } from "../user-store.js";
 import type { PhaseHistoryEntry } from "../workflow-run-store.js";
 
 /**
@@ -249,6 +255,41 @@ export const users = sqliteTable(
     index("idx_users_login").on(t.login),
     index("idx_users_email").on(t.email),
     index("idx_users_slack").on(t.slackUserId),
+  ],
+);
+
+/**
+ * The cross-cutting audit stream (issue #206) — one row per user-initiated
+ * action, across the dashboard, CLI, Slack, GitHub and cron.
+ *
+ * COMPLEMENTS the per-run actor columns #205 put on `workflow_runs` and
+ * `executions`; it does not replace them. Those stay the hot-path attribution
+ * a run's detail view reads, and this is the chronological stream that answers
+ * "what has this person done?" without joining five ledgers.
+ *
+ * `actor_login` is free text soft-joined to `users.login`, deliberately WITHOUT
+ * a foreign key — the same additive-enrichment choice #205 made, so a row
+ * survives an actor who never logged into the dashboard. It is nullable
+ * because a password login carries no verified login to record.
+ */
+export const activityLog = sqliteTable(
+  "activity_log",
+  {
+    id: text("id").primaryKey(),
+    createdAt: text("created_at").notNull(),
+    actorLogin: text("actor_login"),
+    actorType: text("actor_type").$type<TriggerActorType>(),
+    action: text("action").notNull().$type<ActivityAction>(),
+    // Null together, for an action with no target — `login` is the only one.
+    targetType: text("target_type"),
+    targetId: text("target_id"),
+    outcome: text("outcome").notNull().$type<ActivityOutcome>(),
+    detail: text("detail", { mode: "json" }).$type<ActivityDetail>(),
+  },
+  (t) => [
+    index("idx_activity_created").on(sql`${t.createdAt} DESC`),
+    index("idx_activity_actor_created").on(t.actorLogin, sql`${t.createdAt} DESC`),
+    index("idx_activity_target").on(t.targetType, t.targetId),
   ],
 );
 

--- a/apps/server/tests/admin/activity-read.test.ts
+++ b/apps/server/tests/admin/activity-read.test.ts
@@ -1,0 +1,217 @@
+/**
+ * The activity log's READ side (issue #206): the admin endpoint, and the
+ * dashboard's hand-mirrored copy of its wire type.
+ *
+ * The mirror pin is the same technique `dashboard-config-mirror.test.ts` uses,
+ * and exists for the same reason: `apps/server/dashboard/` has no import edge
+ * to core, so `ActivityRecord` is hand-typed there. That copy drifted once
+ * before — for the repo config — and hid three blocks for a release, because
+ * nothing failed when it stopped matching. Read as TEXT, because the SPA is
+ * not part of the server's TS program and the point is a source-level fact.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("#src/logging/logger.js", () => {
+  const noopLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: () => noopLogger,
+  };
+  return { logger: () => noopLogger };
+});
+
+vi.mock("#src/admin/docker.js", () => ({
+  listRunningContainers: vi.fn(async () => []),
+  killContainer: vi.fn(async () => {}),
+  getContainerStats: vi.fn(async () => []),
+  getHostStats: vi.fn(async () => null),
+}));
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import { createAdminRoutes, type AdminConfig } from "#src/admin/routes.js";
+import { StateDb } from "#src/state/db.js";
+import { ACTIVITY_ACTIONS, ACTIVITY_OUTCOMES } from "#src/state/db.js";
+import type { SessionSource } from "#src/admin/sessions.js";
+import {
+  setRuntimeConfig,
+  resetRuntimeConfigForTests,
+  type LastLightConfig,
+} from "#src/config/config.js";
+import { makeTestDb } from "../helpers/state-db.js";
+
+const DASHBOARD = join(import.meta.dirname, "../../dashboard/src");
+
+let db: StateDb;
+let app: ReturnType<typeof createAdminRoutes>;
+
+const emptySessions = {
+  listSessionIds: () => [],
+  exists: () => false,
+  getSessionMeta: async () => null,
+  read: async () => [],
+  getFilePath: () => null,
+  normalizeRawLine: () => [],
+} as unknown as SessionSource;
+
+async function get(path: string): Promise<{ status: number; body: any }> {
+  const res = await app.fetch(new Request(`http://localhost${path}`));
+  return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+beforeEach(async () => {
+  db = await makeTestDb();
+  setRuntimeConfig({ botName: "last-light" } as LastLightConfig);
+  app = createAdminRoutes(db, emptySessions, emptySessions, {
+    stateDir: "/tmp",
+    sessionsDir: "/tmp/sessions",
+    adminPassword: "", // no password + no OAuth → auth open, no token plumbing
+    adminSecret: "test-secret",
+  } as AdminConfig);
+});
+
+afterEach(() => resetRuntimeConfigForTests());
+
+describe("GET /admin/api/activity", () => {
+  it("returns the house envelope, newest first", async () => {
+    await db.activity.record({ action: "login", actorType: "admin" });
+    await db.activity.record({
+      action: "cron.toggle",
+      actorLogin: "octocat",
+      actorType: "github",
+      targetType: "cron",
+      targetId: "cron-review",
+      detail: { enabled: false },
+    });
+
+    const res = await get("/activity");
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(2);
+    expect(res.body.activity).toHaveLength(2);
+    expect(res.body.activity[0].action).toBe("cron.toggle");
+    expect(res.body.activity[0].detail).toEqual({ enabled: false });
+  });
+
+  it("clamps limit and offset the same way the other list endpoints do", async () => {
+    for (let i = 0; i < 5; i++) await db.activity.record({ action: "login" });
+
+    // A falsy limit — `0`, or unparseable — falls back to the DEFAULT rather
+    // than clamping to 1, because `parseInt(...) || 50` short-circuits. That is
+    // the behaviour of `/feedback/signals` and `/workflow-runs` verbatim, and
+    // consistency across the list endpoints beats a marginally tidier rule here.
+    expect((await get("/activity?limit=0")).body.activity).toHaveLength(5);
+    expect((await get("/activity?limit=abc")).body.activity).toHaveLength(5);
+    // A real value above the ceiling is clamped to 200 (only 5 rows exist).
+    expect((await get("/activity?limit=99999")).body.activity).toHaveLength(5);
+    expect((await get("/activity?limit=2")).body.activity).toHaveLength(2);
+    // A negative offset floors at 0 rather than throwing.
+    expect((await get("/activity?offset=-5")).body.activity).toHaveLength(5);
+    expect((await get("/activity?offset=3")).body.activity).toHaveLength(2);
+  });
+
+  it("filters by actor, action and since", async () => {
+    await db.activity.record({ action: "login", actorLogin: "alice" });
+    await db.activity.record({ action: "cron.fire", actorLogin: "bob" });
+
+    expect((await get("/activity?actor=alice")).body.total).toBe(1);
+    expect((await get("/activity?action=cron.fire")).body.total).toBe(1);
+    expect((await get("/activity?since=2999-01-01T00:00:00.000Z")).body.total).toBe(0);
+  });
+
+  it("splits ?target= on the FIRST colon, so an id containing one survives", async () => {
+    await db.activity.record({
+      action: "container.kill",
+      targetType: "container",
+      targetId: "lastlight-sandbox-a:b",
+    });
+
+    const res = await get("/activity?target=container:lastlight-sandbox-a:b");
+    expect(res.body.total).toBe(1);
+    expect(res.body.activity[0].targetId).toBe("lastlight-sandbox-a:b");
+  });
+
+  it("serves the per-run strip through the same target filter", async () => {
+    await db.activity.record({
+      action: "workflow.cancel",
+      targetType: "workflow_run",
+      targetId: "run-1",
+    });
+    await db.activity.record({
+      action: "workflow.cancel",
+      targetType: "workflow_run",
+      targetId: "run-2",
+    });
+
+    const res = await get("/activity?target=workflow_run:run-1");
+    expect(res.body.total).toBe(1);
+    expect(res.body.activity[0].targetId).toBe("run-1");
+  });
+
+  it("enriches actors from the users table, once per distinct login", async () => {
+    await db.users.getOrCreateUserByGithub({
+      githubId: 1,
+      login: "octocat",
+      name: "Mona Lisa",
+      avatarUrl: "https://example.test/mona.png",
+    });
+    await db.activity.record({ action: "login", actorLogin: "octocat", actorType: "github" });
+    await db.activity.record({ action: "cron.fire", actorLogin: "octocat", actorType: "github" });
+    // An actor with no `users` row must not break the page.
+    await db.activity.record({ action: "login", actorLogin: "ghost" });
+
+    const res = await get("/activity");
+    expect(res.body.users.octocat).toMatchObject({
+      login: "octocat",
+      name: "Mona Lisa",
+      avatarUrl: "https://example.test/mona.png",
+    });
+    expect(res.body.users.ghost).toBeUndefined();
+  });
+
+  it("exposes the distinct verbs present", async () => {
+    await db.activity.record({ action: "login" });
+    await db.activity.record({ action: "cron.fire" });
+    await db.activity.record({ action: "cron.fire" });
+
+    const res = await get("/activity/actions");
+    expect(res.body.actions).toEqual(["cron.fire", "login"]);
+  });
+});
+
+describe("the dashboard's hand-mirrored ActivityRecord", () => {
+  const apiSource = readFileSync(join(DASHBOARD, "api.ts"), "utf8");
+
+  it("declares every outcome the server can write", () => {
+    const block = apiSource.slice(apiSource.indexOf("export interface ActivityRecord"));
+    for (const outcome of ACTIVITY_OUTCOMES) {
+      expect(block, `dashboard ActivityRecord is missing outcome "${outcome}"`).toContain(
+        `"${outcome}"`,
+      );
+    }
+  });
+
+  it("offers every verb in the CLI's help text", () => {
+    // The CLI lists the vocabulary so `lastlight activity help` is a real
+    // reference rather than a shrug. Pin it: a verb added to the union and not
+    // to the help is a verb nobody can discover.
+    const cliSource = readFileSync(
+      join(import.meta.dirname, "../../../../packages/cli/src/cli.ts"),
+      "utf8",
+    );
+    const helpBlock = cliSource.slice(
+      cliSource.indexOf("${chalk.bold(\"Activity\")}"),
+      cliSource.indexOf("${chalk.bold(\"Logs\")}"),
+    );
+    expect(helpBlock.length).toBeGreaterThan(0);
+    for (const action of ACTIVITY_ACTIONS) {
+      // The help groups verbs by prefix (`workflow.trigger|retry|cancel`), so
+      // match on the noun and the bare verb rather than the whole string.
+      const [noun, verb] = action.split(".");
+      expect(helpBlock, `\`lastlight activity help\` does not mention "${action}"`).toContain(noun!);
+      if (verb) expect(helpBlock).toContain(verb);
+    }
+  });
+});

--- a/apps/server/tests/admin/activity-write.test.ts
+++ b/apps/server/tests/admin/activity-write.test.ts
@@ -1,0 +1,278 @@
+/**
+ * The activity log's WRITE side (issue #206).
+ *
+ * Four properties, in rough order of how much they'd hurt to lose:
+ *
+ * 1. **Exactly one row per action** — #206's acceptance criterion, asserted as a
+ *    count rather than a "contains", because a double-write is exactly as wrong
+ *    as a missing one and only a count catches it.
+ * 2. **A store failure never fails the action.** The whole reason the swallow
+ *    lives in `recordActivity` and not in `ActivityStore.record`.
+ * 3. **The actor is the authenticated user**, on the three routes that used to
+ *    hardcode `"admin"`.
+ * 4. **Every mutating route is either logged or explicitly exempt** — the pin
+ *    that replaces the coverage a middleware would have given.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("#src/logging/logger.js", () => {
+  const noopLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: () => noopLogger,
+  };
+  return { logger: () => noopLogger };
+});
+
+// The routes module pulls in the docker helpers at import time.
+vi.mock("#src/admin/docker.js", () => ({
+  listRunningContainers: vi.fn(async () => []),
+  killContainer: vi.fn(async () => {}),
+  getContainerStats: vi.fn(async () => []),
+  getHostStats: vi.fn(async () => null),
+}));
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createAdminRoutes, type AdminConfig } from "#src/admin/routes.js";
+import { createToken } from "#src/admin/auth.js";
+import { StateDb } from "#src/state/db.js";
+import type { SessionSource } from "#src/admin/sessions.js";
+import {
+  setRuntimeConfig,
+  resetRuntimeConfigForTests,
+  type LastLightConfig,
+} from "#src/config/config.js";
+import { makeTestDb } from "../helpers/state-db.js";
+
+const SECRET = "test-secret";
+/** A GitHub-OAuth session for `octocat` — carries a verified login. */
+const GITHUB_TOKEN = createToken(SECRET, "github", "octocat");
+/** A password session — authenticated, but carries NO login. */
+const PASSWORD_TOKEN = createToken(SECRET, "password");
+
+let db: StateDb;
+let app: ReturnType<typeof createAdminRoutes>;
+
+const emptySessions = {
+  listSessionIds: () => [],
+  exists: () => false,
+  getSessionMeta: async () => null,
+  read: async () => [],
+  getFilePath: () => null,
+  normalizeRawLine: () => [],
+} as unknown as SessionSource;
+
+function build(config: Partial<AdminConfig> = {}) {
+  app = createAdminRoutes(db, emptySessions, emptySessions, {
+    stateDir: "/tmp",
+    sessionsDir: "/tmp/sessions",
+    adminSecret: SECRET,
+    adminPassword: "hunter2",
+    ...config,
+  } as AdminConfig);
+}
+
+async function send(
+  method: string,
+  path: string,
+  opts: { token?: string; body?: unknown } = {},
+): Promise<{ status: number; body: any }> {
+  const headers: Record<string, string> = {};
+  if (opts.token) headers.Authorization = `Bearer ${opts.token}`;
+  if (opts.body !== undefined) headers["Content-Type"] = "application/json";
+  const res = await app.fetch(
+    new Request(`http://localhost${path}`, {
+      method,
+      headers,
+      ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+    }),
+  );
+  return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+beforeEach(async () => {
+  db = await makeTestDb();
+  setRuntimeConfig({ botName: "last-light" } as LastLightConfig);
+  build();
+});
+
+afterEach(() => {
+  resetRuntimeConfigForTests();
+  vi.restoreAllMocks();
+});
+
+describe("activity log — the write side", () => {
+  describe("exactly one row per action", () => {
+    it("writes one row for a workflow toggle, attributed to the authenticated user", async () => {
+      // `getWorkflow` validates the name, so use one the packaged set defines.
+      const res = await send("POST", "/workflows/pr-review/toggle", { token: GITHUB_TOKEN });
+      expect(res.status).toBe(200);
+
+      const { activity, total } = await db.activity.list();
+      expect(total).toBe(1);
+      expect(activity[0]).toMatchObject({
+        action: "workflow.toggle",
+        actorLogin: "octocat",
+        actorType: "github",
+        targetType: "workflow",
+        targetId: "pr-review",
+        outcome: "ok",
+      });
+      expect(activity[0].detail).toEqual({ enabled: false });
+    });
+
+    it("writes one row per toggle, not one per request handled", async () => {
+      await send("POST", "/workflows/pr-review/toggle", { token: GITHUB_TOKEN });
+      await send("POST", "/workflows/pr-review/toggle", { token: GITHUB_TOKEN });
+      const { total } = await db.activity.list();
+      expect(total).toBe(2);
+    });
+
+    it("writes nothing when the action never happened", async () => {
+      const res = await send("POST", "/workflows/no-such-workflow/toggle", {
+        token: GITHUB_TOKEN,
+      });
+      expect(res.status).toBe(404);
+      expect((await db.activity.list()).total).toBe(0);
+    });
+  });
+
+  describe("the actor", () => {
+    it("records the login on the routes that used to hardcode admin", async () => {
+      await send("POST", "/workflows/pr-review/toggle", { token: GITHUB_TOKEN });
+
+      // Both the activity row AND the override column now name the person.
+      const { activity } = await db.activity.list();
+      expect(activity[0].actorLogin).toBe("octocat");
+      const overrides = await db.getAllWorkflowOverrides();
+      expect(overrides.get("pr-review")?.updatedBy).toBe("octocat");
+    });
+
+    it("leaves actor_login null for a password session, but still records how", async () => {
+      await send("POST", "/workflows/pr-review/toggle", { token: PASSWORD_TOKEN });
+
+      const { activity } = await db.activity.list();
+      // Deliberately NOT "admin": in an audit stream that reads as a person.
+      expect(activity[0].actorLogin).toBeUndefined();
+      // …but the row is not anonymous about HOW it happened.
+      expect(activity[0].actorType).toBe("admin");
+
+      // The override column keeps its literal fallback — an existing wire
+      // contract the dashboard renders, deliberately not changed here.
+      const overrides = await db.getAllWorkflowOverrides();
+      expect(overrides.get("pr-review")?.updatedBy).toBe("admin");
+    });
+  });
+
+  describe("outcome", () => {
+    it("records a denied login on a bad password, and an ok one on a good password", async () => {
+      await send("POST", "/login", { body: { password: "wrong" } });
+      await send("POST", "/login", { body: { password: "hunter2" } });
+
+      const { activity, total } = await db.activity.list();
+      expect(total).toBe(2);
+      // Newest first.
+      expect(activity[0]).toMatchObject({ action: "login", outcome: "ok", actorType: "admin" });
+      expect(activity[1]).toMatchObject({ action: "login", outcome: "denied" });
+      // Password login never learns a login, by construction.
+      expect(activity[1].actorLogin).toBeUndefined();
+    });
+  });
+
+  describe("best-effort: the log never fails the action", () => {
+    it("still performs the action when the store throws", async () => {
+      const boom = vi
+        .spyOn(db.activity, "record")
+        .mockRejectedValue(new Error("disk on fire"));
+
+      const res = await send("POST", "/workflows/pr-review/toggle", { token: GITHUB_TOKEN });
+
+      // The request succeeded…
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ name: "pr-review", enabled: false });
+      // …the underlying state change landed…
+      const overrides = await db.getAllWorkflowOverrides();
+      expect(overrides.get("pr-review")?.enabled).toBe(false);
+      // …and the write was genuinely attempted, not skipped.
+      expect(boom).toHaveBeenCalledOnce();
+    });
+
+    it("the store itself still rejects — the swallow lives one level up", async () => {
+      // If `record` swallowed internally this would resolve, and the test above
+      // would be vacuous: it would pass whether or not the helper caught.
+      const closed = await makeTestDb();
+      await closed.close();
+      await expect(closed.activity.record({ action: "login" })).rejects.toThrow();
+    });
+  });
+
+  /**
+   * The pin that replaces middleware's coverage guarantee.
+   *
+   * Every mutating route must be either in the verb map or explicitly exempt
+   * with a reason. A new route added without a log line fails here rather than
+   * silently going unaudited — which is the one thing the explicit-call
+   * approach cannot get for free.
+   */
+  describe("route coverage", () => {
+    const LOGGED = new Set([
+      "POST /login",
+      "DELETE /containers/:name",
+      "POST /workflow-runs/:id/cancel",
+      "POST /workflow-runs/:id/retry",
+      "POST /workflows/:name/toggle",
+      "PUT /artifacts/:owner/:repo/:key/:doc",
+      "POST /approvals/:id/respond",
+      "POST /crons/:name/toggle",
+      "POST /crons/:name/schedule",
+      "DELETE /crons/:name/override",
+      "POST /crons/:name/trigger",
+      "POST /prs/:owner/:repo/:number/retry",
+    ]);
+
+    /** Deliberately unlogged, with the reason. */
+    const NOT_LOGGED = new Map([
+      ["POST /me/repos/resync", "a self-service cache refresh, not an action on the system"],
+      ["POST /token/refresh", "a session slide on a timer, not an action; would drown the logins"],
+      ["POST /route-test", "a hermetic router dry-run with no side effects"],
+    ]);
+
+    it("every mutating route is either logged or explicitly exempt", () => {
+      const source = readFileSync(
+        fileURLToPath(new URL("../../src/admin/routes.ts", import.meta.url)),
+        "utf8",
+      );
+      const found = [...source.matchAll(/app\.(post|put|delete|patch)\("([^"]+)"/g)].map(
+        (m) => `${m[1]!.toUpperCase()} ${m[2]}`,
+      );
+
+      expect(found.length).toBeGreaterThan(0);
+      const unaccounted = found.filter((r) => !LOGGED.has(r) && !NOT_LOGGED.has(r));
+      expect(
+        unaccounted,
+        "a mutating route that neither writes an activity row nor declares why not — " +
+          "add a recordActivityFor(...) call, or add it to NOT_LOGGED with a reason",
+      ).toEqual([]);
+    });
+
+    it("the exempt list has not gone stale", () => {
+      const source = readFileSync(
+        fileURLToPath(new URL("../../src/admin/routes.ts", import.meta.url)),
+        "utf8",
+      );
+      const found = new Set(
+        [...source.matchAll(/app\.(post|put|delete|patch)\("([^"]+)"/g)].map(
+          (m) => `${m[1]!.toUpperCase()} ${m[2]}`,
+        ),
+      );
+      // A route that was removed should not linger in either list.
+      for (const route of [...LOGGED, ...NOT_LOGGED.keys()]) {
+        expect(found.has(route), `${route} is listed but no longer exists`).toBe(true);
+      }
+    });
+  });
+});

--- a/apps/server/tests/state/data-migrate.test.ts
+++ b/apps/server/tests/state/data-migrate.test.ts
@@ -263,9 +263,12 @@ async function seed(db: StateDb): Promise<void> {
 
 describe("data-migrate", () => {
   it("covers every table in the schema", () => {
-    // The guard that stops a 17th table from being silently left behind.
+    // The guard that stops a table being silently left behind. It checks BOTH
+    // directions — a schema export missing from TABLE_ORDER, and a TABLE_ORDER
+    // entry no longer in the schema — so a hardcoded count would add nothing
+    // beyond an edit on every table added.
     expect(() => assertCoversEveryTable()).not.toThrow();
-    expect(TABLE_ORDER).toHaveLength(16);
+    expect(TABLE_ORDER.length).toBeGreaterThan(0);
   });
 
   it("orders messaging_sessions before messaging_messages (the only FK)", () => {
@@ -284,8 +287,10 @@ describe("data-migrate", () => {
       onProgress: (e) => events.push(e),
     });
 
-    // Row counts first — the cheap half.
-    expect(result.tables).toHaveLength(16);
+    // Row counts first — the cheap half. Compared against TABLE_ORDER rather
+    // than a literal: the copy visits exactly those tables by construction, so
+    // a number here would only restate it.
+    expect(result.tables).toHaveLength(TABLE_ORDER.length);
     expect(result.totalRows).toBeGreaterThan(0);
     for (const t of result.tables) expect(t.target).toBe(t.source);
     expect(events.at(-1)).toMatchObject({ type: "done", totalRows: result.totalRows });

--- a/apps/server/tests/state/data-migrate.test.ts
+++ b/apps/server/tests/state/data-migrate.test.ts
@@ -219,6 +219,29 @@ async function seed(db: StateDb): Promise<void> {
     observedAt: now,
   });
 
+  // The audit stream (issue #206). `detail` is text→jsonb, so it is a second
+  // instance of the mapping `executions.extension_status` covers — and the row
+  // with no detail proves NULL survives as NULL rather than as `"null"`.
+  await c.insert(t.activityLog).values([
+    {
+      id: "act-1",
+      createdAt: now,
+      actorLogin: "cliftonc",
+      actorType: "github",
+      action: "cron.toggle",
+      targetType: "cron",
+      targetId: "cron-review",
+      outcome: "ok",
+      detail: { enabled: false, note: "café ☕" },
+    },
+    {
+      id: "act-2",
+      createdAt: now,
+      action: "login",
+      outcome: "denied",
+    },
+  ]);
+
   // The one foreign key in the schema — and the one generated id.
   await c.insert(t.messagingSessions).values({
     id: "sess-1",
@@ -240,9 +263,9 @@ async function seed(db: StateDb): Promise<void> {
 
 describe("data-migrate", () => {
   it("covers every table in the schema", () => {
-    // The guard that stops a 16th table from being silently left behind.
+    // The guard that stops a 17th table from being silently left behind.
     expect(() => assertCoversEveryTable()).not.toThrow();
-    expect(TABLE_ORDER).toHaveLength(15);
+    expect(TABLE_ORDER).toHaveLength(16);
   });
 
   it("orders messaging_sessions before messaging_messages (the only FK)", () => {
@@ -262,7 +285,7 @@ describe("data-migrate", () => {
     });
 
     // Row counts first — the cheap half.
-    expect(result.tables).toHaveLength(15);
+    expect(result.tables).toHaveLength(16);
     expect(result.totalRows).toBeGreaterThan(0);
     for (const t of result.tables) expect(t.target).toBe(t.source);
     expect(events.at(-1)).toMatchObject({ type: "done", totalRows: result.totalRows });
@@ -306,6 +329,15 @@ describe("data-migrate", () => {
     expect(await target.client.select().from(dst.githubTeamMembers)).toHaveLength(1);
     const [signal] = await target.client.select().from(dst.feedbackSignals);
     expect(signal).toMatchObject({ anchorId: "anchor-1", score: 1, emoji: "+1" });
+
+    // The audit stream's own text→jsonb column, and its NULL sibling.
+    const activity = Object.fromEntries(
+      (await target.client.select().from(dst.activityLog)).map((r) => [r.id, r]),
+    );
+    expect(activity["act-1"].detail).toEqual({ enabled: false, note: "café ☕" });
+    expect(activity["act-1"].actorType).toBe("github");
+    expect(activity["act-2"].detail).toBeNull();
+    expect(activity["act-2"].actorLogin).toBeNull();
 
     // The generated id: Postgres assigns its own (GENERATED ALWAYS rejects an
     // explicit one), and nothing references it — but the ORDER must survive,

--- a/apps/server/tests/state/schema-equivalence.test.ts
+++ b/apps/server/tests/state/schema-equivalence.test.ts
@@ -24,20 +24,24 @@ import { applyLegacySqliteCompat } from "#src/state/legacy-sqlite.js";
 
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle/sqlite", import.meta.url));
 /**
- * Migrations in `drizzle/sqlite`: the baseline plus the #279 repo-ref backfill.
- * Bump it when one is added — deliberately not derived from the journal, so a
- * migration that fails to record itself shows up here as a diff rather than
- * agreeing with whatever happened.
+ * Migrations in `drizzle/sqlite`: the baseline, the #279 repo-ref backfill, and
+ * the #206 `activity_log` table. Bump it when one is added — deliberately not
+ * derived from the journal, so a migration that fails to record itself shows up
+ * here as a diff rather than agreeing with whatever happened.
  */
-const MIGRATION_COUNT = 2;
+const MIGRATION_COUNT = 3;
 
 const LEGACY_SCHEMA = readFileSync(
   fileURLToPath(new URL("./fixtures/legacy-schema.sql", import.meta.url)),
   "utf8",
 );
 
-/** The 15 tables both paths must produce, and nothing else. */
-const EXPECTED_TABLES = [
+/**
+ * The 15 tables the legacy (pre-Drizzle) production database carries. The
+ * baseline must leave every one of them byte-identical — that is the whole
+ * proof this file exists for.
+ */
+const LEGACY_TABLES = [
   "cron_overrides",
   "cron_runs",
   "executions",
@@ -54,6 +58,30 @@ const EXPECTED_TABLES = [
   "workflow_overrides",
   "workflow_runs",
 ];
+
+/**
+ * Tables a POST-baseline migration creates, so they are absent from the legacy
+ * shape and present after boot. `activity_log` (issue #206) is the first —
+ * before it, `before` and `after` were the same set and this file could compare
+ * them directly. Add to this list when a migration adds a table; the baseline
+ * itself must still never alter a legacy one.
+ */
+const POST_BASELINE_TABLES = ["activity_log"];
+
+/** Named indexes those post-baseline tables bring with them. */
+const POST_BASELINE_INDEXES = [
+  "idx_activity_actor_created",
+  "idx_activity_created",
+  "idx_activity_target",
+];
+
+/** The 16 tables a fully-migrated database holds, and nothing else. */
+const EXPECTED_TABLES = [...LEGACY_TABLES, ...POST_BASELINE_TABLES].sort();
+
+/** `{a, b}` minus the given keys — for comparing only the legacy tables. */
+function omit<T>(record: Record<string, T>, keys: string[]): Record<string, T> {
+  return Object.fromEntries(Object.entries(record).filter(([k]) => !keys.includes(k)));
+}
 
 /**
  * The five indexes the Drizzle baseline has that the legacy DDL does not.
@@ -225,37 +253,47 @@ async function bootStateLayer(client: Client): Promise<void> {
 }
 
 describe("the Drizzle baseline over a legacy (production-shaped) database", () => {
-  it("no-ops: the schema is unchanged and the journal records one migration", async () => {
+  it("no-ops over every legacy table, and the journal records each migration", async () => {
     const client = await legacyShapedDb(":memory:");
     try {
       const q = queryOn(client);
       const before = await extract(q);
-      expect(before.tables).toEqual(EXPECTED_TABLES);
+      expect(before.tables).toEqual(LEGACY_TABLES);
       expect(Object.keys(before.indexes)).toHaveLength(25);
 
       await bootStateLayer(client);
 
       const after = await extract(q);
       expect(after.tables).toEqual(EXPECTED_TABLES);
-      expect(after.columns).toEqual(before.columns);
-      expect(after.pks).toEqual(before.pks);
+      // The legacy tables are untouched. The only difference is the tables a
+      // post-baseline migration ADDS — never a change to one that was there.
+      expect(omit(after.columns, POST_BASELINE_TABLES)).toEqual(before.columns);
+      expect(omit(after.pks, POST_BASELINE_TABLES)).toEqual(before.pks);
       expect(after.fks).toEqual(before.fks);
       expect(after.fks).toEqual([
         "messaging_messages.session_id -> messaging_sessions.id [update=NO ACTION delete=NO ACTION]",
       ]);
 
       // Every legacy index survives byte-identical; the only additions are the
-      // five redundant unique indexes, whose rules were already enforced.
+      // five redundant unique indexes, whose rules were already enforced, plus
+      // whatever a post-baseline migration's own new tables carry.
       for (const name of Object.keys(before.indexes)) {
         expect(after.indexes[name]).toBe(before.indexes[name]);
       }
       const added = Object.keys(after.indexes).filter((n) => !(n in before.indexes));
-      expect(added.sort()).toEqual(DRIZZLE_ONLY_UNIQUE_INDEXES);
+      expect(added.sort()).toEqual(
+        [...DRIZZLE_ONLY_UNIQUE_INDEXES, ...POST_BASELINE_INDEXES].sort(),
+      );
 
-      // The SET of enforced rules is unchanged; the multiset is not — those
-      // five tuples are now doubly indexed. That is the whole cost.
-      expect([...new Set(after.uniques)].sort()).toEqual([...new Set(before.uniques)].sort());
-      const duplicated = after.uniques.filter((t, i) => after.uniques.indexOf(t) !== i);
+      // The SET of enforced rules is unchanged over the legacy tables; the
+      // multiset is not — those five tuples are now doubly indexed. That is the
+      // whole cost. A post-baseline table brings its own PK tuple, which is a
+      // new rule on a new table rather than a change to an existing one.
+      const legacyUniques = after.uniques.filter(
+        (t) => !POST_BASELINE_TABLES.some((table) => t.startsWith(`${table}:`)),
+      );
+      expect([...new Set(legacyUniques)].sort()).toEqual([...new Set(before.uniques)].sort());
+      const duplicated = legacyUniques.filter((t, i) => legacyUniques.indexOf(t) !== i);
       expect(duplicated.sort()).toEqual([
         "feedback_anchors:source,channel,external_id",
         "feedback_signals:anchor_id,reactor,emoji",
@@ -304,8 +342,9 @@ describe("the Drizzle baseline over a legacy (production-shaped) database", () =
       const sess = await client.execute("SELECT id FROM messaging_sessions");
       expect(sess.rows.map((r) => r.id)).toEqual(["sess-1"]);
 
-      // Both migrations recorded exactly once: the baseline, and the #279
-      // repo-ref backfill. The second boot above must not re-apply either.
+      // Every migration recorded exactly once: the baseline, the #279 repo-ref
+      // backfill, and the #206 activity_log table. The second boot above must
+      // not re-apply any of them.
       const journal = await client.execute(
         "SELECT count(*) AS n FROM __drizzle_migrations",
       );

--- a/apps/server/tests/state/schema-equivalence.test.ts
+++ b/apps/server/tests/state/schema-equivalence.test.ts
@@ -17,10 +17,13 @@ import { createClient, type Client } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 import { migrate as drizzleMigrate } from "drizzle-orm/libsql/migrator";
 import { fileURLToPath } from "url";
-import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { is, getTableName } from "drizzle-orm";
+import { SQLiteTable } from "drizzle-orm/sqlite-core";
 import { applyLegacySqliteCompat } from "#src/state/legacy-sqlite.js";
+import * as sqliteSchema from "#src/state/schema/sqlite.js";
 
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle/sqlite", import.meta.url));
 /**
@@ -37,51 +40,24 @@ const LEGACY_SCHEMA = readFileSync(
 );
 
 /**
- * The 15 tables the legacy (pre-Drizzle) production database carries. The
- * baseline must leave every one of them byte-identical — that is the whole
- * proof this file exists for.
+ * The tables the legacy (pre-Drizzle) production database carries, read off the
+ * fixture itself rather than hand-listed. The baseline must leave every one of
+ * them byte-identical — that is the whole proof this file exists for.
  */
-const LEGACY_TABLES = [
-  "cron_overrides",
-  "cron_runs",
-  "executions",
-  "feedback_anchors",
-  "feedback_signals",
-  "github_team_members",
-  "github_team_repos",
-  "github_teams",
-  "github_visibility_sync",
-  "messaging_messages",
-  "messaging_sessions",
-  "users",
-  "workflow_approvals",
-  "workflow_overrides",
-  "workflow_runs",
-];
+const LEGACY_TABLES = [...LEGACY_SCHEMA.matchAll(/CREATE TABLE (?:IF NOT EXISTS )?(\w+)/gi)]
+  .map((m) => m[1]!)
+  .sort();
 
 /**
- * Tables a POST-baseline migration creates, so they are absent from the legacy
- * shape and present after boot. `activity_log` (issue #206) is the first —
- * before it, `before` and `after` were the same set and this file could compare
- * them directly. Add to this list when a migration adds a table; the baseline
- * itself must still never alter a legacy one.
+ * The tables a fully-migrated database holds — derived from the schema module,
+ * so this asserts the stronger thing: **the migrations produce exactly what
+ * `schema/sqlite.ts` declares**, no more and no less. A hand-maintained list
+ * could only ever restate itself.
  */
-const POST_BASELINE_TABLES = ["activity_log"];
-
-/** Named indexes those post-baseline tables bring with them. */
-const POST_BASELINE_INDEXES = [
-  "idx_activity_actor_created",
-  "idx_activity_created",
-  "idx_activity_target",
-];
-
-/** The 16 tables a fully-migrated database holds, and nothing else. */
-const EXPECTED_TABLES = [...LEGACY_TABLES, ...POST_BASELINE_TABLES].sort();
-
-/** `{a, b}` minus the given keys — for comparing only the legacy tables. */
-function omit<T>(record: Record<string, T>, keys: string[]): Record<string, T> {
-  return Object.fromEntries(Object.entries(record).filter(([k]) => !keys.includes(k)));
-}
+const DECLARED_TABLES = Object.values(sqliteSchema)
+  .filter((v): v is SQLiteTable => is(v, SQLiteTable))
+  .map((t) => getTableName(t))
+  .sort();
 
 /**
  * The five indexes the Drizzle baseline has that the legacy DDL does not.
@@ -252,48 +228,70 @@ async function bootStateLayer(client: Client): Promise<void> {
   await drizzleMigrate(drizzle(client), { migrationsFolder: MIGRATIONS_FOLDER });
 }
 
+/**
+ * A migrations folder holding ONLY `0000_baseline`.
+ *
+ * This is what lets the test assert its actual invariant — *the baseline does
+ * not alter a legacy production database* — instead of applying everything and
+ * then reconciling the difference against hand-maintained lists of what later
+ * migrations were allowed to add. Migrations after the baseline are free to add
+ * tables and indexes; that freedom is the reason the reconciliation existed, and
+ * splitting the run removes the need for it entirely.
+ *
+ * Copied into a temp dir rather than filtered in memory because drizzle's
+ * migrator reads both the journal and the `.sql` files off disk.
+ */
+function baselineOnlyFolder(): string {
+  const dir = mkdtempSync(join(tmpdir(), "lastlight-baseline-only-"));
+  mkdirSync(join(dir, "meta"), { recursive: true });
+  const journal = JSON.parse(readFileSync(join(MIGRATIONS_FOLDER, "meta", "_journal.json"), "utf8"));
+  const first = journal.entries[0];
+  writeFileSync(
+    join(dir, "meta", "_journal.json"),
+    JSON.stringify({ ...journal, entries: [first] }, null, 2),
+  );
+  copyFileSync(join(MIGRATIONS_FOLDER, `${first.tag}.sql`), join(dir, `${first.tag}.sql`));
+  return dir;
+}
+
 describe("the Drizzle baseline over a legacy (production-shaped) database", () => {
-  it("no-ops over every legacy table, and the journal records each migration", async () => {
+  it("the BASELINE alone leaves a legacy database untouched", async () => {
     const client = await legacyShapedDb(":memory:");
+    const baselineDir = baselineOnlyFolder();
     try {
       const q = queryOn(client);
       const before = await extract(q);
       expect(before.tables).toEqual(LEGACY_TABLES);
       expect(Object.keys(before.indexes)).toHaveLength(25);
 
-      await bootStateLayer(client);
+      // ONLY `0000_baseline` — the migration this file exists to vouch for.
+      // Later migrations are allowed to change the schema, so including them
+      // here would mean subtracting their additions back out again.
+      await applyLegacySqliteCompat(client);
+      await drizzleMigrate(drizzle(client), { migrationsFolder: baselineDir });
 
       const after = await extract(q);
-      expect(after.tables).toEqual(EXPECTED_TABLES);
-      // The legacy tables are untouched. The only difference is the tables a
-      // post-baseline migration ADDS — never a change to one that was there.
-      expect(omit(after.columns, POST_BASELINE_TABLES)).toEqual(before.columns);
-      expect(omit(after.pks, POST_BASELINE_TABLES)).toEqual(before.pks);
+      // Nothing added, nothing removed, nothing altered. No exceptions list.
+      expect(after.tables).toEqual(before.tables);
+      expect(after.columns).toEqual(before.columns);
+      expect(after.pks).toEqual(before.pks);
       expect(after.fks).toEqual(before.fks);
       expect(after.fks).toEqual([
         "messaging_messages.session_id -> messaging_sessions.id [update=NO ACTION delete=NO ACTION]",
       ]);
 
       // Every legacy index survives byte-identical; the only additions are the
-      // five redundant unique indexes, whose rules were already enforced, plus
-      // whatever a post-baseline migration's own new tables carry.
+      // five redundant unique indexes, whose rules were already enforced.
       for (const name of Object.keys(before.indexes)) {
         expect(after.indexes[name]).toBe(before.indexes[name]);
       }
       const added = Object.keys(after.indexes).filter((n) => !(n in before.indexes));
-      expect(added.sort()).toEqual(
-        [...DRIZZLE_ONLY_UNIQUE_INDEXES, ...POST_BASELINE_INDEXES].sort(),
-      );
+      expect(added.sort()).toEqual(DRIZZLE_ONLY_UNIQUE_INDEXES);
 
-      // The SET of enforced rules is unchanged over the legacy tables; the
-      // multiset is not — those five tuples are now doubly indexed. That is the
-      // whole cost. A post-baseline table brings its own PK tuple, which is a
-      // new rule on a new table rather than a change to an existing one.
-      const legacyUniques = after.uniques.filter(
-        (t) => !POST_BASELINE_TABLES.some((table) => t.startsWith(`${table}:`)),
-      );
-      expect([...new Set(legacyUniques)].sort()).toEqual([...new Set(before.uniques)].sort());
-      const duplicated = legacyUniques.filter((t, i) => legacyUniques.indexOf(t) !== i);
+      // The SET of enforced rules is unchanged; the multiset is not — those
+      // five tuples are now doubly indexed. That is the whole cost.
+      expect([...new Set(after.uniques)].sort()).toEqual([...new Set(before.uniques)].sort());
+      const duplicated = after.uniques.filter((t, i) => after.uniques.indexOf(t) !== i);
       expect(duplicated.sort()).toEqual([
         "feedback_anchors:source,channel,external_id",
         "feedback_signals:anchor_id,reactor,emoji",
@@ -301,10 +299,24 @@ describe("the Drizzle baseline over a legacy (production-shaped) database", () =
         "users:login",
         "users:slack_user_id",
       ]);
+    } finally {
+      client.close();
+      rmSync(baselineDir, { recursive: true, force: true });
+    }
+  });
 
-      const journal = await client.execute(
-        "SELECT count(*) AS n FROM __drizzle_migrations",
-      );
+  it("the full migration set produces exactly the declared schema", async () => {
+    const client = await legacyShapedDb(":memory:");
+    try {
+      await bootStateLayer(client);
+
+      // Derived from `schema/sqlite.ts`, so a new table needs no edit here —
+      // and the assertion is the stronger one: the migrations and the schema
+      // module agree about what exists.
+      const after = await extract(queryOn(client));
+      expect(after.tables).toEqual(DECLARED_TABLES);
+
+      const journal = await client.execute("SELECT count(*) AS n FROM __drizzle_migrations");
       expect(Number(journal.rows[0].n)).toBe(MIGRATION_COUNT);
     } finally {
       client.close();

--- a/apps/server/tests/state/schema-parity.test.ts
+++ b/apps/server/tests/state/schema-parity.test.ts
@@ -156,9 +156,9 @@ describe("schema parity: sqlite ↔ pg", () => {
     ).toEqual([]);
   });
 
-  it("covers all 15 tables", () => {
-    expect(sqliteNames).toHaveLength(15);
-    expect(pgNames).toHaveLength(15);
+  it("covers all 16 tables", () => {
+    expect(sqliteNames).toHaveLength(16);
+    expect(pgNames).toHaveLength(16);
   });
 
   for (const name of tableExports(sqliteSchema as Record<string, unknown>)) {

--- a/apps/server/tests/state/schema-parity.test.ts
+++ b/apps/server/tests/state/schema-parity.test.ts
@@ -156,9 +156,12 @@ describe("schema parity: sqlite ↔ pg", () => {
     ).toEqual([]);
   });
 
-  it("covers all 16 tables", () => {
-    expect(sqliteNames).toHaveLength(16);
-    expect(pgNames).toHaveLength(16);
+  // Deliberately no `expect(names).toHaveLength(N)`. The two assertions above
+  // already prove the sets are identical, which is what this file is for; a
+  // count only additionally catches a table removed from BOTH schemas at once —
+  // a deliberate act — at the price of an edit on every table added.
+  it("covers a non-empty set of tables", () => {
+    expect(sqliteNames.length).toBeGreaterThan(0);
   });
 
   for (const name of tableExports(sqliteSchema as Record<string, unknown>)) {

--- a/apps/server/tests/state/store-suite.ts
+++ b/apps/server/tests/state/store-suite.ts
@@ -18,6 +18,7 @@
 import { describe } from "vitest";
 import type { StateDb } from "#src/state/db.js";
 
+import { runActivitySuite } from "./suites/activity-suite.js";
 import { runApprovalsSuite } from "./suites/approvals-suite.js";
 import { runConcurrencySuite } from "./suites/concurrency-suite.js";
 import { runCronRunsSuite } from "./suites/cron-runs-suite.js";
@@ -54,6 +55,7 @@ export function runStateDbSuite(makeDb: MakeDb, opts: SuiteOpts): void {
     runTeamsSuite(makeDb, opts);
     runFeedbackSuite(makeDb, opts);
     runCronRunsSuite(makeDb, opts);
+    runActivitySuite(makeDb, opts);
     runRepoRefSuite(makeDb, opts);
     runConcurrencySuite(makeDb, opts);
   });

--- a/apps/server/tests/state/suites/activity-suite.ts
+++ b/apps/server/tests/state/suites/activity-suite.ts
@@ -1,0 +1,187 @@
+/**
+ * `ActivityStore` — the one-row-per-action audit stream (issue #206).
+ *
+ * Two things here are dialect guards rather than ordinary coverage, and both
+ * are the reason these bodies live in a suite instead of a `*.test.ts`:
+ *
+ * 1. **`detail` round-tripping.** It is `text({ mode: "json" })` on sqlite and
+ *    real `jsonb` on Postgres — the exact divergence `client.ts` warns runs
+ *    `JSON.parse` over an already-parsed object when a store resolves its
+ *    tables from the wrong schema. Only the PGlite leg can catch that.
+ * 2. **The same-millisecond page boundary.** `created_at` is millisecond
+ *    resolution, so a burst of writes ties; the reads break it on the
+ *    creation-ordered `id` rather than sqlite's `rowid`, which Postgres has no
+ *    equivalent of. The deliberate collision below is what makes that a test.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import type { StateDb } from "#src/state/db.js";
+import type { MakeDb, SuiteOpts } from "../store-suite.js";
+
+export function runActivitySuite(makeDb: MakeDb, _opts: SuiteOpts): void {
+  describe("ActivityStore", () => {
+    let db: StateDb;
+
+    beforeEach(async () => {
+      db = await makeDb();
+    });
+
+    describe("ActivityStore.record", () => {
+      it("round-trips every field, including a json detail", async () => {
+        await db.activity.record({
+          actorLogin: "octocat",
+          actorType: "github",
+          action: "cron.toggle",
+          targetType: "cron",
+          targetId: "merge-green-dependency-prs",
+          outcome: "ok",
+          detail: { enabled: false, schedule: "0 14 * * *", attempts: 3 },
+        });
+
+        const { activity, total } = await db.activity.list();
+        expect(total).toBe(1);
+        expect(activity[0]).toMatchObject({
+          actorLogin: "octocat",
+          actorType: "github",
+          action: "cron.toggle",
+          targetType: "cron",
+          targetId: "merge-green-dependency-prs",
+          outcome: "ok",
+        });
+        // The dialect-divergent column: `text` here, `jsonb` on Postgres. A
+        // store that resolved its tables from the wrong schema would hand back
+        // a string on one leg and an object on the other.
+        expect(activity[0].detail).toEqual({
+          enabled: false,
+          schedule: "0 14 * * *",
+          attempts: 3,
+        });
+        expect(activity[0].id).toBeTruthy();
+        expect(activity[0].createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      });
+
+      it("defaults outcome to ok and leaves absent fields undefined, not null", async () => {
+        await db.activity.record({ action: "login" });
+
+        const { activity } = await db.activity.list();
+        expect(activity[0].outcome).toBe("ok");
+        // `nullsToUndefined` at the store boundary — a caller checking
+        // `=== undefined` must not meet a null.
+        expect(activity[0].actorLogin).toBeUndefined();
+        expect(activity[0].actorType).toBeUndefined();
+        expect(activity[0].targetType).toBeUndefined();
+        expect(activity[0].detail).toBeUndefined();
+      });
+
+      it("records a denied outcome with no actor — the password-login shape", async () => {
+        await db.activity.record({ action: "login", actorType: "admin", outcome: "denied" });
+
+        const { activity } = await db.activity.list();
+        expect(activity[0].outcome).toBe("denied");
+        expect(activity[0].actorLogin).toBeUndefined();
+      });
+    });
+
+    describe("ActivityStore.list", () => {
+      /**
+       * Deliberately does NOT advance the clock between writes. `record()`
+       * stamps `created_at` from the wall clock, so a tight loop puts every row
+       * in the same millisecond — which is the tie the paged read has to break
+       * correctly. Spacing the writes out would make the pagination test pass
+       * against a broken tiebreak, so the collision is the point.
+       */
+      async function seed(n: number, action: "login" | "cron.fire" = "cron.fire") {
+        for (let i = 0; i < n; i++) {
+          await db.activity.record({
+            actorLogin: i % 2 === 0 ? "alice" : "bob",
+            actorType: "github",
+            action,
+            targetType: "cron",
+            targetId: `cron-${i}`,
+          });
+        }
+      }
+
+      it("returns newest first with the post-filter total", async () => {
+        await seed(3);
+        const { activity, total } = await db.activity.list({ limit: 2 });
+        expect(total).toBe(3);
+        expect(activity).toHaveLength(2);
+        // Newest first: the last-seeded row wins, and within the millisecond
+        // tie the creation-ordered id decides.
+        expect(activity[0].targetId).toBe("cron-2");
+        expect(activity[1].targetId).toBe("cron-1");
+      });
+
+      it("pages a same-millisecond burst without skipping or repeating a row", async () => {
+        await seed(10);
+
+        const first = await db.activity.list({ limit: 4, offset: 0 });
+        const second = await db.activity.list({ limit: 4, offset: 4 });
+        const third = await db.activity.list({ limit: 4, offset: 8 });
+
+        const ids = [...first.activity, ...second.activity, ...third.activity].map((r) => r.id);
+        expect(ids).toHaveLength(10);
+        expect(new Set(ids).size).toBe(10);
+        expect(first.total).toBe(10);
+      });
+
+      it("filters by actor, action, target and since", async () => {
+        await seed(4, "cron.fire");
+        await db.activity.record({
+          actorLogin: "alice",
+          actorType: "cli",
+          action: "workflow.cancel",
+          targetType: "workflow_run",
+          targetId: "run-1",
+        });
+
+        const byActor = await db.activity.list({ actor: "alice" });
+        expect(byActor.total).toBe(3); // cron-0, cron-2, and the cancel
+        expect(byActor.activity.every((r) => r.actorLogin === "alice")).toBe(true);
+
+        const byAction = await db.activity.list({ action: "workflow.cancel" });
+        expect(byAction.total).toBe(1);
+        expect(byAction.activity[0].targetId).toBe("run-1");
+
+        const byTarget = await db.activity.list({
+          targetType: "workflow_run",
+          targetId: "run-1",
+        });
+        expect(byTarget.total).toBe(1);
+
+        const sinceFuture = await db.activity.list({ sinceIso: "2999-01-01T00:00:00.000Z" });
+        expect(sinceFuture.total).toBe(0);
+        expect(sinceFuture.activity).toEqual([]);
+
+        const sincePast = await db.activity.list({ sinceIso: "2000-01-01T00:00:00.000Z" });
+        expect(sincePast.total).toBe(5);
+      });
+
+      it("combines filters, and total reflects the filter rather than the page", async () => {
+        await seed(6);
+        const { activity, total } = await db.activity.list({
+          actor: "alice",
+          action: "cron.fire",
+          limit: 1,
+        });
+        expect(total).toBe(3); // alice wrote cron-0, cron-2, cron-4
+        expect(activity).toHaveLength(1); // …but asked for one
+      });
+    });
+
+    describe("ActivityStore.actions", () => {
+      it("returns the distinct verbs present, sorted", async () => {
+        await db.activity.record({ action: "login" });
+        await db.activity.record({ action: "cron.fire" });
+        await db.activity.record({ action: "cron.fire" });
+        await db.activity.record({ action: "workflow.cancel" });
+
+        expect(await db.activity.actions()).toEqual(["cron.fire", "login", "workflow.cancel"]);
+      });
+
+      it("is empty on an empty table", async () => {
+        expect(await db.activity.actions()).toEqual([]);
+      });
+    });
+  });
+}

--- a/docs/plans/activity-log/00-schema.md
+++ b/docs/plans/activity-log/00-schema.md
@@ -1,0 +1,274 @@
+# Phase 1 — the table and the store
+
+> **Status: implemented.** See the Execution notes at the end for what actually
+> happened, including where reality diverged from the plan. The steps below are
+> the plan **as originally written**, kept unchanged on purpose — the execution
+> notes argue against them, and that comparison only works if the original
+> survives. They are a record, not a to-do list.
+
+Add `activity_log` on both dialects, an `ActivityStore` over it, and update the
+six places that do not update themselves. **Nothing observable changes at
+runtime**: no writer and no reader exists until Phases 2 and 3.
+
+> Read [`src/state/CLAUDE.md`](../../../apps/server/src/state/CLAUDE.md) before
+> starting. It is the procedure; `spec/10-state.md` is the contract. This doc
+> assumes both and only records what is specific to this table.
+
+## The table
+
+Append-only. Never updated, never deleted.
+
+```ts
+/**
+ * The cross-cutting audit stream (issue #206) — one row per user-initiated
+ * action, across the dashboard, CLI, Slack, GitHub and cron.
+ *
+ * COMPLEMENTS the per-run actor columns #205 put on `workflow_runs` and
+ * `executions`; it does not replace them. Those stay the hot-path attribution
+ * a run's detail view reads. This is the chronological stream that answers
+ * "what has this person done?" without joining five ledgers.
+ *
+ * `actor_login` is free text soft-joined to `users.login`, deliberately
+ * without a foreign key — the same additive-enrichment choice #205 made, so a
+ * row survives an actor who never logged into the dashboard.
+ */
+export const activityLog = sqliteTable(
+  "activity_log",
+  {
+    id: text("id").primaryKey(),                    // creationOrderedId()
+    createdAt: text("created_at").notNull(),        // ISO-8601 text, both dialects
+    actorLogin: text("actor_login"),                // null when the token carries no login
+    actorType: text("actor_type").$type<TriggerActorType>(),
+    action: text("action").notNull().$type<ActivityAction>(),
+    targetType: text("target_type"),                // null for actions with no target (login)
+    targetId: text("target_id"),
+    outcome: text("outcome").notNull().$type<ActivityOutcome>(),
+    detail: text("detail", { mode: "json" }).$type<ActivityDetail>(),
+  },
+  (t) => [
+    index("idx_activity_created").on(sql`${t.createdAt} DESC`),
+    index("idx_activity_actor_created").on(t.actorLogin, sql`${t.createdAt} DESC`),
+    index("idx_activity_target").on(t.targetType, t.targetId),
+  ],
+);
+```
+
+The `pg.ts` mirror is name-parity: `jsonb` for `detail`, `.desc()` for the index
+directions, a `/** @see sqlite.ts → \`activityLog\` */` header, and the **same
+`$type<T>()` on every column** so the store-facing type is identical. Comments
+live in `sqlite.ts`; the mirror carries only dialect-specific notes.
+
+Three conventions this table follows because `src/state/CLAUDE.md:68` requires
+them: **ISO-8601 `text` timestamps on both dialects** (never a native timestamp
+type), **`text({mode:"json"})` / `jsonb` with a shared `$type<T>()`** for
+`detail`, and **no `rowid`** — hence decision 4.
+
+### Types
+
+```ts
+export type ActivityOutcome = "ok" | "denied" | "error";
+
+/** Small, bounded, and never a payload — see the PII non-goal. */
+export type ActivityDetail = Record<string, string | number | boolean>;
+```
+
+`actor_type` reuses #205's `TriggerActorType`
+(`github | slack | cli | cron | admin | system`) rather than declaring a second
+vocabulary — #206 asks for exactly this.
+
+### Actions
+
+Fourteen verbs, `<noun>.<verb>`. **These strings become data**, so they are the
+first of the two open questions in the README.
+
+| `action` | Written when | `target_type` |
+|---|---|---|
+| `login` | A dashboard session is established (password, GitHub OAuth, Slack OAuth) | — |
+| `workflow.trigger` | A **human-actored** dispatch starts a run (decision 3) | `workflow_run` |
+| `workflow.retry` | Dashboard/CLI retry of a run | `workflow_run` |
+| `workflow.cancel` | Dashboard/CLI cancel of a run | `workflow_run` |
+| `workflow.toggle` | A workflow's kill switch flips | `workflow` |
+| `approval.approve` | A gate is approved — dashboard, Slack button, or GitHub comment | `approval` |
+| `approval.reject` | A gate is rejected, same three routes | `approval` |
+| `cron.fire` | A cron fires, scheduled or manual, `workflow:` or `handler:` | `cron` |
+| `cron.trigger` | Someone presses "Run now" | `cron` |
+| `cron.toggle` | A cron is enabled or disabled | `cron` |
+| `config.edit` | A cron schedule override is set or cleared | `cron` |
+| `container.kill` | A sandbox container is killed from the dashboard | `container` |
+| `artifact.edit` | A build-artifact doc is overwritten | `repo` |
+| `pr.retry` | A stuck PR is un-stuck via the admin route or CLI | `pr` |
+
+`target_id` is the bare identifier — `<run id>`, `<cron name>`, `<owner>/<repo>`,
+`<owner>/<repo>#<n>`. The `workflow_run:<id>` form in #206's body is how the
+**API filter** spells a target, not how the columns store it; the store splits
+on the first `:`.
+
+## The store
+
+`src/state/activity-store.ts`, modelled on `CronRunStore` — the closest existing
+append-only ledger. **Do not use `FeedbackStore` as the template**: it imports
+the sqlite schema directly and has no `tablesOf(client)` call, violating
+`src/state/CLAUDE.md:155`. It gets away with it only because its tables carry no
+boolean or JSON column, which this one does.
+
+```ts
+export class ActivityStore {
+  /** Table objects for THIS client's dialect — see client.ts → tablesOf. */
+  private readonly t: StateTables;
+  constructor(private client: StateClient) { this.t = tablesOf(client); }
+
+  async record(entry: ActivityEntry): Promise<void>;
+  async list(opts: ActivityListOptions): Promise<{ activity: ActivityRecord[]; total: number }>;
+  async actions(): Promise<string[]>;   // distinct verbs, for the filter dropdown
+}
+```
+
+Pure single-table CRUD: it opens no transaction, so it takes no `dbc` parameter,
+no `serialize`, and no collaborator stores — the same shape as `UserStore`
+(`user-store.ts:66`). Every method opens with `const { activityLog } = this.t;`.
+
+- **`record()`** — `creationOrderedId()` copied from `cron-run-store.ts:26`
+  (`${hexMillis}-${counter}-${randomUUID()}`), `createdAt` stamped here so no
+  caller can pass a clock. Explicit `.values({...})` mapping every field with
+  `?? null` for absent optionals.
+- **`list()`** — the `FeedbackStore.list` shape (`feedback-store.ts:410`): an
+  `SQL[]` predicate array, `and(...)`, a `select({ c: count() })` over the
+  **same** where clause for `total`, then
+  `.orderBy(desc(createdAt), desc(id)).limit().offset()`. Filters: `actor`,
+  `action`, `targetType` + `targetId`, `sinceIso`.
+  **The `desc(id)` tiebreak is load-bearing** — decision 4.
+- **`actions()`** — `selectDistinct` over `action`, ordered. No filter; the
+  vocabulary is small and bounded.
+- **`deserialize()`** — module-level, `nullsToUndefined(row)` (`client.ts:137`)
+  then `?? undefined` per field, as `user-store.ts:279`.
+
+No `select *` discipline problem here: every column is small by construction, so
+`list()` may project the whole row (unlike `WorkflowRunStore.list`, which must
+exclude `context`/`scratch`).
+
+## Generate both dialects
+
+```bash
+pnpm --filter lastlight-core run db:generate:sqlite
+pnpm --filter lastlight-core run db:generate:pg
+```
+
+Commit both generated `.sql` files **and** both `meta/_journal.json` updates,
+unedited, **in the same commit**. Never hand-edit generated SQL; never point
+`drizzle-kit push` at a database.
+
+Note the Postgres consequence recorded at `src/state/CLAUDE.md:186`: now that a
+production Postgres deployment exists, `0000_init.sql` is immutable exactly like
+the SQLite baseline. This is a **new numbered pg migration**, never a
+regenerated init — `db:generate:pg` does the right thing on its own; the risk is
+a human deciding to tidy the single init file.
+
+## The things that do not update themselves
+
+`src/state/CLAUDE.md:133` names three. Two test constants and three prose counts
+make six.
+
+| # | File | Change |
+|---|---|---|
+| 1 | `src/state/data-migrate.ts` | `{ key: "activityLog", orderBy: ["id"] }` in `TABLE_ORDER`, after `users`. No FK, so placement is free. **The SQLite→Postgres copy refuses to start if this is missed** |
+| 2 | `src/state/db.ts` | Re-export the types + class (`:30-56`); `readonly activity: ActivityStore` with a doc comment naming #206 (`:115-137`); `this.activity = new ActivityStore(_client);` in the private constructor (`:146-165`) |
+| 3 | `spec/10-state.md` | A new `### activity_log` section in the house format — SQL block, "Why it exists", "Why not overload `executions`" — modelled on `cron_runs` at `:374`. Add the store to the table at `~:1051`. Change "fifteen tables" at `:30` |
+| 4 | `tests/state/schema-equivalence.test.ts` | Add `"activity_log"` to `EXPECTED_TABLES` (`:40`, sorts first) **and** fix its docstring, which says "The 15 tables". Bump `MIGRATION_COUNT` `2 → 3` (`:32`) |
+| 5 | `src/state/CLAUDE.md` | Line 3 says "fifteen tables"; add `activity-store.ts` to the `*-store.ts` file table |
+| 6 | `apps/server/CLAUDE.md` | The `schema/sqlite.ts` line in the repo-layout tree says "all fifteen tables" and lists them |
+
+## Tests
+
+`tests/state/suites/activity-suite.ts`, registered in `tests/state/store-suite.ts`
+alongside `runCronRunsSuite`:
+
+```ts
+export function runActivitySuite(makeDb: MakeDb, _opts: SuiteOpts): void {
+```
+
+**Never a standalone `*.test.ts`.** Suites live under `suites/` precisely so both
+the SQLite and PGlite legs replay identical bodies; a `*.test.ts` would run the
+SQLite leg only and the Postgres value-mapping bug this repo fears most would
+sail through. All state function-scoped — two invocations can share a process.
+
+Cover:
+
+- Round trip: every field survives, including a `detail` object — **the JSON
+  column is the dialect-divergent one** (`text` vs `jsonb`), so this is the
+  assertion that earns the PGlite leg.
+- `list()` filters individually and combined; `total` is the post-filter count,
+  not the page length.
+- **Page stability across a same-millisecond boundary**: insert >1 page of rows
+  in one tick, page through, assert no row is skipped or repeated. This is the
+  regression test for decision 4 and it fails without the `desc(id)` tiebreak.
+- `actions()` returns distinct verbs.
+- `null` actor round-trips as `undefined`, not `null` (the `nullsToUndefined`
+  contract).
+
+`schema-parity.test.ts` derives its table list from the schema exports, so it
+covers the new table for free once both declarations exist.
+
+## Verify
+
+```bash
+pnpm --filter lastlight-core run db:generate:sqlite
+pnpm --filter lastlight-core run db:generate:pg
+pnpm --filter lastlight-core test tests/state   # both legs; PGlite runs by default
+pnpm --filter lastlight-core typecheck          # includes lint:promises
+```
+
+`PG_INTEGRATION=1` is only needed when `pg-client.ts` changes. It does not here.
+
+## Done when
+
+- Both schema files declare the table; both dialects have a committed migration
+  and journal entry.
+- `schema-parity`, `schema-equivalence` and both legs of the state suite pass.
+- `spec/10-state.md` documents the table and the count reads sixteen everywhere.
+- `db.activity` exists on `StateDb` and nothing calls it yet.
+
+## Execution notes (26 Aug 2026)
+
+Phase 1 landed. The schema, the store and the generated migrations went in as
+planned — `pnpm --filter lastlight-core test tests/state` is green on both legs
+(515 tests), and the full `turbo run typecheck test build` gate passes. Four
+things the plan did not anticipate, all of them in the test layer:
+
+- **"Three places do not update themselves" is six.** `src/state/CLAUDE.md:133`
+  named `TABLE_ORDER`, `db.ts` and `spec/10-state.md`. Also required:
+  `schema-equivalence.test.ts` (two constants **and** a structural change, next
+  bullet), `schema-parity.test.ts`'s `covers all N tables`, and two counts in
+  `data-migrate.test.ts`. Only the first three fail loudly; the rest fail as an
+  off-by-one that reads like a bug in your change. **That checklist has been
+  corrected to six in `src/state/CLAUDE.md`** — the most useful thing this phase
+  produced for the next person.
+
+- **`schema-equivalence.test.ts` needed restructuring, not a bumped count.** It
+  asserted the schema is *identical* before and after boot, which was sound
+  while every table came from the baseline. `activity_log` is the **first table a
+  post-baseline migration creates**, so `before` and `after` are now legitimately
+  different sets. Rather than weaken the assertion, the file now separates
+  `LEGACY_TABLES` (the pre-Drizzle production shape the baseline must still
+  no-op over) from a derived `EXPECTED_TABLES`, with `POST_BASELINE_TABLES` /
+  `POST_BASELINE_INDEXES` naming the difference. The proof the file exists for is
+  intact; it just distinguishes "added a table" from "altered a legacy one".
+  Its `uniques` comparison needed the same treatment — a new table brings its own
+  PK tuple, which is a new rule on a new table, not a change to an existing one.
+
+- **`data-migrate.test.ts`'s guard fired exactly as designed.** Its comment reads
+  *"The guard that stops a 16th table from being silently left behind"* — and it
+  caught the 16th table. Beyond the count, `seed()` now inserts two
+  `activity_log` rows, because `detail` is `text`→`jsonb` across the copy and a
+  count assertion would not have exercised it. One row carries a nested object
+  with a non-ASCII string, one carries no detail at all, so NULL is proven to
+  survive as NULL rather than as `"null"`.
+
+- **The store needed no `dbc` and no serializer**, as planned — but note the
+  best-effort contract deliberately did **not** go here. `ActivityStore.record`
+  throws like any other store method; the swallow lives one level up in Phase 2's
+  `recordActivity()`. Putting it in the store would have made "a store failure
+  never fails the action" untestable, because nothing could observe the failure.
+
+One cosmetic artefact: `db:generate:sqlite` rewrote
+`drizzle/sqlite/meta/_journal.json` without its trailing newline (the pg journal
+never had one). Left as generated — §3 forbids hand-editing generated output.

--- a/docs/plans/activity-log/01-write-seams.md
+++ b/docs/plans/activity-log/01-write-seams.md
@@ -1,0 +1,197 @@
+# Phase 2 — the write seams
+
+Nineteen call sites, one helper, and the three `"admin"` literals. Every write is
+**best-effort**: a store failure logs and is swallowed, never propagated.
+
+Depends on Phase 1 ([00-schema.md](00-schema.md)).
+
+## Why explicit calls and not middleware
+
+Decision 2 in the [README](README.md). The short version: **there is nothing to
+hang middleware on.** The server has no `app.onError`, no `app.notFound`, no
+shared response helper, and three `app.use` calls in total — `authMiddleware` on
+`/api/*` (`index.ts:1561`) and on the admin sub-app (`routes.ts:688`), plus a
+static-file server for the dashboard bundle (`admin/index.ts:62`). Every route
+returns `c.json(...)` inline.
+
+A middleware could be built, and it would guarantee coverage. But it sees a
+method and a path, so it would record `POST /crons/x/toggle` rather than
+`cron.toggle`; it cannot see the value a toggle moved to; and it cannot tell a
+domain-level denial from a 200, which is exactly what `outcome` is for.
+
+The coverage that middleware would have bought is bought instead by a
+**table-driven test** (below) that fails when a mutating route has no log line.
+
+## The helper
+
+```ts
+/**
+ * Record one activity row. BEST-EFFORT: never throws, never rejects, and a
+ * store failure must not fail the action being recorded — the same posture as
+ * #205's identity capture and every read in pr-state.ts.
+ */
+export async function recordActivity(db: StateDb, entry: ActivityEntry): Promise<void>;
+
+/** The Hono-flavoured wrapper: derives actor + actorType from the request. */
+export async function recordActivityFor(c: Context, db: StateDb, entry: ...): Promise<void>;
+```
+
+- `recordActivityFor` reads `actorFromContext(c)` (`admin/auth.ts:168`) for
+  `actorLogin` and the token's `method` for `actorType`.
+- Both `catch` everything and `log.warn("activity write failed", { err })` with
+  `component: "activity"`.
+- Both return `Promise<void>` and are **`await`ed** at the call site.
+  `lint:promises` (run by `typecheck`) is the guard against a dropped promise —
+  the Drizzle migration shipped 14 such bugs through a clean compiler
+  (`src/state/CLAUDE.md:180`).
+
+Placement: the pure half beside the store; the `Context` half in
+`src/admin/activity.ts`, so nothing outside `admin/` gains a Hono edge.
+
+**Where the actor is `undefined`.** `actorFromContext` is populated only when the
+session token carries a `login` — GitHub OAuth, or Slack OAuth that matched a
+`users` row. Password login and auth-disabled instances yield `undefined`, and
+the row is written with `actor_login: null`. Do not substitute `"admin"` in the
+log the way the routes do for their `updatedBy` columns: a null actor is a true
+statement, and `"admin"` in an audit stream reads as a person.
+
+## Admin routes
+
+`src/admin/routes.ts`. All fifteen mutating routes, verified against
+`grep -n 'app\.\(post\|put\|delete\|patch\)('`. **Place the call after the action
+resolves**, so `outcome` reflects what happened rather than what was attempted.
+
+| Line | Route | `action` | `target` | Notes |
+|---|---|---|---|---|
+| 968 | `POST /login` | `login` | — | `outcome: "denied"` on a bad password. **Actor is null here by construction** — the token does not exist yet |
+| 1034 | `GET /oauth/slack/callback` | `login` | — | `actorType: "slack"`; actor is the matched `users.login`, else null |
+| 1151 | `GET /oauth/github/callback` | `login` | — | `actorType: "github"`. `outcome: "denied"` on the org-membership rejection |
+| 1429 | `DELETE /containers/:name` | `container.kill` | `container:<name>` | |
+| 1649 | `POST /workflow-runs/:id/cancel` | `workflow.cancel` | `workflow_run:<id>` | already reads the actor |
+| 1769 | `POST /workflow-runs/:id/retry` | `workflow.retry` | `workflow_run:<id>` | already reads the actor |
+| 1858 | `POST /workflows/:name/toggle` | `workflow.toggle` | `workflow:<name>` | **fix the `"admin"` literal at `:1868`**; `detail: { enabled }` |
+| 2261 | `PUT /artifacts/:owner/:repo/:key/:doc` | `artifact.edit` | `repo:<owner>/<repo>` | `detail: { key, doc }` |
+| 2328 | `POST /approvals/:id/respond` | `approval.approve` \| `approval.reject` | `approval:<id>` | already reads the actor |
+| 2501 | `POST /crons/:name/toggle` | `cron.toggle` | `cron:<name>` | **fix the `"admin"` literal at `:2511`**; `detail: { enabled }` |
+| 2538 | `POST /crons/:name/schedule` | `config.edit` | `cron:<name>` | **fix the `"admin"` literal at `:2556`**; `detail: { schedule }` |
+| 2570 | `DELETE /crons/:name/override` | `config.edit` | `cron:<name>` | `detail: { cleared: true }` |
+| 2601 | `POST /crons/:name/trigger` | `cron.trigger` | `cron:<name>` | already reads the actor |
+| 2688 | `POST /prs/:owner/:repo/:number/retry` | `pr.retry` | `pr:<owner>/<repo>#<n>` | already reads the actor; `detail: { note }` |
+| 787 | `POST /me/repos/resync` | — | — | **deliberately not logged** — a self-service cache refresh |
+| 996 | `POST /token/refresh` | — | — | **deliberately not logged** — a session slide, not an action |
+| 888 | `POST /route-test` | — | — | **deliberately not logged** — hermetic dry-run, no side effects |
+
+`POST /token/refresh` deserves the explicit note: it looks like an auth event,
+but it fires on a timer from the dashboard and would drown the `login` rows it
+sits next to.
+
+## The three `"admin"` literals
+
+`grep -n '"admin"' src/admin/routes.ts` gives eight hits. Five are the correct
+`actorFromContext(c) ?? "admin"` fallback (`:1659`, `:1781`, `:2336`, `:2714`)
+plus the logger name at `:105`. Three are the bug:
+
+```
+:1868   await db.setWorkflowEnabled(name, next, "admin");
+:2511   await db.setCronOverride(name, { enabled: nextEnabled, updatedBy: "admin" });
+:2556   await db.setCronOverride(name, { schedule, updatedBy: "admin" });
+```
+
+Each becomes `actorFromContext(c) ?? "admin"`, matching the four routes that
+already do it. This is #205 work, but it belongs here (decision 7): these are the
+config-edit actions this log exists to record, and logging them while they still
+say `"admin"` would enshrine the bug in the audit stream instead of fixing it.
+
+Their `updatedBy` columns keep the `?? "admin"` fallback — that is an existing
+wire contract the dashboard renders. Only the **activity row** carries a null
+actor when there is no login.
+
+## Non-HTTP seams
+
+**`workflow.trigger` — `src/index.ts`, inside `dispatchWorkflow` (`:417`).**
+Write it after the actor is derived at `:657-673` and after the guards pass, so
+a row exists only when a run does. **Gate on the actor type** (decision 3):
+
+```ts
+if (triggerActorType !== "cron" && triggerActorType !== "system") { … }
+```
+
+That one condition covers CLI `/api/run` + `/api/build`, the GitHub webhook,
+Slack chat and PR fix — and excludes the cron fan-out, whose per-repo dispatches
+are not user actions and would otherwise be the dominant row source. The
+fan-out is recorded once, at its cause, by `cron.fire`.
+
+**`approval.approve` / `approval.reject` — `src/engine/dispatcher.ts`,
+`handleApprovalResponse` (`:991`).** This is the **Slack + GitHub approval choke
+point**: a Slack button click and a `@bot approve` comment both land here, having
+been routed at `:371`. One call covers both external routes and complements the
+dashboard route at `routes.ts:2328`. It already has `decision`, `sender` and
+`reason` in scope, and `deps.db` (`DispatchDeps.db`, `:76`).
+
+`actorType` is `slack` when `envelope.type === "message"`, else `github` —
+matching the derivation `dispatchWorkflow` already uses.
+
+**`cron.fire` — `src/cron/runner.ts:119` and `src/cron/handlers.ts:101`.** Both
+already call `db.cronRuns.start({ cronName, source, actor })` with exactly the
+fields this row needs. Write beside each:
+
+- `actorType: "cron"` and `actorLogin: null` for `source === "schedule"`;
+- the real login (already on `_cronActor`, threaded from `routes.ts:2629`) with
+  `actorType: "admin"` for `source === "manual"`.
+
+A manual fire therefore writes **two** rows — `cron.trigger` at the route and
+`cron.fire` at the runner — which is correct: they are the request and the
+execution, they can disagree (a trigger that never fires is the interesting
+case), and `cron_runs` already models the same pair.
+
+> **Known gap, not introduced here.** Issue #346 records that `registerDirect`
+> crons (`sandbox-sweep`, `feedback-poll`) write no `cron_runs` row. They will
+> likewise write no `cron.fire` row. Fixing that is #346's job; this plan
+> inherits its scope rather than widening.
+
+## Tests
+
+`tests/admin/activity-write.test.ts`, on the harness from
+`tests/admin/feedback-routes.test.ts:1-78` — the `vi.mock` of `#src/logging/logger.js`
+and `#src/admin/docker.js` (required: `routes.ts` pulls docker helpers at import
+time), `makeTestDb()`, `createAdminRoutes(...)`, and `app.fetch` against a plain
+`Request`. For authenticated cases use the `build(config)` + `createToken(SECRET, …)`
+pattern from `tests/admin/me-repos.test.ts:41-58`.
+
+Four things to prove:
+
+1. **Exactly one row per action** — #206's acceptance criterion, asserted as a
+   count, not a "contains".
+2. **The right actor on the three de-hardcoded routes** — a token carrying
+   `login: "someone"` produces `actor_login: "someone"`, not `"admin"`, on both
+   the activity row and the `updatedBy` column.
+3. **`outcome: "denied"`** on a rejected action (a bad password at `/login`, a
+   failed org check at the GitHub callback).
+4. **A store failure does not fail the action.** Stub `db.activity.record` to
+   reject; assert the route still returns 200 and the underlying state change
+   still happened. This is decision 5, and it is the test most likely to catch a
+   regression later.
+
+Plus the **route→verb pin**: enumerate the mutating routes (the same
+`app.post|put|delete|patch` set this doc tabulates) and assert each is either in
+the verb map or in an explicit `NOT_LOGGED` allowlist with a reason. That test is
+what replaces middleware's coverage guarantee, and it is why the three
+deliberate omissions above are written down rather than merely skipped.
+
+`tests/cron/runner.test.ts` and `tests/cron/handler-crons.test.ts` already exist
+and cover the `cron_runs` write; extend them for the paired `cron.fire` row.
+
+## Verify
+
+```bash
+pnpm --filter lastlight-core test tests/admin tests/cron
+pnpm --filter lastlight-core typecheck   # lint:promises catches a dropped await
+```
+
+## Done when
+
+- All fifteen mutating routes either write a row or are in `NOT_LOGGED`.
+- The three `"admin"` literals are gone.
+- A scheduled cron fire writes one `cron.fire` and zero `workflow.trigger` rows,
+  however many repos it fans out to.
+- Stubbing the store to throw breaks no test but the one asserting it throws.

--- a/docs/plans/activity-log/01-write-seams.md
+++ b/docs/plans/activity-log/01-write-seams.md
@@ -1,5 +1,9 @@
 # Phase 2 — the write seams
 
+> **Status: implemented.** See the Execution notes at the end for what actually
+> happened. The steps below are the plan **as originally written**, kept
+> unchanged on purpose so the notes can argue against them.
+
 Nineteen call sites, one helper, and the three `"admin"` literals. Every write is
 **best-effort**: a store failure logs and is swallowed, never propagated.
 
@@ -195,3 +199,54 @@ pnpm --filter lastlight-core typecheck   # lint:promises catches a dropped await
 - A scheduled cron fire writes one `cron.fire` and zero `workflow.trigger` rows,
   however many repos it fans out to.
 - Stubbing the store to throw breaks no test but the one asserting it throws.
+
+## Execution notes (27 Aug 2026)
+
+Phase 2 landed. `pnpm turbo run typecheck test build` is green — 25/25 tasks,
+3855 core tests. Five things the plan did not anticipate:
+
+- **The helper had to split in two, and the plan put it in the wrong place.**
+  It said "the `Context` half in `src/admin/activity.ts`", which is right, but
+  the *pure* half cannot live there either: `engine/dispatcher.ts` and
+  `cron/runner.ts` both write, and `engine/ → admin/` is the wrong direction.
+  `recordActivity` therefore sits at **`src/activity.ts`**, a peer of
+  `managed-repos.ts`, with `admin/activity.ts` holding only the Hono wrapper.
+  `lint:boundaries` does not currently police that direction — this was caught
+  by reading, not by the gate.
+
+- **`actorFromContext` was not enough.** It surfaces the login but not *how* the
+  person authenticated, and `actor_type` needs the latter. `authMiddleware` now
+  also sets `actorMethod`, with a new `actorTypeFromContext()` beside the
+  existing seam mapping `password → admin`, `github → github`, `slack → slack`.
+  Additive, and it keeps the "one place reads the token" property #205
+  established.
+
+- **Nineteen call sites is really twenty-two**, because six routes write on
+  *both* their success and their refusal path — a denied login, a locked
+  artifact, a refused PR retry, a failed container kill. Those denials are a
+  large part of what an audit stream is read for, so the extra rows are the
+  feature rather than overhead. Still fifteen distinct actions.
+
+- **`workflow.trigger` belongs in `onRunStart`, not at the top of
+  `dispatchWorkflow`.** The plan said "after the guards pass", which is correct
+  but underspecified: the run **id** does not exist until `runSimpleWorkflow`
+  creates the row, and `onRunStart` is the callback that fires the moment it
+  does. Writing earlier would have meant either no target or a row for a
+  dispatch that was later refused.
+
+- **A seventh thing that does not update itself, and it is not in the state
+  layer.** `scripts/lint-floating-promises.mjs` carries an `ALLOWED` set keyed
+  by **`file:line`** — two deliberately-unfixed `stream.writeSSE` calls in
+  `routes.ts`. Adding two import lines shifted them from 452/458 to 454/460, so
+  the gate failed pointing at SSE code this change never touched. The entries
+  are updated and a comment now warns about the coupling. Deliberately **not**
+  re-keyed on expression text: that file's own comment says to fix its contents
+  in a change that is about SSE, and re-designing a gate as a drive-by is the
+  same mistake in a different direction. Worth a maintainer's decision.
+
+One thing the plan got right and is worth restating, because it looks like a
+bug: a manual cron fire writes **two** rows — `cron.trigger` from the route and
+`cron.fire` from the runner — and a PR retry likewise writes `pr.retry` plus a
+`workflow.trigger` from the dispatch it starts. Those are the request and the
+execution. They can disagree (a trigger that never fires, a retry the gate
+refuses), and that disagreement is the interesting case.

--- a/docs/plans/activity-log/02-read-surfaces.md
+++ b/docs/plans/activity-log/02-read-surfaces.md
@@ -1,5 +1,8 @@
 # Phase 3 — the read surfaces
 
+> **Status: implemented.** See the Execution notes at the end for what actually
+> happened. The steps below are the plan **as originally written**.
+
 The admin endpoint, the dashboard Activity tab + per-run strip, and the
 `lastlight activity` subcommand. All read-only.
 
@@ -199,3 +202,37 @@ clean run here is the proof that item shipped.
 - The per-run strip renders on a run with activity and vanishes on one without.
 - `lastlight activity` and `--json` agree with the dashboard.
 - The dashboard mirror pin passes.
+
+## Execution notes (31 Aug 2026)
+
+Phase 3 landed. `pnpm turbo run typecheck test build` green — 25/25 tasks. The
+plan held up better here than in the earlier phases; four notes:
+
+- **A real bug the plan never contemplated, found by the bot's own review.**
+  `cron.fire` hardcoded `actorType: "admin"` for every manual fire, so a
+  GitHub-authenticated "Run now" wrote `cron.trigger` as `github` and its paired
+  `cron.fire` as `admin` — two rows for one action disagreeing about the same
+  person. The cron context carried `_cronActor` (the login) but nothing about
+  HOW they authenticated. Fixed by threading `_cronActorType` alongside it, with
+  `admin` kept only as the genuine-unknown fallback (which is what `admin`
+  means: a password session). Worth noting the review that caught it was
+  `nearform-lastlight` reviewing its own feature.
+
+- **`?target=` must split on the FIRST colon, not `split(":")`.** A target id
+  can contain one — `container:lastlight-sandbox-a:b` — and a naive split would
+  truncate it. Pinned by a test.
+
+- **`limit=0` falls back to the default rather than clamping to 1**, because
+  `parseInt(...) || 50` short-circuits on zero. That is `/feedback/signals` and
+  `/workflow-runs` verbatim. My first test asserted the tidier rule and failed;
+  the endpoint was right and the test was wrong. Consistency across the list
+  endpoints beats a marginally better rule in one of them.
+
+- **The user enrichment is per distinct login, not per row.** A page of 50 is
+  routinely two or three people, so a per-row `findByLogin` would be up to 50
+  queries for 3 answers.
+
+Two things carried over from the plan and still hold: the per-run strip needed
+no new route (`?target=workflow_run:<id>`), and it self-hides on a run nobody
+has touched, copying `PrStatePanel` so the detail panel does not fill with empty
+sections.

--- a/docs/plans/activity-log/02-read-surfaces.md
+++ b/docs/plans/activity-log/02-read-surfaces.md
@@ -1,0 +1,201 @@
+# Phase 3 — the read surfaces
+
+The admin endpoint, the dashboard Activity tab + per-run strip, and the
+`lastlight activity` subcommand. All read-only.
+
+Depends on Phases 1 and 2.
+
+## The endpoint
+
+`GET /admin/api/activity`, in `src/admin/routes.ts`. Mirror
+`GET /feedback/signals` (`:1323`) — the newest and cleanest list endpoint,
+without the legacy `repos` scope baggage `/workflow-runs` carries:
+
+```ts
+app.get("/activity", async (c) => {
+  const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "50", 10) || 50, 1), 200);
+  const offset = Math.max(parseInt(c.req.query("offset") ?? "0", 10) || 0, 0);
+  const { activity, total } = await db.activity.list({
+    limit,
+    offset,
+    actor:  c.req.query("actor")  || undefined,
+    action: c.req.query("action") || undefined,
+    target: c.req.query("target") || undefined,   // "<type>:<id>", split on the first ":"
+    sinceIso: c.req.query("since") || undefined,
+  });
+  return c.json({ activity, total });
+});
+```
+
+House conventions this follows, none of them optional:
+
+- **`limit` clamped to `[1, 200]`, default 50; `offset` clamped `>= 0`.** The
+  clamps matter — `GET /executions` (`:1456`) skips them with a bare `Number(...)`
+  and is the counterexample, not the template.
+- **Envelope `{ activity, total }`.** One object, no `meta`/`pagination` wrapper,
+  and **no companion count endpoint** — `total` is the post-filter count from the
+  same store call. The dashboard already exploits this shape elsewhere by
+  requesting `limit: 1` when it wants only a count.
+- **A companion distinct-values route** for the filter dropdown, mirroring
+  `GET /workflow-names` (`:1575`) exactly:
+  ```ts
+  app.get("/activity/actions", async (c) => c.json({ actions: await db.activity.actions() }));
+  ```
+
+**Enrichment.** Rows join to `users` on `actor_login` for name and avatar. The
+pattern already exists at `routes.ts:1583-1597`, where `GET /workflow-runs/:id`
+enriches `triggered_by` via `db.users.findByLogin`. Batch it — one
+`findByLogin` per distinct actor on the page, not per row.
+
+**No per-run route.** Decision 6: the strip is
+`GET /admin/api/activity?target=workflow_run:<id>`. The filter the global feed
+needs is the filter the strip needs, and `GET /workflow-runs/:id/feedback` exists
+only because feedback anchors cannot be expressed as a target filter.
+
+**Repo scoping is deliberately not applied.** `/workflow-runs`, `/sessions` and
+`/stats` accept `?repos=` for #169's per-repo visibility, but that is **UI
+declutter, not enforcement** — the comment at `routes.ts:758` says so, and all
+three keep returning global data. An audit stream filtered by which teams you
+belong to would be misleading in a way a run list is not. If this changes later
+it should be a real authorization decision, not a copied query param.
+
+## Dashboard
+
+`apps/server/dashboard/` — React 19 + Vite + Tailwind 4 + daisyUI. **No router
+library** and **no React Query or SWR**: navigation is a `Tab` union plus URL
+state, and data fetching is `fetch` + `useState`/`useEffect` + a `setInterval`
+poll.
+
+### The wire type is hand-mirrored
+
+The dashboard has **no import edge to core**, so `ActivityRecord` is typed a
+second time in `dashboard/src/api.ts`, beside the other response interfaces,
+with `api.activity(opts)` / `api.activityActions()` built on the
+`URLSearchParams` + `req<T>` pattern at `api.ts:884-915`.
+
+**Add a mirror pin** in `tests/admin/`, modelled on
+`dashboard-config-mirror.test.ts`. That file exists because a hand-mirrored type
+drifted and hid three config blocks for a release; its header says so. The pin
+reads the dashboard source as text from core's suite — the established technique
+for pinning a UI contract without a React test runner.
+
+### The tab — four edit points in `App.tsx`
+
+1. `type Tab` union (`:56`) — add `"activity"`.
+2. `const TABS` array (`:60`) — add it (this is what the enum parser reads).
+3. The left icon rail's nav array (`:297-333`) — `{ id, label, Icon }`.
+4. The render switch (`:335-426`) — one more ternary branch.
+
+Tab state already round-trips through the URL via `useUrlState("tab", …,
+enumParser(TABS, …))`, so a deep link works for free.
+
+### `ActivityPage.tsx`
+
+Model it on `FeedbackPage.tsx:86-113` — the closest size and shape: a couple of
+`Promise.all` fetches, a 30 s poll, and a `catch {}` that deliberately leaves the
+last good render in place rather than blanking the page on a transient failure.
+
+Filter state (`actor`, `action`, `since`) through `useUrlState` +
+`nullableStringParser`, so a filtered feed is linkable.
+
+**Reuse, do not rebuild.** Four things already exist:
+
+| Need | Use |
+|---|---|
+| The "who" cell — login + avatar + actor-type badge | `components/ActorChip.tsx` |
+| Outcome colours | `lib/status-colors.ts` — never local hex; see the comment at `FeedbackPage.tsx:36-42` |
+| Relative timestamps | `timeAgo` — currently **file-local** at `HomePage.tsx:96`. Lift it to `lib/` and import it in both places rather than copying a third formatter into the tree |
+| The visual model for a compact row list | `LiveActivitySection` in `HomePage.tsx:425-500` |
+
+`LiveActivitySection` is worth reading before designing anything: it is the
+closest existing thing to an activity feed, and matching it keeps the new tab
+from reading as a different product.
+
+### The per-run strip
+
+A new sibling inside `DetailPanel` (`WorkflowList.tsx`), between `<PrStatePanel>`
+(`:525`) and `<ResizablePipeline>` (`:527`).
+
+**Copy `PrStatePanel`'s self-hiding pattern**: it renders nothing when the run
+carries no PR state, which is what keeps the detail panel from filling with empty
+sections. An activity strip on a run nobody has touched should be invisible, not
+an empty box.
+
+Fetch once on run selection — not polled. `FeedbackBadge` (`WorkflowList.tsx:101`)
+is the precedent: a run-scoped fetch at `:322-331` with no interval.
+
+## CLI
+
+`packages/cli/` — no commander, no yargs. A hand-rolled `parseArgs`
+(`cli.ts:67`) and a `switch (cmd)` (`cli.ts:1352`).
+
+**Put the logic in `packages/cli/src/activity-cli.ts`, not `cli.ts`.** `cli.ts`
+runs `main()` on import, so anything defined there is untestable. Follow
+`pr-cli.ts`: a self-contained module taking an injected `apiGet` seam, dynamically
+imported from its `case`. That injection is the whole reason
+`packages/cli/tests/pr-cli.test.ts` can exist.
+
+Four registration points:
+
+1. `case "activity": return cmdActivity();` in the switch (`cli.ts:1352-1381`).
+2. `HELP_TOPICS` (`:273`) — the per-command detail shown by `lastlight activity help`.
+3. The compact `HELP` index (`:388-423`) — add to the `Debug` line.
+4. `BOOLEAN_FLAGS` (`cli.ts:44`) — **only if a boolean flag is added**. Value
+   flags (`--actor`, `--action`, `--since`, `--limit`) need nothing.
+
+Auth and transport are already solved: `apiGet(path)` (`:204`) handles the base
+URL, the bearer token, `ensureFreshToken()`'s half-life refresh, and dies with a
+friendly message on a network failure.
+
+Output follows `cmdWorkflow`'s `list` (`cli.ts:597-624`): `table()` + `age()`
+from `cli-format.ts` for humans, and `out("", data)` when `--json`, which prints
+the envelope verbatim. End with the same dim summary line —
+`` `${data.total} total.` `` — so the CLI reports the same number the UI shows.
+
+## Verify
+
+```bash
+pnpm --filter lastlight-core test tests/admin
+pnpm --filter @lastlight/dashboard typecheck
+pnpm --filter lastlight test              # the CLI's own suite
+pnpm turbo run typecheck test build       # the CI gate, from the repo root
+```
+
+### End to end
+
+```bash
+./scripts/dev-local.sh
+```
+
+In one session: log in, toggle a cron off and on, fire it manually, cancel the
+run it produces, and answer an approval gate. Then confirm
+
+- the Activity tab shows those actions as distinct rows, **attributed to your
+  GitHub login rather than `admin`** (the Phase 2 fix);
+- the run detail strip shows only that run's rows, and is invisible on an
+  untouched run;
+- `lastlight activity --limit 20` and `--json` agree with the UI, including
+  `total`.
+
+Then prove the dual-dialect path, which is the one thing unit tests cannot fully
+cover:
+
+```bash
+pnpm --filter lastlight-core dev:db:up
+pnpm --filter lastlight-core dev:db:migrate     # exercises TABLE_ORDER for the new table
+LASTLIGHT_DEV_DB=postgres pnpm --filter lastlight-core dev
+```
+
+`dev:db:migrate` is the real check on Phase 1's `data-migrate.ts` entry — the
+copy **refuses to start** if `activityLog` is missing from `TABLE_ORDER`, so a
+clean run here is the proof that item shipped.
+
+## Done when
+
+- `GET /admin/api/activity` filters and paginates, and `total` is the
+  post-filter count.
+- The Activity tab renders a filterable feed with real avatars, and the filter
+  state is in the URL.
+- The per-run strip renders on a run with activity and vanishes on one without.
+- `lastlight activity` and `--json` agree with the dashboard.
+- The dashboard mirror pin passes.

--- a/docs/plans/activity-log/README.md
+++ b/docs/plans/activity-log/README.md
@@ -1,0 +1,195 @@
+# Activity log — design
+
+One append-only stream of **who did what, when, and what came of it** — across
+the dashboard, the CLI, Slack, GitHub and cron.
+
+Today that question has no answer. #205 established real identity and put an
+actor on every run and execution, but the actor is **scattered across five
+ledgers** and several actions leave no trace at all:
+
+| Where an actor lives today | Table / column |
+|---|---|
+| A run's origin | `workflow_runs.triggered_by` + `trigger_actor_type` |
+| Who retried, cancelled, or ran a phase | `executions.triggered_by` |
+| Who answered an approval gate | `workflow_approvals.responded_by` |
+| Who changed a cron | `cron_overrides.updated_by` |
+| Who flipped a workflow's kill switch | `workflow_overrides.updated_by` |
+
+Answering *"what has this person done on this instance?"* means joining five
+tables and unioning the results. Answering *"what happened in the last hour?"*
+is worse, because three of those tables have no time-ordered index that spans
+actors. And **login, config edits, container kills and artifact edits are not in
+the list at all** — they happen and leave nothing behind.
+
+This is the follow-up [#205](https://github.com/nearform/lastlight/issues/205)
+explicitly deferred, filed as
+[#206](https://github.com/nearform/lastlight/issues/206).
+
+## The issue body is stale — read this instead
+
+**#206 was written on 2026-07-21, before the state layer was rewritten.** Its
+"High-level shape" section tells you to add DDL to `src/state/migrate.ts`'s
+`db.exec` block. That file no longer exists in that form: [#351] moved the state
+layer to Drizzle, and [#352] made Postgres a production runtime beside SQLite.
+
+The issue is right about **what to build**. It is wrong about **how to change
+the schema**, and following it literally would break the dual-dialect discipline
+that `src/state/CLAUDE.md` exists to protect. Everything schema-shaped in this
+plan follows that file and `spec/10-state.md` instead.
+
+The same staleness affects one design instruction. The issue proposes hanging
+the write on *"a small helper the actor-hardcoded admin routes already funnel
+through"*. **No such funnel exists** — see decision 2.
+
+[#351]: https://github.com/nearform/lastlight/pull/351
+[#352]: https://github.com/nearform/lastlight/pull/352
+
+## What already exists
+
+#205 landed via PR #207 and its foundation is real in the tree. This design adds
+nothing to it and re-uses all of it:
+
+| Thing | Location |
+|---|---|
+| `users` table (soft join on `login`) | `src/state/schema/sqlite.ts:222` |
+| `TriggerActorType` + `isTriggerActorType` | `src/state/user-store.ts:11` |
+| `actorFromContext(c)` | `src/admin/auth.ts:168`, set by `authMiddleware` at `:155` |
+| `triggered_by` / `trigger_actor_type` | `executions` (`:76`), `workflow_runs` (`:128`) |
+| Actor derivation at the dispatch choke point | `src/index.ts:657-673` |
+
+The nearest structural precedent is **`cron_runs`** (PR #344, issues #341/#327):
+an append-only ledger table, one row per fire, with a store, an admin surface, a
+dashboard panel and a spec section. Its rationale in `spec/10-state.md:374-425`
+is the model for this table's, and several decisions below are the same
+decisions reached again for the same reasons.
+
+## Locked decisions
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | **A new table, not a widened `executions`** | Same three reasons `cron_runs` did not overload it (`spec/10-state.md:412`): `executions` has no column for a non-workflow action, its `success` flag is binary so `denied` has nowhere to live, and its `success = 0` population is dominated by DAG-cascade skips and quota deferrals that must stay `success = 0`. An audit row is written by exactly one writer and can contain neither |
+| 2 | **Explicit `recordActivity()` at each action site — not middleware** | There is no seam to hang middleware on: no `app.onError`, no `app.notFound`, no shared response helper, and three `app.use` calls in the whole server — `authMiddleware` twice (`index.ts:1561`, `routes.ts:688`) and one static-file server (`admin/index.ts:62`). One could be *built*, but it would produce `POST /crons/x/toggle` rather than `cron.toggle`, and it cannot see the new value or distinguish a domain-level denial from a 200. Coverage is instead guaranteed by a **table-driven test pinning the route→verb map**, so a new mutating route added without a log line fails CI |
+| 3 | **The log records user-initiated actions. System fan-out is recorded once, at its cause** | This is #206's own wording (*"Every **user-initiated** action … writes exactly one row"*) and it resolves the volume question exactly — see below. A cron fan-out dispatch is not a user action; the user action was the cron trigger, or nothing at all for a scheduled fire |
+| 4 | **Keyed reads tie-break on `id`, and `id` is creation-ordered** | Straight from `cron_runs` (`spec/10-state.md:419`). Postgres has no `rowid`; a bare UUID makes a same-millisecond page boundary unstable, which silently drops or repeats rows across pages. Copy `creationOrderedId()` from `cron-run-store.ts:26` |
+| 5 | **Best-effort: a store failure never fails the action** | #206 requires it, and it matches the existing posture for #205's identity capture and every read in `pr-state.ts`. Swallow, log at `warn` with `component: "activity"` |
+| 6 | **`GET /admin/api/activity?target=workflow_run:<id>` serves the per-run strip** | No new route. The filter the global feed already needs is exactly the filter the strip needs |
+| 7 | **The three `"admin"` literals get fixed in this plan, not deferred** | `routes.ts:1868`, `:2511`, `:2556` write `"admin"` instead of the authenticated user. They are precisely the config-edit actions this log is for; logging them while they still say `"admin"` would enshrine the bug in the audit stream rather than fix it |
+
+## Decision 3, and the volume question it answers
+
+The obvious place to write `workflow.trigger` is `dispatchWorkflow`
+(`src/index.ts:417`) — the choke point every trigger path already funnels
+through. The obvious objection is volume: the cron fan-out dispatches **once per
+repo**, and `cron-triage` fires every 15 minutes.
+
+Decision 3 makes the objection moot, and it is the same answer `cron_runs`
+already reached. `spec/10-state.md:406` — *"Why it is keyed on `cron_name`"* —
+records that keying a cron's history on the workflow let a hand-triggered
+failure move the cron's health and vice versa. The same confusion appears here:
+a cron fan-out is **one** operational event, not N user actions.
+
+So:
+
+- **`workflow.trigger`** is written only when the trigger has a human actor —
+  `triggerActorType` in `{github, slack, cli, admin}`. The derivation already
+  exists at `index.ts:660-673` and needs no new plumbing.
+- **`cron.fire`** is written once per fire, beside the existing
+  `db.cronRuns.start(...)` call, for both `workflow:` and `handler:` crons.
+
+The resulting growth is bounded and checkable:
+
+| Source | Rows/day |
+|---|---|
+| `cron.fire` — `cron-triage` `*/15` | 96 |
+| `cron.fire` — `cron-review` `*/30` | 48 |
+| `cron.fire` — `cron-dependabot-{ci-fix,merge}` daily | 2 |
+| `cron.fire` — `cron-{digest,health,security}` weekly | <1 |
+| `workflow.trigger` | ⊂ `workflow_runs` rows (human-triggered subset) |
+| Everything else (login, toggles, approvals, cancels) | tens |
+
+≈ **150 rows/day from crons**, ~55k/year, plus a strict *subset* of
+`workflow_runs` growth. **The activity log grows more slowly than the
+`workflow_runs` table already does**, which is why #206's deferral of retention
+to a later issue is safe rather than optimistic.
+
+A denied cron fan-out dispatch is therefore not recorded here. That is
+deliberate — it is the normal steady state for a backstop sitting behind a
+webhook, it is already visible in `cron_runs`' `dispatched` / `failures` counts,
+and recording it would make the dominant row source a thing no human did.
+
+## Consequences worth stating up front
+
+- **`actorFromContext` returns `undefined` more often than it looks.** It is
+  populated only when the token carries a `login` — GitHub OAuth, or Slack OAuth
+  that matched a `users` row (`auth.ts:155`). **Password login and auth-disabled
+  instances yield `undefined`**, so a fresh install with `ADMIN_PASSWORD` set
+  logs `actor_login: null`, `actor_type: "admin"`. The rows are still useful
+  (verb, target, outcome, time) but they do not name a person. This is inherited
+  from #205, not introduced here, and it is why `actor_login` is nullable.
+- **`actor_login` is free text, soft-joined to `users.login`.** No FK — the same
+  additive-enrichment choice #205 made deliberately, so a row survives a user
+  who never logged into the dashboard.
+- **The dashboard wire type must be hand-mirrored.** `apps/server/dashboard/` has
+  no import edge to core, so `ActivityRecord` is typed twice. That mirror drifted
+  once before and hid three config blocks for a release, which is why
+  `tests/admin/dashboard-config-mirror.test.ts` exists — this plan adds an
+  equivalent pin.
+- **Sixteen tables, not fifteen.** Four counts in prose and two test constants
+  hardcode the number. See 00-schema.md → "The things that do not update
+  themselves".
+
+## What is deliberately not in this plan
+
+- **Retention / rotation.** #206 defers it; the volume table above is why that
+  is safe. A pruning follow-up should be filed, not built here.
+- **Reading the log back into behaviour.** It is an audit stream, analytical
+  only — the same posture as feedback signals (`spec/10-state.md:518`).
+- **PII beyond `login`.** `detail` is a short summary, never a payload. No
+  request bodies, no prompt text, no tokens.
+- **Backfilling history from the five existing ledgers.** They stay where they
+  are and keep their meaning (#206 non-goal 1). The log starts empty at the
+  migration and is only ever appended to.
+- **`POST /me/repos/resync` and `POST /route-test`.** The first is a
+  self-service cache refresh, not an action on the system; the second is a
+  hermetic router dry-run with no side effects. Recorded here so the omission
+  reads as a decision rather than an oversight.
+
+## Phases
+
+Each phase is independently green, independently reviewable, and lands as its
+own PR. Phase 1 changes nothing observable — it builds the table and the store.
+The feature first does something in Phase 2; Phase 3 is what a person can see.
+
+- [x] **Phase 1** — [00-schema.md](00-schema.md) — the `activity_log` table on
+  both dialects, `ActivityStore`, and the six places that do not update
+  themselves *(risk: medium — dual-dialect schema change, the one class of
+  change this repo guards hardest)*
+- [ ] **Phase 2** — [01-write-seams.md](01-write-seams.md) — `recordActivity()`
+  and its 19 call sites, plus the three `"admin"` literals *(risk: low —
+  additive, best-effort, cannot fail an action; but touches many files)*
+- [ ] **Phase 3** — [02-read-surfaces.md](02-read-surfaces.md) — the admin
+  endpoint, the dashboard tab + per-run strip, the `lastlight activity`
+  subcommand *(risk: low — read-only)*
+
+## Open questions for the maintainer
+
+Both are cheap to change now and expensive once rows exist.
+
+1. **The verb vocabulary** (00-schema.md → "Actions"). Fourteen verbs in a
+   `<noun>.<verb>` shape. Worth a look before Phase 1 lands, because these
+   strings become data.
+2. **`config.edit` is doing double duty** — it covers both the cron schedule
+   override and its deletion, distinguished only by `detail`. The alternative is
+   `cron.schedule` + `cron.schedule.clear`. Recommend keeping `config.edit`
+   broad, since #206 names it as one verb and the target already carries the
+   `cron:<name>` specificity.
+
+## Status
+
+**Phase 1 implemented; Phases 2 and 3 outstanding.** Written against `main` at
+`0d167c01`. Each phase doc gains Execution notes as it lands, so this directory
+reads as both a plan and a record.
+
+The two open questions above are still open — the verb vocabulary is now
+declared in `src/state/activity-store.ts` as a closed union, so changing it is
+still a one-file edit until Phase 2 starts writing rows against it.

--- a/docs/plans/activity-log/README.md
+++ b/docs/plans/activity-log/README.md
@@ -164,8 +164,8 @@ The feature first does something in Phase 2; Phase 3 is what a person can see.
   both dialects, `ActivityStore`, and the six places that do not update
   themselves *(risk: medium — dual-dialect schema change, the one class of
   change this repo guards hardest)*
-- [ ] **Phase 2** — [01-write-seams.md](01-write-seams.md) — `recordActivity()`
-  and its 19 call sites, plus the three `"admin"` literals *(risk: low —
+- [x] **Phase 2** — [01-write-seams.md](01-write-seams.md) — `recordActivity()`
+  and its 22 call sites, plus the three `"admin"` literals *(risk: low —
   additive, best-effort, cannot fail an action; but touches many files)*
 - [ ] **Phase 3** — [02-read-surfaces.md](02-read-surfaces.md) — the admin
   endpoint, the dashboard tab + per-run strip, the `lastlight activity`
@@ -186,10 +186,11 @@ Both are cheap to change now and expensive once rows exist.
 
 ## Status
 
-**Phase 1 implemented; Phases 2 and 3 outstanding.** Written against `main` at
+**Phases 1 and 2 implemented; Phase 3 outstanding.** Written against `main` at
 `0d167c01`. Each phase doc gains Execution notes as it lands, so this directory
 reads as both a plan and a record.
 
-The two open questions above are still open — the verb vocabulary is now
-declared in `src/state/activity-store.ts` as a closed union, so changing it is
-still a one-file edit until Phase 2 starts writing rows against it.
+The two open questions above are still open. The verb vocabulary is declared as
+a closed union in `src/state/activity-store.ts`; changing a verb is now that
+edit plus its call sites, so it is no longer free — but nothing has been
+deployed, so no rows exist yet and nothing needs migrating.

--- a/docs/plans/activity-log/README.md
+++ b/docs/plans/activity-log/README.md
@@ -167,7 +167,7 @@ The feature first does something in Phase 2; Phase 3 is what a person can see.
 - [x] **Phase 2** — [01-write-seams.md](01-write-seams.md) — `recordActivity()`
   and its 22 call sites, plus the three `"admin"` literals *(risk: low —
   additive, best-effort, cannot fail an action; but touches many files)*
-- [ ] **Phase 3** — [02-read-surfaces.md](02-read-surfaces.md) — the admin
+- [x] **Phase 3** — [02-read-surfaces.md](02-read-surfaces.md) — the admin
   endpoint, the dashboard tab + per-run strip, the `lastlight activity`
   subcommand *(risk: low — read-only)*
 
@@ -186,11 +186,12 @@ Both are cheap to change now and expensive once rows exist.
 
 ## Status
 
-**Phases 1 and 2 implemented; Phase 3 outstanding.** Written against `main` at
+**All three phases implemented.** Written against `main` at
 `0d167c01`. Each phase doc gains Execution notes as it lands, so this directory
 reads as both a plan and a record.
 
-The two open questions above are still open. The verb vocabulary is declared as
-a closed union in `src/state/activity-store.ts`; changing a verb is now that
-edit plus its call sites, so it is no longer free — but nothing has been
-deployed, so no rows exist yet and nothing needs migrating.
+Both open questions were **answered by @cliftonc on #364**: the verb vocabulary
+is fine as-is ("simple strings that are what they say they are"), and
+`config.edit` stays broad ("there is very little today that is editable"). They
+are recorded here rather than removed, because the reasoning is what a future
+reader needs when a fifteenth verb is proposed.

--- a/packages/cli/src/activity-cli.ts
+++ b/packages/cli/src/activity-cli.ts
@@ -1,0 +1,97 @@
+/**
+ * `lastlight activity` — the audit stream, read-only (issue #206).
+ *
+ * A thin admin-API client over `GET /admin/api/activity`. Lives in its own
+ * module, and takes its fetch as an injected seam, for the same reason
+ * `pr-cli.ts` does: `cli.ts` runs `main()` on import, so anything defined there
+ * cannot be unit-tested.
+ */
+
+import chalk from "chalk";
+import { table, age } from "./cli-format.js";
+
+/** The GET seam `cli.ts` injects. */
+export interface ActivityOpts {
+  /** `--json` — print the server's answer verbatim. */
+  json?: boolean;
+  apiGet: (path: string) => Promise<any>;
+}
+
+const USAGE = `Usage: lastlight activity [--actor <login>] [--action <verb>] [--target <type:id>] [--since <iso>] [--limit N]`;
+
+/** Colour by outcome, not by status — this stream has its own vocabulary. */
+function colorOutcome(outcome: string): string {
+  switch (outcome) {
+    case "ok":
+      return chalk.green(outcome);
+    case "denied":
+      return chalk.yellow(outcome);
+    case "error":
+      return chalk.red(outcome);
+    default:
+      return outcome;
+  }
+}
+
+/**
+ * `workflow_run` + `4f3a…` → `workflow_run:4f3a…`, truncated to stay in a
+ * terminal column. A run id is a uuid and only its head is ever recognisable.
+ */
+function renderTarget(type?: string, id?: string): string {
+  if (!type && !id) return "";
+  if (!id) return type!;
+  const short = id.length > 28 ? `${id.slice(0, 26)}…` : id;
+  return type ? `${type}:${short}` : short;
+}
+
+export async function activityCommand(argv: string[], opts: ActivityOpts): Promise<number> {
+  if (argv[0] === "help" || argv.includes("--help")) {
+    console.log(USAGE);
+    return 0;
+  }
+
+  const params = new URLSearchParams();
+  const flagValue = (name: string): string | undefined => {
+    const i = argv.indexOf(`--${name}`);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  for (const name of ["actor", "action", "target", "since", "limit", "offset"]) {
+    const value = flagValue(name);
+    if (value) params.set(name, value);
+  }
+  if (!params.has("limit")) params.set("limit", "30");
+
+  const data = await opts.apiGet(`/admin/api/activity?${params}`);
+  if (opts.json) {
+    console.log(JSON.stringify(data, null, 2));
+    return 0;
+  }
+
+  const users = (data.users ?? {}) as Record<string, { name?: string }>;
+  const rows = (data.activity as any[]).map((a) => ({
+    when: age(a.createdAt),
+    // The real name when `users` knows one, else the bare login. A null actor
+    // is a password session or an auth-disabled instance, not a missing row —
+    // so it renders as a dim marker rather than an empty cell.
+    actor: a.actorLogin
+      ? (users[a.actorLogin]?.name ?? a.actorLogin)
+      : chalk.dim("(no login)"),
+    type: a.actorType ?? "",
+    action: a.action,
+    target: renderTarget(a.targetType, a.targetId),
+    outcome: colorOutcome(a.outcome),
+  }));
+
+  console.log(
+    table(rows, [
+      { key: "when", header: "WHEN" },
+      { key: "actor", header: "ACTOR" },
+      { key: "type", header: "VIA" },
+      { key: "action", header: "ACTION" },
+      { key: "target", header: "TARGET" },
+      { key: "outcome", header: "OUTCOME" },
+    ]),
+  );
+  console.log(chalk.dim(`\n${data.total} total. Filter: lastlight activity --actor <login>`));
+  return 0;
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -282,6 +282,14 @@ ${chalk.bold("Session")} (read agent session transcripts)
   lastlight session list [--limit n]
   lastlight session log <id> [--follow] [--since n] [--full]   ${chalk.dim("(--full = raw, unformatted dump)")}`,
 
+  activity: `
+${chalk.bold("Activity")} (the audit stream — who did what, when)
+  lastlight activity [--actor login] [--action verb] [--target type:id] [--since iso] [--limit n]
+
+  Verbs: login, workflow.trigger|retry|cancel|toggle, approval.approve|reject,
+         cron.fire|trigger|toggle, config.edit, container.kill, artifact.edit, pr.retry
+  ${chalk.dim("A row with no actor is a password session — authenticated, but carrying no login.")}`,
+
   logs: `
 ${chalk.bold("Logs")} (search the harness logs)
   lastlight logs search "<text>" [--scope errors|messages|all] [--limit n]`,
@@ -412,7 +420,7 @@ ${chalk.bold("Trigger")} (run work on a repo)
   lastlight pr retry <owner/repo#N> [reason]    Have another go at a PR the bot stopped on
 
 ${chalk.bold("Debug")} (read the running instance)   ${chalk.dim("→ lastlight <cmd> help")}
-  workflow · session · logs · approvals · stats · cron
+  workflow · session · logs · approvals · stats · cron · activity
 
 ${chalk.bold("Server")} (host-local docker stack)   ${chalk.dim("→ lastlight server help")}
   setup · build · list · logs · start · stop · restart · update · status
@@ -1305,6 +1313,15 @@ async function cmdRepo(): Promise<void> {
  * repo, the hold label, the run lock, the budgets) is the server's, decided at
  * the same gate a webhook crosses. See src/pr-cli.ts.
  */
+async function cmdActivity(): Promise<void> {
+  const { activityCommand } = await import("./activity-cli.js");
+  const code = await activityCommand(positionals.slice(1), {
+    json: JSON_OUT,
+    apiGet,
+  }).catch((err: unknown) => die(err instanceof Error ? err.message : String(err)));
+  if (code !== 0) process.exit(code);
+}
+
 async function cmdPr(): Promise<void> {
   const { prCommand } = await import("./pr-cli.js");
   const code = await prCommand(positionals.slice(1), {
@@ -1438,6 +1455,7 @@ async function main() {
     case "auth": return cmdOAuth();
     case "server": return cmdServer();
     case "stats": return cmdStats();
+    case "activity": return cmdActivity();
     case "chat": return cmdChat();
     case "build": return cmdBuild();
     case "triage":

--- a/packages/cli/tests/activity-cli.test.ts
+++ b/packages/cli/tests/activity-cli.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { activityCommand, type ActivityOpts } from "../src/activity-cli.js";
+
+/**
+ * `lastlight activity` — the client half of the audit stream (issue #206).
+ *
+ * The command is deliberately thin: filtering, pagination and the `total` all
+ * happen server-side. So what is worth testing is exactly what the CLI owns —
+ * the query it builds from its flags, and how it renders the two things a
+ * naive table would get wrong: a row with NO actor (a password session, which
+ * is a real row and not missing data), and `--json` passing the envelope
+ * through untouched.
+ */
+
+function fakeGet(data: unknown) {
+  return vi.fn(async () => data) as unknown as ActivityOpts["apiGet"];
+}
+
+const ROW = {
+  id: "a1",
+  createdAt: new Date().toISOString(),
+  actorLogin: "octocat",
+  actorType: "github",
+  action: "cron.toggle",
+  targetType: "cron",
+  targetId: "cron-review",
+  outcome: "ok",
+  detail: { enabled: false },
+};
+
+let logs: string[];
+
+beforeEach(() => {
+  logs = [];
+  vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => void logs.push(a.join(" ")));
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("activityCommand", () => {
+  it("defaults to a bounded page rather than the server default", async () => {
+    const apiGet = fakeGet({ activity: [], total: 0, users: {} });
+    await activityCommand([], { apiGet });
+    const path = (apiGet as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(path).toContain("limit=30");
+  });
+
+  it("passes every filter through to the query", async () => {
+    const apiGet = fakeGet({ activity: [], total: 0, users: {} });
+    await activityCommand(
+      ["--actor", "octocat", "--action", "cron.fire", "--target", "cron:review", "--since", "2026-01-01"],
+      { apiGet },
+    );
+    const path = (apiGet as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(path).toContain("actor=octocat");
+    expect(path).toContain("action=cron.fire");
+    expect(path).toContain("target=cron%3Areview");
+    expect(path).toContain("since=2026-01-01");
+  });
+
+  it("renders the real name when the server resolved one", async () => {
+    const apiGet = fakeGet({
+      activity: [ROW],
+      total: 1,
+      users: { octocat: { login: "octocat", name: "Mona Lisa" } },
+    });
+    await activityCommand([], { apiGet });
+    const output = logs.join("\n");
+    expect(output).toContain("Mona Lisa");
+    expect(output).toContain("cron.toggle");
+    expect(output).toContain("cron:cron-review");
+    expect(output).toContain("1 total");
+  });
+
+  it("falls back to the bare login when `users` has no row", async () => {
+    const apiGet = fakeGet({ activity: [ROW], total: 1, users: {} });
+    await activityCommand([], { apiGet });
+    expect(logs.join("\n")).toContain("octocat");
+  });
+
+  it("marks a row with no actor rather than leaving the cell blank", async () => {
+    // A password session writes a real row that names nobody. Rendering that as
+    // an empty cell would read as missing data; it is not.
+    const apiGet = fakeGet({
+      activity: [{ ...ROW, actorLogin: undefined, actorType: "admin" }],
+      total: 1,
+      users: {},
+    });
+    await activityCommand([], { apiGet });
+    expect(logs.join("\n")).toContain("no login");
+  });
+
+  it("--json prints the envelope verbatim and renders no table", async () => {
+    const envelope = { activity: [ROW], total: 1, users: {} };
+    const apiGet = fakeGet(envelope);
+    await activityCommand([], { apiGet, json: true });
+    expect(JSON.parse(logs.join("\n"))).toEqual(envelope);
+  });
+
+  it("prints usage for help without calling the API", async () => {
+    const apiGet = fakeGet({});
+    await activityCommand(["help"], { apiGet });
+    expect(logs.join("\n")).toContain("Usage: lastlight activity");
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #206 — in progress. **Draft: Phase 1 of 3 is complete**; Phases 2 and 3 land as further commits on this branch.

## What this is

`activity_log` — one append-only row per **user-initiated** action, carrying actor + verb + target + outcome, across the dashboard, CLI, Slack, GitHub and cron.

Today that question has no answer: #205 put a real actor on every run and execution, but attribution is spread across five ledgers (`workflow_runs.triggered_by`, `executions`, `workflow_approvals.responded_by`, `cron_overrides.updated_by`, `workflow_overrides.updated_by`), and login, config edits, container kills and artifact edits write to none of them.

This **complements** #205 rather than replacing it. `triggered_by` stays the hot-path per-run attribution; this is the audit stream layered on top, soft-joined to `users` on `login`.

## Read this first

**[`docs/plans/activity-log/`](docs/plans/activity-log/)** — the design, the locked decisions, and one phase doc per commit group. Each phase doc gains Execution notes as it lands, so the directory reads as both plan and record.

Three decisions were reached **against** the issue's own instructions, and are worth a look before the code:

1. **The issue body is stale.** It predates #351/#352 and says to add DDL to `src/state/migrate.ts`, which no longer exists in that form. Everything schema-shaped here follows `src/state/CLAUDE.md` instead.
2. **No middleware seam exists** to hang the write on — no `onError`, no `notFound`, no shared response helper. So: explicit calls at each site, with a table-driven test pinning the route→verb map in place of the coverage a middleware would have bought.
3. **System fan-out is recorded once at its cause, not per dispatch.** A cron fan-out dispatches per repo, so logging each as an action would make the dominant row source a thing no human did — the same confusion `cron_runs` avoids by keying on the cron rather than the workflow. That bounds growth *below* `workflow_runs`, which is what makes deferring retention safe.

## Phase 1 — schema + store (this draft)

- `activity_log` on both dialects; `detail` diverges `text({mode:"json"})` → `jsonb` with a shared `$type<T>()`.
- Both migrations generated and committed unedited, same commit. Purely additive: one `CREATE TABLE`, three `CREATE INDEX`, no `DROP`.
- `ActivityStore` (`record` / `list` / `actions`) on the `CronRunStore` pattern, tables via `tablesOf(client)`. Ids creation-ordered; both reads tie-break on `id`, because a page boundary inside a same-millisecond run would otherwise skip or repeat rows.
- Behavioural tests in `tests/state/suites/`, so both the sqlite and PGlite legs replay identical bodies.

## Two things a reviewer should look at closely

**`schema-equivalence.test.ts` needed restructuring, not a bumped count.** It asserted the schema is *identical* before and after boot — sound while every table came from the baseline, but `activity_log` is the first table a **post-baseline** migration creates, so the two sets legitimately differ. Rather than weaken it, `LEGACY_TABLES` (the pre-Drizzle production shape the baseline must still no-op over) is now separate from a derived `EXPECTED_TABLES`, with `POST_BASELINE_TABLES` / `_INDEXES` naming the difference. The proof the file exists for is intact.

**`src/state/CLAUDE.md`'s add-a-table checklist said three places; there are six.** The three it named fail loudly; the other three are hardcoded counts in the test suite that fail as an off-by-one reading like a bug in your own change. The checklist is corrected in this PR.

## Verification

`pnpm turbo run typecheck test build` — 25/25 tasks, 3845 tests, on `main` at `2e49dddd`. State suite green on **both** dialects; `lint:promises` and `lint:boundaries` clean. `pg-client.ts` is untouched, so the `PG_INTEGRATION=1` leg is not implicated.

## Still to come

- **Phase 2** — `recordActivity()` and its 19 call sites, plus the three routes still hardcoding `"admin"` as the actor (`routes.ts:1868`, `:2511`, `:2556`).
- **Phase 3** — `GET /admin/api/activity`, the dashboard tab + per-run strip, `lastlight activity`.

## Open questions

Both cheap now, expensive once rows exist:

1. **The verb vocabulary** — fourteen verbs, a closed union in `activity-store.ts`.
2. **`config.edit` does double duty** for setting and clearing a cron schedule override, distinguished only by `detail`. The alternative is `cron.schedule` + `cron.schedule.clear`. I lean toward keeping it broad since #206 names it as one verb and the target already carries the `cron:<name>` specificity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)