### PR TITLE
fix(dependabot-ci-fix): type the repair commit so it can't cut a release

### DIFF
--- a/apps/server/tests/workflows/dependabot-ci-fix.test.ts
+++ b/apps/server/tests/workflows/dependabot-ci-fix.test.ts
@@ -106,6 +106,26 @@ describe("dependabot-ci-fix — the publish step", () => {
     expect(prompt).not.toContain("git push origin HEAD");
   });
 
+  it("types the repair commit so it cannot cut a release", () => {
+    // The repair commit lands in the MANAGED repo, not here — this repo cuts
+    // releases by hand. On a managed repo that derives releases from commit
+    // types (release-please, semantic-release), `fix` is releasable, so a bump
+    // that merely needed a base-branch merge cut a patch release whose
+    // changelog read "make #123 mergeable". `chore` is hidden by the
+    // conventional-changelog presets.
+    //
+    // Asserted as the TYPE of the published message, not as
+    // `not.toContain("fix(deps):")`: that guards only the one value this
+    // replaced, and a later `feat(deps):` would sail through it while cutting a
+    // MINOR release — the same bug, one notch worse. Anchoring the type rejects
+    // every releasable type at once, and `chore(deps)!:` with them, since a `!`
+    // breaking marker cuts a MAJOR whatever the type in front of it.
+    const prompt = loadPromptTemplate("prompts/dependabot-ci-fix.md");
+    const message = prompt.match(/message:\s*"([^"]+)"/);
+    expect(message).not.toBeNull();
+    expect(message![1]).toMatch(/^chore\(deps\):/);
+  });
+
   it("tells the agent not to work around a refused publish", () => {
     const prompt = loadPromptTemplate("prompts/dependabot-ci-fix.md");
     expect(prompt).toMatch(/do NOT (fall back to |work around)/i);

--- a/apps/server/workflows/prompts/dependabot-ci-fix.md
+++ b/apps/server/workflows/prompts/dependabot-ci-fix.md
@@ -129,7 +129,7 @@ one slow or unreproducible check. Run tests cheaply per the **building** skill
 
 AFTER FIXING:
 1. Publish with `github_publish` — `{ owner: "{{owner}}", repo: "{{repo}}",
-   message: "fix(deps): make #{{prNumber}} mergeable" }`. It commits the whole
+   message: "chore(deps): make #{{prNumber}} mergeable" }`. It commits the whole
    working tree (the merge from step 1 and/or your CI fix) and pushes it in one
    step. Do NOT use `git commit` / `git push`: a commit built by git here is
    unsigned, and on a repo that requires signed commits one unsigned commit


### PR DESCRIPTION
## Problem

`dependabot-ci-fix` publishes its repair commit as:

```
fix(deps): make #{{prNumber}} mergeable
```

On a managed repo that derives releases from commit types — release-please,
semantic-release, and similar — `fix` is a releasable type. So a dependency
bump that needed a base-branch merge or a CI repair doesn't just become
mergeable; it cuts a patch release, and that release's changelog reads:

```
### Bug Fixes

* **deps:** make #5 mergeable
```

I hit this on a repo where the bump itself was correctly typed and produced no
changelog entry, but the two repair commits cut a release between them.

The subject can't be a useful changelog entry under any circumstances: it
describes the process that unblocked the PR, not a change to the product. And
the bump is already typed by Dependabot, so the repair doesn't need a second
visible entry alongside it.

## Change

One word in `apps/server/workflows/prompts/dependabot-ci-fix.md` — the
published type becomes `chore(deps)`, which conventional-changelog presets
hide by default. The commit's contents, its signing, and the `github_publish`
path are all unchanged.

This keeps the repair invisible to release tooling while leaving it fully
visible in git history and in the PR timeline, which is where someone looks
for it.

## Checked before opening

- Nothing in `apps/server/src` or `packages/*/src` matches on the repair
  commit's type or message, so no dispatch, cron or dedup path recognises it
  that way — `dependabot-discovery` keys on PR state.
- No test asserts the string (searched `apps/server/tests` and
  `packages/*/tests`).
- `apps/www/src/pages/docs/workflows/dependabot-ci-fix.astro` doesn't quote
  the message, so no doc update is needed.
- Left `docs/plans/signed-commit-publish/01-publish-helper.md:1587` alone — it
  carries the same string, but as a record of what was planned at the time.

Happy to use `ci(deps)` instead if you'd rather the type named the activity;
`chore` was chosen only because it's the one the presets already hide.