### PR TITLE
fix(cli): stop `<cmd> help` firing a real workflow dispatch

### DIFF
--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -86,6 +86,15 @@ Per-command help: `lastlight <cmd> help` (e.g. `lastlight cron help`) — the
 top-level `lastlight` / `--help` is a compact index; detail lives under each
 command's help.
 
+The seven trigger commands (`triage`, `review`, `health`, `security`, `verify`,
+`qa-test`, `demo`) share one shape table near the top of `cli.ts`: `SKILL_MAP`,
+`REPO_LEVEL_ONLY`, `TAKES_CLAIM` and `triggerUsage()` build both their
+`HELP_TOPICS` entries and the validation `cmdSkill` enforces, so the usage a
+user is shown is the usage that is checked. A target must parse as a GitHub ref
+or match bare `owner/repo`; anything else (a typo, or the word `help`) dies
+before the POST. It used to become a repo-wide scan target and dispatch a real
+workflow — issue #361, covered by `tests/trigger-help.test.ts`.
+
 ## Un-stick a PR (`pr-cli.ts`)
 
 `lastlight pr retry <owner/repo#N> [reason]` — the third of the three surfaces

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -265,6 +265,44 @@ function num(flag: string | boolean | undefined, fallback: number): number {
   return Number.isFinite(n) ? n : fallback;
 }
 
+// ── trigger commands — shape tables ────────────────────────────────────────
+//
+// Shared by the help screens and by `cmdSkill`, so the usage a user is shown is
+// the usage the dispatcher actually enforces. Declared here (above HELP_TOPICS)
+// because the topic strings below are built from them at module load.
+
+const SKILL_MAP: Record<string, string> = {
+  triage: "issue-triage", review: "pr-review", health: "repo-health", security: "security-review",
+  verify: "verify", "qa-test": "qa-test", demo: "demo",
+};
+
+/** Commands that scan a whole repository — an issue/PR number means nothing. */
+const REPO_LEVEL_ONLY = new Set(["health", "security"]);
+/** Commands that take free text after the target (a claim, steps, demo notes). */
+const TAKES_CLAIM = new Set(["verify", "qa-test", "demo"]);
+
+/** A well-formed `owner/repo` — no ref, no number, no stray path segment. */
+const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+/** Words a user types when they want help, never a repository. */
+const HELP_WORDS = new Set(["help", "--help", "-h", "-?", "?"]);
+
+function triggerUsage(name: string): string {
+  const target = REPO_LEVEL_ONLY.has(name) ? "<owner/repo>" : "<owner/repo[#N]> | <github-url>";
+  const claim = TAKES_CLAIM.has(name) ? ` [-- "<claim or steps>"]` : "";
+  return `lastlight ${name} ${target}${claim}`;
+}
+
+const TRIGGER_BLURB: Record<string, string> = {
+  triage: "Triage one issue, or every open issue in the repo",
+  review: "Review one PR, or every open PR in the repo",
+  health: "Weekly repository health report",
+  security: "Security review of the repository",
+  verify: "Test a claim against the code → pass/fail",
+  "qa-test": "Drive a flow end-to-end → pass/fail",
+  demo: "Record a demo of the change",
+};
+
 // ── help ───────────────────────────────────────────────────────────────────
 
 // Per-command detail, shown by `lastlight <cmd> help` (or `<cmd> --help`). The
@@ -395,6 +433,22 @@ ${chalk.bold("OAuth")} (host-local — subscription logins for the model provide
   lastlight oauth logout [provider]  Remove one (or all) stored logins
                                      Writes auth.json under $STATE_DIR; restart the agent after.`,
 };
+// The seven trigger commands get a topic each, built from the same tables the
+// dispatcher validates against. Without an entry here `lastlight review help`
+// fell through to `cmdSkill`, where "help" became a target and fired a real
+// workflow dispatch (issue #361).
+for (const name of Object.keys(SKILL_MAP)) {
+  const claimLine = TAKES_CLAIM.has(name)
+    ? `\n  ${chalk.dim('The text after `--` is passed to the agent as the claim / steps to follow.')}`
+    : "";
+  const scanLine = REPO_LEVEL_ONLY.has(name)
+    ? ""
+    : `\n  ${chalk.dim("Omit #N to scan the whole repo; a full github.com URL works too.")}`;
+  HELP_TOPICS[name] = `
+${chalk.bold(name)} (${TRIGGER_BLURB[name]})
+  ${triggerUsage(name)}${scanLine}${claimLine}`;
+}
+
 // Aliases so `<alias> help` resolves to the same topic as the primary command.
 HELP_TOPICS.workflows = HELP_TOPICS.workflow;
 HELP_TOPICS.sessions = HELP_TOPICS.session;
@@ -1166,23 +1220,35 @@ async function cmdBuild(): Promise<void> {
 
 async function cmdSkill(name: string): Promise<void> {
   const target = positionals[1];
-  const skillMap: Record<string, string> = {
-    triage: "issue-triage", review: "pr-review", health: "repo-health", security: "security-review",
-    verify: "verify", "qa-test": "qa-test", demo: "demo",
-  };
-  const skill = skillMap[name];
-  const repoLevelOnly = name === "health" || name === "security";
+  const skill = SKILL_MAP[name];
+  const repoLevelOnly = REPO_LEVEL_ONLY.has(name);
   // verify / qa-test / demo take a free-text argument after the target (claim,
   // steps, or demo notes) — accept it either as trailing positionals or as a
   // quoted `-- "<text>"` (the arg parser folds the latter into flags[""]).
-  const takesClaim = name === "verify" || name === "qa-test" || name === "demo";
+  const takesClaim = TAKES_CLAIM.has(name);
   const claim = takesClaim
     ? (positionals.slice(2).join(" ") || (typeof flags[""] === "string" ? flags[""] : "")).trim()
     : "";
-  if (!target) {
-    die(`Usage: lastlight ${name} <owner/repo${repoLevelOnly ? "" : "#N"}>${takesClaim ? ` [-- "<claim or steps>"]` : ""}`);
+  if (!target) die(`Usage: ${triggerUsage(name)}`);
+  // A help word is never a repository. `main` already routes `<cmd> help` and
+  // `<cmd> --help` to the topic, so reaching here means an odd spelling — print
+  // the same topic rather than dispatching it (issue #361: "help" used to sail
+  // through as a repo-wide scan target and POST /api/run for real).
+  if (HELP_WORDS.has(target.toLowerCase())) {
+    console.log(HELP_TOPICS[name]);
+    process.exit(0);
   }
   const parsed = repoLevelOnly ? null : parseGitHubRef(target);
+  // Anything that is neither a parseable ref nor a bare `owner/repo` is a typo,
+  // not a scan target. Dispatching it costs a real workflow run on the instance,
+  // so fail here — before the network — the way `build` always has.
+  if (!parsed && !OWNER_REPO_RE.test(target)) {
+    die(
+      `Not a repository: ${target}\n` +
+        `Usage: ${triggerUsage(name)}` +
+        (repoLevelOnly ? `\n${name} scans a whole repository — drop any #N.` : ""),
+    );
+  }
   // `pr-review` is PR-SCOPED (`pr_scoped: true` in its workflow YAML), and the
   // server resolves the `PrState` snapshot only when the dispatch context
   // carries `prNumber` **as a number**. `issueNumber` alone does not satisfy

--- a/packages/cli/tests/trigger-help.test.ts
+++ b/packages/cli/tests/trigger-help.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `lastlight <cmd> help` must never dispatch a workflow.
+ *
+ * The seven trigger commands took `positionals[1]` as their target with no
+ * validation, so `lastlight review help` POSTed /api/run with `repo: "help"` —
+ * a real, billable repo-wide scan on whatever instance the CLI was pointed at.
+ * It only ever looked harmless because no repository is named "help" and the
+ * server answered 403; the write path was reached every time (issue #361).
+ *
+ * Asserted on the wire, not on the exit code: the whole failure was that the
+ * request happened at all.
+ */
+import { describe, it, expect } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createServer, type Server } from "node:http";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { AddressInfo } from "node:net";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const TRIGGERS = ["triage", "review", "health", "security", "verify", "qa-test", "demo"];
+
+const run = promisify(execFile);
+
+type Result = { requests: string[]; stdout: string; stderr: string; code: number };
+
+/** Run one CLI command against a server that records every request path. */
+async function runCli(args: string[]): Promise<Result> {
+  const requests: string[] = [];
+  const server: Server = createServer((req, res) => {
+    requests.push(`${req.method} ${req.url}`);
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ accepted: true, executionId: "test" }));
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const { port } = server.address() as AddressInfo;
+  try {
+    const res = await run(
+      process.execPath,
+      [join(PACKAGE_ROOT, "node_modules", "tsx", "dist", "cli.mjs"), join(PACKAGE_ROOT, "src", "cli.ts"), ...args],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NO_COLOR: "1",
+          LASTLIGHT_URL: `http://127.0.0.1:${port}`,
+          LASTLIGHT_TOKEN: "test-token",
+        },
+      },
+    ).catch((e: Error & { stdout?: string; stderr?: string; code?: number }) => ({
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? e.message,
+      code: e.code ?? 1,
+    }));
+    return { requests, stdout: res.stdout, stderr: res.stderr, code: (res as { code?: number }).code ?? 0 };
+  } finally {
+    // `close()` alone waits on keep-alive sockets the CLI's fetch leaves open.
+    server.closeAllConnections();
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+}
+
+describe("trigger commands — help never dispatches", () => {
+  for (const cmd of TRIGGERS) {
+    it(`\`${cmd} help\` prints usage and sends nothing`, { timeout: 60_000 }, async () => {
+      const res = await runCli([cmd, "help"]);
+      expect(res.requests).toEqual([]);
+      expect(res.code).toBe(0);
+      expect(res.stdout).toContain(`lastlight ${cmd} `);
+    });
+
+    it(`\`${cmd} --help\` prints usage and sends nothing`, { timeout: 60_000 }, async () => {
+      const res = await runCli([cmd, "--help"]);
+      expect(res.requests).toEqual([]);
+      expect(res.stdout).toContain(`lastlight ${cmd} `);
+    });
+  }
+});
+
+describe("trigger commands — unparseable targets fail before the network", () => {
+  it("rejects a bare word as a scan target", { timeout: 60_000 }, async () => {
+    const res = await runCli(["review", "widget"]);
+    expect(res.requests).toEqual([]);
+    expect(res.code).toBe(1);
+    expect(res.stderr).toContain("Not a repository: widget");
+  });
+
+  it("rejects an issue ref for a repo-level command", { timeout: 60_000 }, async () => {
+    const res = await runCli(["health", "acme/widget#941"]);
+    expect(res.requests).toEqual([]);
+    expect(res.stderr).toContain("scans a whole repository");
+  });
+
+  it("still dispatches a well-formed repo scan", { timeout: 60_000 }, async () => {
+    const res = await runCli(["review", "acme/widget"]);
+    expect(res.requests).toEqual(["POST /api/run"]);
+  });
+});


### PR DESCRIPTION
Fixes #361.

`lastlight review help` (and the same for `triage`, `health`, `security`, `verify`, `qa-test`, `demo`) took `help` as the target and POSTed `/api/run` with `repo: "help"` — a real repo-wide scan against whatever instance the CLI was pointed at. The 403 that came back was luck, not a guard, and the CLI's own help text teaches the pattern.

## What changed

- One shape table near the top of `cli.ts` (`SKILL_MAP`, `REPO_LEVEL_ONLY`, `TAKES_CLAIM`, `triggerUsage()`) now feeds both the help topics and the validation in `cmdSkill`, so the usage a user is shown is the usage that is enforced.
- Each of the seven commands gets a `HELP_TOPICS` entry, which makes `<cmd> help` and `<cmd> --help` print per-command usage and exit 0 instead of falling through to dispatch.
- A target must parse as a GitHub ref or match a bare `owner/repo`. Anything else dies before the network, the way `build` always has. `health` and `security` say explicitly to drop a `#N`.

## Tests

`packages/cli/tests/trigger-help.test.ts` runs each command against a throwaway HTTP server that records every request, and asserts no request is made for `help` / `--help` / a bare word / an issue ref given to a repo-level command, while a well-formed `owner/repo` still dispatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)